### PR TITLE
Fix event data generation

### DIFF
--- a/main.go
+++ b/main.go
@@ -157,8 +157,7 @@ func main() {
 			mdf := &modfile.File{}
 			mdf.AddModuleStmt(GetConfig().ModPath)
 
-			mdf.AddNewRequire("github.com/gagliardetto/solana-go", "v1.5.0", false)
-			mdf.AddNewRequire("github.com/fragmetric-labs/solana-binary-go", "v0.8.0", false)
+			mdf.AddNewRequire("github.com/gagliardetto/solana-go", "v1.12.0", false)
 			mdf.AddNewRequire("github.com/gagliardetto/treeout", "v0.1.4", false)
 			mdf.AddNewRequire("github.com/gagliardetto/gofuzz", "v1.2.2", false)
 			mdf.AddNewRequire("github.com/stretchr/testify", "v1.6.1", false)

--- a/main.go
+++ b/main.go
@@ -375,6 +375,8 @@ func DecodeInstructions(message *ag_solanago.Message) (instructions []*Instructi
 
 		// TODO: refactor it
 		// to generate import statements
+		file.Add(Empty().Var().Defs(Id("_").Qual("fmt", "Formatter").Op("=").Nil()))
+		file.Add(Empty().Var().Defs(Id("_").Op("*").Qual(PkgSolanaGo, "Transaction").Op("=").Nil()))
 		file.Add(Empty().Var().Defs(Id("_").Op("*").Qual("strings", "Builder").Op("=").Nil()))
 		file.Add(Empty().Var().Defs(Id("_").Op("*").Qual("encoding/base64", "Encoding").Op("=").Nil()))
 		file.Add(Empty().Var().Defs(Id("_").Op("*").Qual(PkgDfuseBinary, "Decoder").Op("=").Nil())) // TODO: ..

--- a/main.go
+++ b/main.go
@@ -352,6 +352,16 @@ func DecodeInstructions(message *ag_solanago.Message) (instructions []*Instructi
 					Type: defs[evt.Name].Type,
 				}))
 				file.Add(Func().Params(Op("*").Id(eventDataTypeName)).Id("isEventData").Params().Block())
+
+				file.Add(Func().Params(Id("obj").Op("*").Id(eventDataTypeName)).Id("Self").Params().
+					Params(
+						ListFunc(func(results *Group) {
+							// Results:
+							results.Any()
+						}),
+					).BlockFunc(func(body *Group) {
+					body.Return(Id("obj"))
+				}))
 			} else {
 				panic(`not implemented - only IDL from ("anchor": ">=0.30.0") is available`)
 			}
@@ -392,6 +402,7 @@ type Event struct {
 type EventData interface {
 	UnmarshalWithDecoder(decoder *ag_binary.Decoder) error
 	isEventData()
+	Self() any
 }
 
 const eventLogPrefix = "Program data: "


### PR DESCRIPTION
Hey! 

Thanks for reviving this repo and make it work with a more modern version of anchor!  We are currently working on a Solana program but the rest of our stack is in `go` so this tool makes our lives a lot easier. 

While working on our integration, we came across a couple of little bugs that this PR fixes. I wish I could share our IDL to maybe include it in the tests but we are not ready yet. 

I'm adding three different fixes that are split into their own commits. I could also split the PR in three if needed. 

1. [fix go mod import generation](https://github.com/fragmetric-labs/solana-anchor-go/commit/c70f1e6edde818dd198c4161303536093edfa6bb): the generated go.mod file (via `--mod` flag) was wrong. 
2.  [fix imports in event data file](https://github.com/fragmetric-labs/solana-anchor-go/commit/11ad66ec400fb3fcb09fc1949aedb84ac604188e): the generated `events.go` file would not build due to missing imports. 
3. [add Self() to EventData interface](https://github.com/fragmetric-labs/solana-anchor-go/commit/12af093e3b3a0fe8496036c45cdf8ea7105a688c): this adds a `Self()` method to the `EventData` interface so we can access the unmarshalled event. Maybe there's another way of doing it but as far as I can tell, the data is already there but simply hidden behind the opaque interface. 

Thanks once again!