### PR TITLE
Add suffix to instruction types to avoid type conflicts with idl types

### DIFF
--- a/gen_testing.go
+++ b/gen_testing.go
@@ -138,11 +138,11 @@ func genTestingFuncs(idl IDL) ([]*FileWrapper, error) {
 									BlockFunc(func(tFunGroup *Group) {
 
 										if isInsFieldComplexEnum(instruction.Args...) {
-											genTestWithComplexEnum(tFunGroup, insExportedName, instruction, idl)
+											genTestWithComplexEnum(tFunGroup, formatInstructionTypeName(insExportedName), instruction, idl)
 										} else if isInsDeepFieldComplexEnum(idl, instruction.Args...) {
-											genTestWithDeepComplexEnum(tFunGroup, insExportedName, instruction, idl)
+											genTestWithDeepComplexEnum(tFunGroup, formatInstructionTypeName(insExportedName), instruction, idl)
 										} else {
-											genTestNOComplexEnum(tFunGroup, insExportedName, instruction)
+											genTestNOComplexEnum(tFunGroup, formatInstructionTypeName(insExportedName), instruction)
 										}
 									}),
 								)

--- a/generated/restaking/admininitializeextraaccountmetalist.go
+++ b/generated/restaking/admininitializeextraaccountmetalist.go
@@ -11,7 +11,7 @@ import (
 )
 
 // AdminInitializeExtraAccountMetaList is the `admin_initialize_extra_account_meta_list` instruction.
-type AdminInitializeExtraAccountMetaList struct {
+type AdminInitializeExtraAccountMetaListInstruction struct {
 
 	// [0] = [WRITE, SIGNER] payer
 	//
@@ -29,9 +29,9 @@ type AdminInitializeExtraAccountMetaList struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewAdminInitializeExtraAccountMetaListInstructionBuilder creates a new `AdminInitializeExtraAccountMetaList` instruction builder.
-func NewAdminInitializeExtraAccountMetaListInstructionBuilder() *AdminInitializeExtraAccountMetaList {
-	nd := &AdminInitializeExtraAccountMetaList{
+// NewAdminInitializeExtraAccountMetaListInstructionBuilder creates a new `AdminInitializeExtraAccountMetaListInstruction` instruction builder.
+func NewAdminInitializeExtraAccountMetaListInstructionBuilder() *AdminInitializeExtraAccountMetaListInstruction {
+	nd := &AdminInitializeExtraAccountMetaListInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 7),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["fragkamrANLvuZYQPcmPsCATQAabkqNGH6gxqqPG3aP"]).SIGNER()
@@ -40,56 +40,56 @@ func NewAdminInitializeExtraAccountMetaListInstructionBuilder() *AdminInitialize
 }
 
 // SetPayerAccount sets the "payer" account.
-func (inst *AdminInitializeExtraAccountMetaList) SetPayerAccount(payer ag_solanago.PublicKey) *AdminInitializeExtraAccountMetaList {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) SetPayerAccount(payer ag_solanago.PublicKey) *AdminInitializeExtraAccountMetaListInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(payer).WRITE().SIGNER()
 	return inst
 }
 
 // GetPayerAccount gets the "payer" account.
-func (inst *AdminInitializeExtraAccountMetaList) GetPayerAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) GetPayerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetAdminAccount sets the "admin" account.
-func (inst *AdminInitializeExtraAccountMetaList) SetAdminAccount(admin ag_solanago.PublicKey) *AdminInitializeExtraAccountMetaList {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) SetAdminAccount(admin ag_solanago.PublicKey) *AdminInitializeExtraAccountMetaListInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(admin).SIGNER()
 	return inst
 }
 
 // GetAdminAccount gets the "admin" account.
-func (inst *AdminInitializeExtraAccountMetaList) GetAdminAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) GetAdminAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *AdminInitializeExtraAccountMetaList) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *AdminInitializeExtraAccountMetaList {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *AdminInitializeExtraAccountMetaListInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *AdminInitializeExtraAccountMetaList) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *AdminInitializeExtraAccountMetaList) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *AdminInitializeExtraAccountMetaList {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *AdminInitializeExtraAccountMetaListInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *AdminInitializeExtraAccountMetaList) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetExtraAccountMetaListAccount sets the "extra_account_meta_list" account.
-func (inst *AdminInitializeExtraAccountMetaList) SetExtraAccountMetaListAccount(extraAccountMetaList ag_solanago.PublicKey) *AdminInitializeExtraAccountMetaList {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) SetExtraAccountMetaListAccount(extraAccountMetaList ag_solanago.PublicKey) *AdminInitializeExtraAccountMetaListInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(extraAccountMetaList).WRITE()
 	return inst
 }
 
-func (inst *AdminInitializeExtraAccountMetaList) findFindExtraAccountMetaListAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) findFindExtraAccountMetaListAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: extra-account-metas
 	seeds = append(seeds, []byte{byte(0x65), byte(0x78), byte(0x74), byte(0x72), byte(0x61), byte(0x2d), byte(0x61), byte(0x63), byte(0x63), byte(0x6f), byte(0x75), byte(0x6e), byte(0x74), byte(0x2d), byte(0x6d), byte(0x65), byte(0x74), byte(0x61), byte(0x73)})
@@ -106,12 +106,12 @@ func (inst *AdminInitializeExtraAccountMetaList) findFindExtraAccountMetaListAdd
 }
 
 // FindExtraAccountMetaListAddressWithBumpSeed calculates ExtraAccountMetaList account address with given seeds and a known bump seed.
-func (inst *AdminInitializeExtraAccountMetaList) FindExtraAccountMetaListAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) FindExtraAccountMetaListAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindExtraAccountMetaListAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminInitializeExtraAccountMetaList) MustFindExtraAccountMetaListAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) MustFindExtraAccountMetaListAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindExtraAccountMetaListAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -120,12 +120,12 @@ func (inst *AdminInitializeExtraAccountMetaList) MustFindExtraAccountMetaListAdd
 }
 
 // FindExtraAccountMetaListAddress finds ExtraAccountMetaList account address with given seeds.
-func (inst *AdminInitializeExtraAccountMetaList) FindExtraAccountMetaListAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) FindExtraAccountMetaListAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindExtraAccountMetaListAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *AdminInitializeExtraAccountMetaList) MustFindExtraAccountMetaListAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) MustFindExtraAccountMetaListAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindExtraAccountMetaListAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -134,17 +134,17 @@ func (inst *AdminInitializeExtraAccountMetaList) MustFindExtraAccountMetaListAdd
 }
 
 // GetExtraAccountMetaListAccount gets the "extra_account_meta_list" account.
-func (inst *AdminInitializeExtraAccountMetaList) GetExtraAccountMetaListAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) GetExtraAccountMetaListAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *AdminInitializeExtraAccountMetaList) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminInitializeExtraAccountMetaList {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminInitializeExtraAccountMetaListInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *AdminInitializeExtraAccountMetaList) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -159,12 +159,12 @@ func (inst *AdminInitializeExtraAccountMetaList) findFindEventAuthorityAddress(k
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *AdminInitializeExtraAccountMetaList) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *AdminInitializeExtraAccountMetaList) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -173,12 +173,12 @@ func (inst *AdminInitializeExtraAccountMetaList) MustFindEventAuthorityAddressWi
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *AdminInitializeExtraAccountMetaList) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *AdminInitializeExtraAccountMetaList) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -187,22 +187,22 @@ func (inst *AdminInitializeExtraAccountMetaList) MustFindEventAuthorityAddress()
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *AdminInitializeExtraAccountMetaList) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *AdminInitializeExtraAccountMetaList) SetProgramAccount(program ag_solanago.PublicKey) *AdminInitializeExtraAccountMetaList {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) SetProgramAccount(program ag_solanago.PublicKey) *AdminInitializeExtraAccountMetaListInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *AdminInitializeExtraAccountMetaList) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
-func (inst AdminInitializeExtraAccountMetaList) Build() *Instruction {
+func (inst AdminInitializeExtraAccountMetaListInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_AdminInitializeExtraAccountMetaList,
@@ -212,14 +212,14 @@ func (inst AdminInitializeExtraAccountMetaList) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst AdminInitializeExtraAccountMetaList) ValidateAndBuild() (*Instruction, error) {
+func (inst AdminInitializeExtraAccountMetaListInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *AdminInitializeExtraAccountMetaList) Validate() error {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -247,7 +247,7 @@ func (inst *AdminInitializeExtraAccountMetaList) Validate() error {
 	return nil
 }
 
-func (inst *AdminInitializeExtraAccountMetaList) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *AdminInitializeExtraAccountMetaListInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -272,10 +272,10 @@ func (inst *AdminInitializeExtraAccountMetaList) EncodeToTree(parent ag_treeout.
 		})
 }
 
-func (obj AdminInitializeExtraAccountMetaList) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj AdminInitializeExtraAccountMetaListInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *AdminInitializeExtraAccountMetaList) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *AdminInitializeExtraAccountMetaListInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -288,7 +288,7 @@ func NewAdminInitializeExtraAccountMetaListInstruction(
 	receiptTokenMint ag_solanago.PublicKey,
 	extraAccountMetaList ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *AdminInitializeExtraAccountMetaList {
+	program ag_solanago.PublicKey) *AdminInitializeExtraAccountMetaListInstruction {
 	return NewAdminInitializeExtraAccountMetaListInstructionBuilder().
 		SetPayerAccount(payer).
 		SetAdminAccount(admin).

--- a/generated/restaking/admininitializeextraaccountmetalist_test.go
+++ b/generated/restaking/admininitializeextraaccountmetalist_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_AdminInitializeExtraAccountMetaList(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("AdminInitializeExtraAccountMetaList"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(AdminInitializeExtraAccountMetaList)
+				params := new(AdminInitializeExtraAccountMetaListInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(AdminInitializeExtraAccountMetaList)
+				got := new(AdminInitializeExtraAccountMetaListInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/admininitializefundaccount.go
+++ b/generated/restaking/admininitializefundaccount.go
@@ -11,7 +11,7 @@ import (
 )
 
 // AdminInitializeFundAccount is the `admin_initialize_fund_account` instruction.
-type AdminInitializeFundAccount struct {
+type AdminInitializeFundAccountInstruction struct {
 
 	// [0] = [WRITE, SIGNER] payer
 	//
@@ -38,9 +38,9 @@ type AdminInitializeFundAccount struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewAdminInitializeFundAccountInstructionBuilder creates a new `AdminInitializeFundAccount` instruction builder.
-func NewAdminInitializeFundAccountInstructionBuilder() *AdminInitializeFundAccount {
-	nd := &AdminInitializeFundAccount{
+// NewAdminInitializeFundAccountInstructionBuilder creates a new `AdminInitializeFundAccountInstruction` instruction builder.
+func NewAdminInitializeFundAccountInstructionBuilder() *AdminInitializeFundAccountInstruction {
+	nd := &AdminInitializeFundAccountInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 10),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["fragkamrANLvuZYQPcmPsCATQAabkqNGH6gxqqPG3aP"]).SIGNER()
@@ -50,35 +50,35 @@ func NewAdminInitializeFundAccountInstructionBuilder() *AdminInitializeFundAccou
 }
 
 // SetPayerAccount sets the "payer" account.
-func (inst *AdminInitializeFundAccount) SetPayerAccount(payer ag_solanago.PublicKey) *AdminInitializeFundAccount {
+func (inst *AdminInitializeFundAccountInstruction) SetPayerAccount(payer ag_solanago.PublicKey) *AdminInitializeFundAccountInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(payer).WRITE().SIGNER()
 	return inst
 }
 
 // GetPayerAccount gets the "payer" account.
-func (inst *AdminInitializeFundAccount) GetPayerAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundAccountInstruction) GetPayerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetAdminAccount sets the "admin" account.
-func (inst *AdminInitializeFundAccount) SetAdminAccount(admin ag_solanago.PublicKey) *AdminInitializeFundAccount {
+func (inst *AdminInitializeFundAccountInstruction) SetAdminAccount(admin ag_solanago.PublicKey) *AdminInitializeFundAccountInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(admin).SIGNER()
 	return inst
 }
 
 // GetAdminAccount gets the "admin" account.
-func (inst *AdminInitializeFundAccount) GetAdminAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundAccountInstruction) GetAdminAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *AdminInitializeFundAccount) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *AdminInitializeFundAccount {
+func (inst *AdminInitializeFundAccountInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *AdminInitializeFundAccountInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *AdminInitializeFundAccount) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundAccountInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
@@ -86,7 +86,7 @@ func (inst *AdminInitializeFundAccount) GetSystemProgramAccount() *ag_solanago.A
 // Mint authority must be admin or fund account,
 // otherwise `set_authority` CPI will fail.
 // Therefore, no extra constraint is needed.
-func (inst *AdminInitializeFundAccount) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *AdminInitializeFundAccount {
+func (inst *AdminInitializeFundAccountInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *AdminInitializeFundAccountInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenMint).WRITE()
 	return inst
 }
@@ -95,28 +95,28 @@ func (inst *AdminInitializeFundAccount) SetReceiptTokenMintAccount(receiptTokenM
 // Mint authority must be admin or fund account,
 // otherwise `set_authority` CPI will fail.
 // Therefore, no extra constraint is needed.
-func (inst *AdminInitializeFundAccount) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundAccountInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetReceiptTokenProgramAccount sets the "receipt_token_program" account.
-func (inst *AdminInitializeFundAccount) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *AdminInitializeFundAccount {
+func (inst *AdminInitializeFundAccountInstruction) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *AdminInitializeFundAccountInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(receiptTokenProgram)
 	return inst
 }
 
 // GetReceiptTokenProgramAccount gets the "receipt_token_program" account.
-func (inst *AdminInitializeFundAccount) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundAccountInstruction) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *AdminInitializeFundAccount) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *AdminInitializeFundAccount {
+func (inst *AdminInitializeFundAccountInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *AdminInitializeFundAccountInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *AdminInitializeFundAccount) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundAccountInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -133,12 +133,12 @@ func (inst *AdminInitializeFundAccount) findFindFundAccountAddress(receiptTokenM
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *AdminInitializeFundAccount) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminInitializeFundAccountInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminInitializeFundAccount) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundAccountInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -147,12 +147,12 @@ func (inst *AdminInitializeFundAccount) MustFindFundAccountAddressWithBumpSeed(r
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *AdminInitializeFundAccount) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundAccountInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *AdminInitializeFundAccount) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundAccountInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -161,17 +161,17 @@ func (inst *AdminInitializeFundAccount) MustFindFundAccountAddress(receiptTokenM
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *AdminInitializeFundAccount) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundAccountInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetFundReceiptTokenLockAccountAccount sets the "fund_receipt_token_lock_account" account.
-func (inst *AdminInitializeFundAccount) SetFundReceiptTokenLockAccountAccount(fundReceiptTokenLockAccount ag_solanago.PublicKey) *AdminInitializeFundAccount {
+func (inst *AdminInitializeFundAccountInstruction) SetFundReceiptTokenLockAccountAccount(fundReceiptTokenLockAccount ag_solanago.PublicKey) *AdminInitializeFundAccountInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(fundReceiptTokenLockAccount)
 	return inst
 }
 
-func (inst *AdminInitializeFundAccount) findFindFundReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundAccountInstruction) findFindFundReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: fundAccount
 	seeds = append(seeds, fundAccount.Bytes())
@@ -192,12 +192,12 @@ func (inst *AdminInitializeFundAccount) findFindFundReceiptTokenLockAccountAddre
 }
 
 // FindFundReceiptTokenLockAccountAddressWithBumpSeed calculates FundReceiptTokenLockAccount account address with given seeds and a known bump seed.
-func (inst *AdminInitializeFundAccount) FindFundReceiptTokenLockAccountAddressWithBumpSeed(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminInitializeFundAccountInstruction) FindFundReceiptTokenLockAccountAddressWithBumpSeed(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundReceiptTokenLockAccountAddress(fundAccount, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminInitializeFundAccount) MustFindFundReceiptTokenLockAccountAddressWithBumpSeed(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundAccountInstruction) MustFindFundReceiptTokenLockAccountAddressWithBumpSeed(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReceiptTokenLockAccountAddress(fundAccount, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -206,12 +206,12 @@ func (inst *AdminInitializeFundAccount) MustFindFundReceiptTokenLockAccountAddre
 }
 
 // FindFundReceiptTokenLockAccountAddress finds FundReceiptTokenLockAccount account address with given seeds.
-func (inst *AdminInitializeFundAccount) FindFundReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundAccountInstruction) FindFundReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundReceiptTokenLockAccountAddress(fundAccount, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *AdminInitializeFundAccount) MustFindFundReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundAccountInstruction) MustFindFundReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReceiptTokenLockAccountAddress(fundAccount, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -220,17 +220,17 @@ func (inst *AdminInitializeFundAccount) MustFindFundReceiptTokenLockAccountAddre
 }
 
 // GetFundReceiptTokenLockAccountAccount gets the "fund_receipt_token_lock_account" account.
-func (inst *AdminInitializeFundAccount) GetFundReceiptTokenLockAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundAccountInstruction) GetFundReceiptTokenLockAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetFundReserveAccountAccount sets the "fund_reserve_account" account.
-func (inst *AdminInitializeFundAccount) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *AdminInitializeFundAccount {
+func (inst *AdminInitializeFundAccountInstruction) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *AdminInitializeFundAccountInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(fundReserveAccount)
 	return inst
 }
 
-func (inst *AdminInitializeFundAccount) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundAccountInstruction) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_reserve
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x72), byte(0x65), byte(0x73), byte(0x65), byte(0x72), byte(0x76), byte(0x65)})
@@ -247,12 +247,12 @@ func (inst *AdminInitializeFundAccount) findFindFundReserveAccountAddress(receip
 }
 
 // FindFundReserveAccountAddressWithBumpSeed calculates FundReserveAccount account address with given seeds and a known bump seed.
-func (inst *AdminInitializeFundAccount) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminInitializeFundAccountInstruction) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminInitializeFundAccount) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundAccountInstruction) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -261,12 +261,12 @@ func (inst *AdminInitializeFundAccount) MustFindFundReserveAccountAddressWithBum
 }
 
 // FindFundReserveAccountAddress finds FundReserveAccount account address with given seeds.
-func (inst *AdminInitializeFundAccount) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundAccountInstruction) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *AdminInitializeFundAccount) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundAccountInstruction) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -275,17 +275,17 @@ func (inst *AdminInitializeFundAccount) MustFindFundReserveAccountAddress(receip
 }
 
 // GetFundReserveAccountAccount gets the "fund_reserve_account" account.
-func (inst *AdminInitializeFundAccount) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundAccountInstruction) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *AdminInitializeFundAccount) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminInitializeFundAccount {
+func (inst *AdminInitializeFundAccountInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminInitializeFundAccountInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *AdminInitializeFundAccount) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundAccountInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -300,12 +300,12 @@ func (inst *AdminInitializeFundAccount) findFindEventAuthorityAddress(knownBumpS
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *AdminInitializeFundAccount) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminInitializeFundAccountInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *AdminInitializeFundAccount) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundAccountInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -314,12 +314,12 @@ func (inst *AdminInitializeFundAccount) MustFindEventAuthorityAddressWithBumpSee
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *AdminInitializeFundAccount) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundAccountInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *AdminInitializeFundAccount) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundAccountInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -328,22 +328,22 @@ func (inst *AdminInitializeFundAccount) MustFindEventAuthorityAddress() (pda ag_
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *AdminInitializeFundAccount) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundAccountInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *AdminInitializeFundAccount) SetProgramAccount(program ag_solanago.PublicKey) *AdminInitializeFundAccount {
+func (inst *AdminInitializeFundAccountInstruction) SetProgramAccount(program ag_solanago.PublicKey) *AdminInitializeFundAccountInstruction {
 	inst.AccountMetaSlice[9] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *AdminInitializeFundAccount) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundAccountInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(9)
 }
 
-func (inst AdminInitializeFundAccount) Build() *Instruction {
+func (inst AdminInitializeFundAccountInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_AdminInitializeFundAccount,
@@ -353,14 +353,14 @@ func (inst AdminInitializeFundAccount) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst AdminInitializeFundAccount) ValidateAndBuild() (*Instruction, error) {
+func (inst AdminInitializeFundAccountInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *AdminInitializeFundAccount) Validate() error {
+func (inst *AdminInitializeFundAccountInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -397,7 +397,7 @@ func (inst *AdminInitializeFundAccount) Validate() error {
 	return nil
 }
 
-func (inst *AdminInitializeFundAccount) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *AdminInitializeFundAccountInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -425,10 +425,10 @@ func (inst *AdminInitializeFundAccount) EncodeToTree(parent ag_treeout.Branches)
 		})
 }
 
-func (obj AdminInitializeFundAccount) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj AdminInitializeFundAccountInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *AdminInitializeFundAccount) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *AdminInitializeFundAccountInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -444,7 +444,7 @@ func NewAdminInitializeFundAccountInstruction(
 	fundReceiptTokenLockAccount ag_solanago.PublicKey,
 	fundReserveAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *AdminInitializeFundAccount {
+	program ag_solanago.PublicKey) *AdminInitializeFundAccountInstruction {
 	return NewAdminInitializeFundAccountInstructionBuilder().
 		SetPayerAccount(payer).
 		SetAdminAccount(admin).

--- a/generated/restaking/admininitializefundaccount_test.go
+++ b/generated/restaking/admininitializefundaccount_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_AdminInitializeFundAccount(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("AdminInitializeFundAccount"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(AdminInitializeFundAccount)
+				params := new(AdminInitializeFundAccountInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(AdminInitializeFundAccount)
+				got := new(AdminInitializeFundAccountInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/admininitializefundwrapaccountrewardaccount.go
+++ b/generated/restaking/admininitializefundwrapaccountrewardaccount.go
@@ -11,7 +11,7 @@ import (
 )
 
 // AdminInitializeFundWrapAccountRewardAccount is the `admin_initialize_fund_wrap_account_reward_account` instruction.
-type AdminInitializeFundWrapAccountRewardAccount struct {
+type AdminInitializeFundWrapAccountRewardAccountInstruction struct {
 
 	// [0] = [WRITE, SIGNER] payer
 	//
@@ -37,9 +37,9 @@ type AdminInitializeFundWrapAccountRewardAccount struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewAdminInitializeFundWrapAccountRewardAccountInstructionBuilder creates a new `AdminInitializeFundWrapAccountRewardAccount` instruction builder.
-func NewAdminInitializeFundWrapAccountRewardAccountInstructionBuilder() *AdminInitializeFundWrapAccountRewardAccount {
-	nd := &AdminInitializeFundWrapAccountRewardAccount{
+// NewAdminInitializeFundWrapAccountRewardAccountInstructionBuilder creates a new `AdminInitializeFundWrapAccountRewardAccountInstruction` instruction builder.
+func NewAdminInitializeFundWrapAccountRewardAccountInstructionBuilder() *AdminInitializeFundWrapAccountRewardAccountInstruction {
+	nd := &AdminInitializeFundWrapAccountRewardAccountInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 11),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["fragkamrANLvuZYQPcmPsCATQAabkqNGH6gxqqPG3aP"]).SIGNER()
@@ -48,34 +48,34 @@ func NewAdminInitializeFundWrapAccountRewardAccountInstructionBuilder() *AdminIn
 }
 
 // SetPayerAccount sets the "payer" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) SetPayerAccount(payer ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccount {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) SetPayerAccount(payer ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccountInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(payer).WRITE().SIGNER()
 	return inst
 }
 
 // GetPayerAccount gets the "payer" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) GetPayerAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) GetPayerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetAdminAccount sets the "admin" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) SetAdminAccount(admin ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccount {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) SetAdminAccount(admin ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccountInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(admin).SIGNER()
 	return inst
 }
 
 // GetAdminAccount gets the "admin" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) GetAdminAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) GetAdminAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetFundWrapAccountAccount sets the "fund_wrap_account" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) SetFundWrapAccountAccount(fundWrapAccount ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccount {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) SetFundWrapAccountAccount(fundWrapAccount ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccountInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(fundWrapAccount)
 	return inst
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) findFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) findFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_wrap
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x77), byte(0x72), byte(0x61), byte(0x70)})
@@ -92,12 +92,12 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) findFindFundWrapAccount
 }
 
 // FindFundWrapAccountAddressWithBumpSeed calculates FundWrapAccount account address with given seeds and a known bump seed.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) FindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) FindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundWrapAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) MustFindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -106,12 +106,12 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindFundWrapAccount
 }
 
 // FindFundWrapAccountAddress finds FundWrapAccount account address with given seeds.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) FindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) FindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundWrapAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) MustFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -120,39 +120,39 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindFundWrapAccount
 }
 
 // GetFundWrapAccountAccount gets the "fund_wrap_account" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) GetFundWrapAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) GetFundWrapAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccount {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccountInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccount {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccountInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetReceiptTokenWrapAccountAccount sets the "receipt_token_wrap_account" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) SetReceiptTokenWrapAccountAccount(receiptTokenWrapAccount ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccount {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) SetReceiptTokenWrapAccountAccount(receiptTokenWrapAccount ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccountInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(receiptTokenWrapAccount)
 	return inst
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) findFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) findFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: fundWrapAccount
 	seeds = append(seeds, fundWrapAccount.Bytes())
@@ -173,12 +173,12 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) findFindReceiptTokenWra
 }
 
 // FindReceiptTokenWrapAccountAddressWithBumpSeed calculates ReceiptTokenWrapAccount account address with given seeds and a known bump seed.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) FindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) FindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) MustFindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -187,12 +187,12 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindReceiptTokenWra
 }
 
 // FindReceiptTokenWrapAccountAddress finds ReceiptTokenWrapAccount account address with given seeds.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) FindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) FindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenMint, 0)
 	return
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) MustFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -201,17 +201,17 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindReceiptTokenWra
 }
 
 // GetReceiptTokenWrapAccountAccount gets the "receipt_token_wrap_account" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) GetReceiptTokenWrapAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) GetReceiptTokenWrapAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccount {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccountInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(fundAccount)
 	return inst
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -228,12 +228,12 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) findFindFundAccountAddr
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -242,12 +242,12 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindFundAccountAddr
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -256,17 +256,17 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindFundAccountAddr
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccount {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccountInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -283,12 +283,12 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) findFindRewardAccountAd
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -297,12 +297,12 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindRewardAccountAd
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -311,17 +311,17 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindRewardAccountAd
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetFundWrapAccountRewardAccountAccount sets the "fund_wrap_account_reward_account" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) SetFundWrapAccountRewardAccountAccount(fundWrapAccountRewardAccount ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccount {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) SetFundWrapAccountRewardAccountAccount(fundWrapAccountRewardAccount ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccountInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(fundWrapAccountRewardAccount).WRITE()
 	return inst
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) findFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) findFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -340,12 +340,12 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) findFindFundWrapAccount
 }
 
 // FindFundWrapAccountRewardAccountAddressWithBumpSeed calculates FundWrapAccountRewardAccount account address with given seeds and a known bump seed.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) FindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) FindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, bumpSeed)
 	return
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) MustFindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -354,12 +354,12 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindFundWrapAccount
 }
 
 // FindFundWrapAccountRewardAccountAddress finds FundWrapAccountRewardAccount account address with given seeds.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) FindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) FindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, 0)
 	return
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) MustFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, 0)
 	if err != nil {
 		panic(err)
@@ -368,17 +368,17 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindFundWrapAccount
 }
 
 // GetFundWrapAccountRewardAccountAccount gets the "fund_wrap_account_reward_account" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) GetFundWrapAccountRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) GetFundWrapAccountRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccount {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccountInstruction {
 	inst.AccountMetaSlice[9] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -393,12 +393,12 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) findFindEventAuthorityA
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -407,12 +407,12 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindEventAuthorityA
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -421,22 +421,22 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) MustFindEventAuthorityA
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(9)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) SetProgramAccount(program ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccount {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) SetProgramAccount(program ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccountInstruction {
 	inst.AccountMetaSlice[10] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *AdminInitializeFundWrapAccountRewardAccount) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(10)
 }
 
-func (inst AdminInitializeFundWrapAccountRewardAccount) Build() *Instruction {
+func (inst AdminInitializeFundWrapAccountRewardAccountInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_AdminInitializeFundWrapAccountRewardAccount,
@@ -446,14 +446,14 @@ func (inst AdminInitializeFundWrapAccountRewardAccount) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst AdminInitializeFundWrapAccountRewardAccount) ValidateAndBuild() (*Instruction, error) {
+func (inst AdminInitializeFundWrapAccountRewardAccountInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) Validate() error {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -493,7 +493,7 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) Validate() error {
 	return nil
 }
 
-func (inst *AdminInitializeFundWrapAccountRewardAccount) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *AdminInitializeFundWrapAccountRewardAccountInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -522,10 +522,10 @@ func (inst *AdminInitializeFundWrapAccountRewardAccount) EncodeToTree(parent ag_
 		})
 }
 
-func (obj AdminInitializeFundWrapAccountRewardAccount) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj AdminInitializeFundWrapAccountRewardAccountInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *AdminInitializeFundWrapAccountRewardAccount) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *AdminInitializeFundWrapAccountRewardAccountInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -542,7 +542,7 @@ func NewAdminInitializeFundWrapAccountRewardAccountInstruction(
 	rewardAccount ag_solanago.PublicKey,
 	fundWrapAccountRewardAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccount {
+	program ag_solanago.PublicKey) *AdminInitializeFundWrapAccountRewardAccountInstruction {
 	return NewAdminInitializeFundWrapAccountRewardAccountInstructionBuilder().
 		SetPayerAccount(payer).
 		SetAdminAccount(admin).

--- a/generated/restaking/admininitializefundwrapaccountrewardaccount_test.go
+++ b/generated/restaking/admininitializefundwrapaccountrewardaccount_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_AdminInitializeFundWrapAccountRewardAccount(t *testing.T) 
 	for i := 0; i < 1; i++ {
 		t.Run("AdminInitializeFundWrapAccountRewardAccount"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(AdminInitializeFundWrapAccountRewardAccount)
+				params := new(AdminInitializeFundWrapAccountRewardAccountInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(AdminInitializeFundWrapAccountRewardAccount)
+				got := new(AdminInitializeFundWrapAccountRewardAccountInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/admininitializenormalizedtokenpoolaccount.go
+++ b/generated/restaking/admininitializenormalizedtokenpoolaccount.go
@@ -11,7 +11,7 @@ import (
 )
 
 // AdminInitializeNormalizedTokenPoolAccount is the `admin_initialize_normalized_token_pool_account` instruction.
-type AdminInitializeNormalizedTokenPoolAccount struct {
+type AdminInitializeNormalizedTokenPoolAccountInstruction struct {
 
 	// [0] = [WRITE, SIGNER] payer
 	//
@@ -31,9 +31,9 @@ type AdminInitializeNormalizedTokenPoolAccount struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewAdminInitializeNormalizedTokenPoolAccountInstructionBuilder creates a new `AdminInitializeNormalizedTokenPoolAccount` instruction builder.
-func NewAdminInitializeNormalizedTokenPoolAccountInstructionBuilder() *AdminInitializeNormalizedTokenPoolAccount {
-	nd := &AdminInitializeNormalizedTokenPoolAccount{
+// NewAdminInitializeNormalizedTokenPoolAccountInstructionBuilder creates a new `AdminInitializeNormalizedTokenPoolAccountInstruction` instruction builder.
+func NewAdminInitializeNormalizedTokenPoolAccountInstructionBuilder() *AdminInitializeNormalizedTokenPoolAccountInstruction {
+	nd := &AdminInitializeNormalizedTokenPoolAccountInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 8),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["fragkamrANLvuZYQPcmPsCATQAabkqNGH6gxqqPG3aP"]).SIGNER()
@@ -43,67 +43,67 @@ func NewAdminInitializeNormalizedTokenPoolAccountInstructionBuilder() *AdminInit
 }
 
 // SetPayerAccount sets the "payer" account.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) SetPayerAccount(payer ag_solanago.PublicKey) *AdminInitializeNormalizedTokenPoolAccount {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) SetPayerAccount(payer ag_solanago.PublicKey) *AdminInitializeNormalizedTokenPoolAccountInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(payer).WRITE().SIGNER()
 	return inst
 }
 
 // GetPayerAccount gets the "payer" account.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) GetPayerAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) GetPayerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetAdminAccount sets the "admin" account.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) SetAdminAccount(admin ag_solanago.PublicKey) *AdminInitializeNormalizedTokenPoolAccount {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) SetAdminAccount(admin ag_solanago.PublicKey) *AdminInitializeNormalizedTokenPoolAccountInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(admin).SIGNER()
 	return inst
 }
 
 // GetAdminAccount gets the "admin" account.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) GetAdminAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) GetAdminAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *AdminInitializeNormalizedTokenPoolAccount {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *AdminInitializeNormalizedTokenPoolAccountInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetNormalizedTokenProgramAccount sets the "normalized_token_program" account.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) SetNormalizedTokenProgramAccount(normalizedTokenProgram ag_solanago.PublicKey) *AdminInitializeNormalizedTokenPoolAccount {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) SetNormalizedTokenProgramAccount(normalizedTokenProgram ag_solanago.PublicKey) *AdminInitializeNormalizedTokenPoolAccountInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(normalizedTokenProgram)
 	return inst
 }
 
 // GetNormalizedTokenProgramAccount gets the "normalized_token_program" account.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) GetNormalizedTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) GetNormalizedTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetNormalizedTokenMintAccount sets the "normalized_token_mint" account.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) SetNormalizedTokenMintAccount(normalizedTokenMint ag_solanago.PublicKey) *AdminInitializeNormalizedTokenPoolAccount {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) SetNormalizedTokenMintAccount(normalizedTokenMint ag_solanago.PublicKey) *AdminInitializeNormalizedTokenPoolAccountInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(normalizedTokenMint).WRITE()
 	return inst
 }
 
 // GetNormalizedTokenMintAccount gets the "normalized_token_mint" account.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) GetNormalizedTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) GetNormalizedTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetNormalizedTokenPoolAccountAccount sets the "normalized_token_pool_account" account.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) SetNormalizedTokenPoolAccountAccount(normalizedTokenPoolAccount ag_solanago.PublicKey) *AdminInitializeNormalizedTokenPoolAccount {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) SetNormalizedTokenPoolAccountAccount(normalizedTokenPoolAccount ag_solanago.PublicKey) *AdminInitializeNormalizedTokenPoolAccountInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(normalizedTokenPoolAccount).WRITE()
 	return inst
 }
 
-func (inst *AdminInitializeNormalizedTokenPoolAccount) findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: nt_pool
 	seeds = append(seeds, []byte{byte(0x6e), byte(0x74), byte(0x5f), byte(0x70), byte(0x6f), byte(0x6f), byte(0x6c)})
@@ -120,12 +120,12 @@ func (inst *AdminInitializeNormalizedTokenPoolAccount) findFindNormalizedTokenPo
 }
 
 // FindNormalizedTokenPoolAccountAddressWithBumpSeed calculates NormalizedTokenPoolAccount account address with given seeds and a known bump seed.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) FindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) FindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminInitializeNormalizedTokenPoolAccount) MustFindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) MustFindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -134,12 +134,12 @@ func (inst *AdminInitializeNormalizedTokenPoolAccount) MustFindNormalizedTokenPo
 }
 
 // FindNormalizedTokenPoolAccountAddress finds NormalizedTokenPoolAccount account address with given seeds.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) FindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) FindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, 0)
 	return
 }
 
-func (inst *AdminInitializeNormalizedTokenPoolAccount) MustFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) MustFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -148,17 +148,17 @@ func (inst *AdminInitializeNormalizedTokenPoolAccount) MustFindNormalizedTokenPo
 }
 
 // GetNormalizedTokenPoolAccountAccount gets the "normalized_token_pool_account" account.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) GetNormalizedTokenPoolAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) GetNormalizedTokenPoolAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminInitializeNormalizedTokenPoolAccount {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminInitializeNormalizedTokenPoolAccountInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *AdminInitializeNormalizedTokenPoolAccount) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -173,12 +173,12 @@ func (inst *AdminInitializeNormalizedTokenPoolAccount) findFindEventAuthorityAdd
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *AdminInitializeNormalizedTokenPoolAccount) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -187,12 +187,12 @@ func (inst *AdminInitializeNormalizedTokenPoolAccount) MustFindEventAuthorityAdd
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *AdminInitializeNormalizedTokenPoolAccount) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -201,22 +201,22 @@ func (inst *AdminInitializeNormalizedTokenPoolAccount) MustFindEventAuthorityAdd
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) SetProgramAccount(program ag_solanago.PublicKey) *AdminInitializeNormalizedTokenPoolAccount {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) SetProgramAccount(program ag_solanago.PublicKey) *AdminInitializeNormalizedTokenPoolAccountInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *AdminInitializeNormalizedTokenPoolAccount) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
-func (inst AdminInitializeNormalizedTokenPoolAccount) Build() *Instruction {
+func (inst AdminInitializeNormalizedTokenPoolAccountInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_AdminInitializeNormalizedTokenPoolAccount,
@@ -226,14 +226,14 @@ func (inst AdminInitializeNormalizedTokenPoolAccount) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst AdminInitializeNormalizedTokenPoolAccount) ValidateAndBuild() (*Instruction, error) {
+func (inst AdminInitializeNormalizedTokenPoolAccountInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *AdminInitializeNormalizedTokenPoolAccount) Validate() error {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -264,7 +264,7 @@ func (inst *AdminInitializeNormalizedTokenPoolAccount) Validate() error {
 	return nil
 }
 
-func (inst *AdminInitializeNormalizedTokenPoolAccount) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *AdminInitializeNormalizedTokenPoolAccountInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -290,10 +290,10 @@ func (inst *AdminInitializeNormalizedTokenPoolAccount) EncodeToTree(parent ag_tr
 		})
 }
 
-func (obj AdminInitializeNormalizedTokenPoolAccount) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj AdminInitializeNormalizedTokenPoolAccountInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *AdminInitializeNormalizedTokenPoolAccount) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *AdminInitializeNormalizedTokenPoolAccountInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -307,7 +307,7 @@ func NewAdminInitializeNormalizedTokenPoolAccountInstruction(
 	normalizedTokenMint ag_solanago.PublicKey,
 	normalizedTokenPoolAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *AdminInitializeNormalizedTokenPoolAccount {
+	program ag_solanago.PublicKey) *AdminInitializeNormalizedTokenPoolAccountInstruction {
 	return NewAdminInitializeNormalizedTokenPoolAccountInstructionBuilder().
 		SetPayerAccount(payer).
 		SetAdminAccount(admin).

--- a/generated/restaking/admininitializenormalizedtokenpoolaccount_test.go
+++ b/generated/restaking/admininitializenormalizedtokenpoolaccount_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_AdminInitializeNormalizedTokenPoolAccount(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("AdminInitializeNormalizedTokenPoolAccount"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(AdminInitializeNormalizedTokenPoolAccount)
+				params := new(AdminInitializeNormalizedTokenPoolAccountInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(AdminInitializeNormalizedTokenPoolAccount)
+				got := new(AdminInitializeNormalizedTokenPoolAccountInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/admininitializerewardaccount.go
+++ b/generated/restaking/admininitializerewardaccount.go
@@ -11,7 +11,7 @@ import (
 )
 
 // AdminInitializeRewardAccount is the `admin_initialize_reward_account` instruction.
-type AdminInitializeRewardAccount struct {
+type AdminInitializeRewardAccountInstruction struct {
 
 	// [0] = [WRITE, SIGNER] payer
 	//
@@ -29,9 +29,9 @@ type AdminInitializeRewardAccount struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewAdminInitializeRewardAccountInstructionBuilder creates a new `AdminInitializeRewardAccount` instruction builder.
-func NewAdminInitializeRewardAccountInstructionBuilder() *AdminInitializeRewardAccount {
-	nd := &AdminInitializeRewardAccount{
+// NewAdminInitializeRewardAccountInstructionBuilder creates a new `AdminInitializeRewardAccountInstruction` instruction builder.
+func NewAdminInitializeRewardAccountInstructionBuilder() *AdminInitializeRewardAccountInstruction {
+	nd := &AdminInitializeRewardAccountInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 7),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["fragkamrANLvuZYQPcmPsCATQAabkqNGH6gxqqPG3aP"]).SIGNER()
@@ -40,56 +40,56 @@ func NewAdminInitializeRewardAccountInstructionBuilder() *AdminInitializeRewardA
 }
 
 // SetPayerAccount sets the "payer" account.
-func (inst *AdminInitializeRewardAccount) SetPayerAccount(payer ag_solanago.PublicKey) *AdminInitializeRewardAccount {
+func (inst *AdminInitializeRewardAccountInstruction) SetPayerAccount(payer ag_solanago.PublicKey) *AdminInitializeRewardAccountInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(payer).WRITE().SIGNER()
 	return inst
 }
 
 // GetPayerAccount gets the "payer" account.
-func (inst *AdminInitializeRewardAccount) GetPayerAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeRewardAccountInstruction) GetPayerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetAdminAccount sets the "admin" account.
-func (inst *AdminInitializeRewardAccount) SetAdminAccount(admin ag_solanago.PublicKey) *AdminInitializeRewardAccount {
+func (inst *AdminInitializeRewardAccountInstruction) SetAdminAccount(admin ag_solanago.PublicKey) *AdminInitializeRewardAccountInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(admin).SIGNER()
 	return inst
 }
 
 // GetAdminAccount gets the "admin" account.
-func (inst *AdminInitializeRewardAccount) GetAdminAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeRewardAccountInstruction) GetAdminAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *AdminInitializeRewardAccount) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *AdminInitializeRewardAccount {
+func (inst *AdminInitializeRewardAccountInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *AdminInitializeRewardAccountInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *AdminInitializeRewardAccount) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeRewardAccountInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *AdminInitializeRewardAccount) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *AdminInitializeRewardAccount {
+func (inst *AdminInitializeRewardAccountInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *AdminInitializeRewardAccountInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *AdminInitializeRewardAccount) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeRewardAccountInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *AdminInitializeRewardAccount) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *AdminInitializeRewardAccount {
+func (inst *AdminInitializeRewardAccountInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *AdminInitializeRewardAccountInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *AdminInitializeRewardAccount) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeRewardAccountInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -106,12 +106,12 @@ func (inst *AdminInitializeRewardAccount) findFindRewardAccountAddress(receiptTo
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *AdminInitializeRewardAccount) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminInitializeRewardAccountInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminInitializeRewardAccount) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeRewardAccountInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -120,12 +120,12 @@ func (inst *AdminInitializeRewardAccount) MustFindRewardAccountAddressWithBumpSe
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *AdminInitializeRewardAccount) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeRewardAccountInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *AdminInitializeRewardAccount) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeRewardAccountInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -134,17 +134,17 @@ func (inst *AdminInitializeRewardAccount) MustFindRewardAccountAddress(receiptTo
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *AdminInitializeRewardAccount) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeRewardAccountInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *AdminInitializeRewardAccount) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminInitializeRewardAccount {
+func (inst *AdminInitializeRewardAccountInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminInitializeRewardAccountInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *AdminInitializeRewardAccount) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeRewardAccountInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -159,12 +159,12 @@ func (inst *AdminInitializeRewardAccount) findFindEventAuthorityAddress(knownBum
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *AdminInitializeRewardAccount) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminInitializeRewardAccountInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *AdminInitializeRewardAccount) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeRewardAccountInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -173,12 +173,12 @@ func (inst *AdminInitializeRewardAccount) MustFindEventAuthorityAddressWithBumpS
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *AdminInitializeRewardAccount) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminInitializeRewardAccountInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *AdminInitializeRewardAccount) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *AdminInitializeRewardAccountInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -187,22 +187,22 @@ func (inst *AdminInitializeRewardAccount) MustFindEventAuthorityAddress() (pda a
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *AdminInitializeRewardAccount) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeRewardAccountInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *AdminInitializeRewardAccount) SetProgramAccount(program ag_solanago.PublicKey) *AdminInitializeRewardAccount {
+func (inst *AdminInitializeRewardAccountInstruction) SetProgramAccount(program ag_solanago.PublicKey) *AdminInitializeRewardAccountInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *AdminInitializeRewardAccount) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminInitializeRewardAccountInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
-func (inst AdminInitializeRewardAccount) Build() *Instruction {
+func (inst AdminInitializeRewardAccountInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_AdminInitializeRewardAccount,
@@ -212,14 +212,14 @@ func (inst AdminInitializeRewardAccount) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst AdminInitializeRewardAccount) ValidateAndBuild() (*Instruction, error) {
+func (inst AdminInitializeRewardAccountInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *AdminInitializeRewardAccount) Validate() error {
+func (inst *AdminInitializeRewardAccountInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -247,7 +247,7 @@ func (inst *AdminInitializeRewardAccount) Validate() error {
 	return nil
 }
 
-func (inst *AdminInitializeRewardAccount) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *AdminInitializeRewardAccountInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -272,10 +272,10 @@ func (inst *AdminInitializeRewardAccount) EncodeToTree(parent ag_treeout.Branche
 		})
 }
 
-func (obj AdminInitializeRewardAccount) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj AdminInitializeRewardAccountInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *AdminInitializeRewardAccount) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *AdminInitializeRewardAccountInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -288,7 +288,7 @@ func NewAdminInitializeRewardAccountInstruction(
 	receiptTokenMint ag_solanago.PublicKey,
 	rewardAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *AdminInitializeRewardAccount {
+	program ag_solanago.PublicKey) *AdminInitializeRewardAccountInstruction {
 	return NewAdminInitializeRewardAccountInstructionBuilder().
 		SetPayerAccount(payer).
 		SetAdminAccount(admin).

--- a/generated/restaking/admininitializerewardaccount_test.go
+++ b/generated/restaking/admininitializerewardaccount_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_AdminInitializeRewardAccount(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("AdminInitializeRewardAccount"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(AdminInitializeRewardAccount)
+				params := new(AdminInitializeRewardAccountInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(AdminInitializeRewardAccount)
+				got := new(AdminInitializeRewardAccountInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/adminsetaddresslookuptableaccount.go
+++ b/generated/restaking/adminsetaddresslookuptableaccount.go
@@ -11,7 +11,7 @@ import (
 )
 
 // AdminSetAddressLookupTableAccount is the `admin_set_address_lookup_table_account` instruction.
-type AdminSetAddressLookupTableAccount struct {
+type AdminSetAddressLookupTableAccountInstruction struct {
 	AddressLookupTableAccount *ag_solanago.PublicKey `bin:"optional"`
 
 	// [0] = [SIGNER] payer
@@ -28,9 +28,9 @@ type AdminSetAddressLookupTableAccount struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewAdminSetAddressLookupTableAccountInstructionBuilder creates a new `AdminSetAddressLookupTableAccount` instruction builder.
-func NewAdminSetAddressLookupTableAccountInstructionBuilder() *AdminSetAddressLookupTableAccount {
-	nd := &AdminSetAddressLookupTableAccount{
+// NewAdminSetAddressLookupTableAccountInstructionBuilder creates a new `AdminSetAddressLookupTableAccountInstruction` instruction builder.
+func NewAdminSetAddressLookupTableAccountInstructionBuilder() *AdminSetAddressLookupTableAccountInstruction {
+	nd := &AdminSetAddressLookupTableAccountInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 6),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["fragkamrANLvuZYQPcmPsCATQAabkqNGH6gxqqPG3aP"]).SIGNER()
@@ -38,40 +38,40 @@ func NewAdminSetAddressLookupTableAccountInstructionBuilder() *AdminSetAddressLo
 }
 
 // SetAddressLookupTableAccount sets the "address_lookup_table_account" parameter.
-func (inst *AdminSetAddressLookupTableAccount) SetAddressLookupTableAccount(address_lookup_table_account ag_solanago.PublicKey) *AdminSetAddressLookupTableAccount {
+func (inst *AdminSetAddressLookupTableAccountInstruction) SetAddressLookupTableAccount(address_lookup_table_account ag_solanago.PublicKey) *AdminSetAddressLookupTableAccountInstruction {
 	inst.AddressLookupTableAccount = &address_lookup_table_account
 	return inst
 }
 
 // SetPayerAccount sets the "payer" account.
-func (inst *AdminSetAddressLookupTableAccount) SetPayerAccount(payer ag_solanago.PublicKey) *AdminSetAddressLookupTableAccount {
+func (inst *AdminSetAddressLookupTableAccountInstruction) SetPayerAccount(payer ag_solanago.PublicKey) *AdminSetAddressLookupTableAccountInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(payer).SIGNER()
 	return inst
 }
 
 // GetPayerAccount gets the "payer" account.
-func (inst *AdminSetAddressLookupTableAccount) GetPayerAccount() *ag_solanago.AccountMeta {
+func (inst *AdminSetAddressLookupTableAccountInstruction) GetPayerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetAdminAccount sets the "admin" account.
-func (inst *AdminSetAddressLookupTableAccount) SetAdminAccount(admin ag_solanago.PublicKey) *AdminSetAddressLookupTableAccount {
+func (inst *AdminSetAddressLookupTableAccountInstruction) SetAdminAccount(admin ag_solanago.PublicKey) *AdminSetAddressLookupTableAccountInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(admin).SIGNER()
 	return inst
 }
 
 // GetAdminAccount gets the "admin" account.
-func (inst *AdminSetAddressLookupTableAccount) GetAdminAccount() *ag_solanago.AccountMeta {
+func (inst *AdminSetAddressLookupTableAccountInstruction) GetAdminAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *AdminSetAddressLookupTableAccount) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *AdminSetAddressLookupTableAccount {
+func (inst *AdminSetAddressLookupTableAccountInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *AdminSetAddressLookupTableAccountInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *AdminSetAddressLookupTableAccount) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminSetAddressLookupTableAccountInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -88,12 +88,12 @@ func (inst *AdminSetAddressLookupTableAccount) findFindFundAccountAddress(receip
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *AdminSetAddressLookupTableAccount) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminSetAddressLookupTableAccountInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminSetAddressLookupTableAccount) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminSetAddressLookupTableAccountInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -102,12 +102,12 @@ func (inst *AdminSetAddressLookupTableAccount) MustFindFundAccountAddressWithBum
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *AdminSetAddressLookupTableAccount) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminSetAddressLookupTableAccountInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *AdminSetAddressLookupTableAccount) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminSetAddressLookupTableAccountInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -116,28 +116,28 @@ func (inst *AdminSetAddressLookupTableAccount) MustFindFundAccountAddress(receip
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *AdminSetAddressLookupTableAccount) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminSetAddressLookupTableAccountInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *AdminSetAddressLookupTableAccount) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *AdminSetAddressLookupTableAccount {
+func (inst *AdminSetAddressLookupTableAccountInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *AdminSetAddressLookupTableAccountInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *AdminSetAddressLookupTableAccount) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *AdminSetAddressLookupTableAccountInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *AdminSetAddressLookupTableAccount) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminSetAddressLookupTableAccount {
+func (inst *AdminSetAddressLookupTableAccountInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminSetAddressLookupTableAccountInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *AdminSetAddressLookupTableAccount) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminSetAddressLookupTableAccountInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -152,12 +152,12 @@ func (inst *AdminSetAddressLookupTableAccount) findFindEventAuthorityAddress(kno
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *AdminSetAddressLookupTableAccount) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminSetAddressLookupTableAccountInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *AdminSetAddressLookupTableAccount) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminSetAddressLookupTableAccountInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -166,12 +166,12 @@ func (inst *AdminSetAddressLookupTableAccount) MustFindEventAuthorityAddressWith
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *AdminSetAddressLookupTableAccount) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminSetAddressLookupTableAccountInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *AdminSetAddressLookupTableAccount) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *AdminSetAddressLookupTableAccountInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -180,22 +180,22 @@ func (inst *AdminSetAddressLookupTableAccount) MustFindEventAuthorityAddress() (
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *AdminSetAddressLookupTableAccount) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *AdminSetAddressLookupTableAccountInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *AdminSetAddressLookupTableAccount) SetProgramAccount(program ag_solanago.PublicKey) *AdminSetAddressLookupTableAccount {
+func (inst *AdminSetAddressLookupTableAccountInstruction) SetProgramAccount(program ag_solanago.PublicKey) *AdminSetAddressLookupTableAccountInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *AdminSetAddressLookupTableAccount) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminSetAddressLookupTableAccountInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
-func (inst AdminSetAddressLookupTableAccount) Build() *Instruction {
+func (inst AdminSetAddressLookupTableAccountInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_AdminSetAddressLookupTableAccount,
@@ -205,14 +205,14 @@ func (inst AdminSetAddressLookupTableAccount) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst AdminSetAddressLookupTableAccount) ValidateAndBuild() (*Instruction, error) {
+func (inst AdminSetAddressLookupTableAccountInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *AdminSetAddressLookupTableAccount) Validate() error {
+func (inst *AdminSetAddressLookupTableAccountInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 	}
@@ -241,7 +241,7 @@ func (inst *AdminSetAddressLookupTableAccount) Validate() error {
 	return nil
 }
 
-func (inst *AdminSetAddressLookupTableAccount) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *AdminSetAddressLookupTableAccountInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -267,7 +267,7 @@ func (inst *AdminSetAddressLookupTableAccount) EncodeToTree(parent ag_treeout.Br
 		})
 }
 
-func (obj AdminSetAddressLookupTableAccount) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj AdminSetAddressLookupTableAccountInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `AddressLookupTableAccount` param (optional):
 	{
 		if obj.AddressLookupTableAccount == nil {
@@ -288,7 +288,7 @@ func (obj AdminSetAddressLookupTableAccount) MarshalWithEncoder(encoder *ag_bina
 	}
 	return nil
 }
-func (obj *AdminSetAddressLookupTableAccount) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *AdminSetAddressLookupTableAccountInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `AddressLookupTableAccount` (optional):
 	{
 		ok, err := decoder.ReadBool()
@@ -315,7 +315,7 @@ func NewAdminSetAddressLookupTableAccountInstruction(
 	fundAccount ag_solanago.PublicKey,
 	receiptTokenMint ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *AdminSetAddressLookupTableAccount {
+	program ag_solanago.PublicKey) *AdminSetAddressLookupTableAccountInstruction {
 	return NewAdminSetAddressLookupTableAccountInstructionBuilder().
 		SetAddressLookupTableAccount(address_lookup_table_account).
 		SetPayerAccount(payer).

--- a/generated/restaking/adminsetaddresslookuptableaccount_test.go
+++ b/generated/restaking/adminsetaddresslookuptableaccount_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_AdminSetAddressLookupTableAccount(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("AdminSetAddressLookupTableAccount"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(AdminSetAddressLookupTableAccount)
+				params := new(AdminSetAddressLookupTableAccountInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(AdminSetAddressLookupTableAccount)
+				got := new(AdminSetAddressLookupTableAccountInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/adminupdateextraaccountmetalistifneeded.go
+++ b/generated/restaking/adminupdateextraaccountmetalistifneeded.go
@@ -11,7 +11,7 @@ import (
 )
 
 // AdminUpdateExtraAccountMetaListIfNeeded is the `admin_update_extra_account_meta_list_if_needed` instruction.
-type AdminUpdateExtraAccountMetaListIfNeeded struct {
+type AdminUpdateExtraAccountMetaListIfNeededInstruction struct {
 
 	// [0] = [SIGNER] payer
 	//
@@ -27,9 +27,9 @@ type AdminUpdateExtraAccountMetaListIfNeeded struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewAdminUpdateExtraAccountMetaListIfNeededInstructionBuilder creates a new `AdminUpdateExtraAccountMetaListIfNeeded` instruction builder.
-func NewAdminUpdateExtraAccountMetaListIfNeededInstructionBuilder() *AdminUpdateExtraAccountMetaListIfNeeded {
-	nd := &AdminUpdateExtraAccountMetaListIfNeeded{
+// NewAdminUpdateExtraAccountMetaListIfNeededInstructionBuilder creates a new `AdminUpdateExtraAccountMetaListIfNeededInstruction` instruction builder.
+func NewAdminUpdateExtraAccountMetaListIfNeededInstructionBuilder() *AdminUpdateExtraAccountMetaListIfNeededInstruction {
+	nd := &AdminUpdateExtraAccountMetaListIfNeededInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 6),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["fragkamrANLvuZYQPcmPsCATQAabkqNGH6gxqqPG3aP"]).SIGNER()
@@ -37,45 +37,45 @@ func NewAdminUpdateExtraAccountMetaListIfNeededInstructionBuilder() *AdminUpdate
 }
 
 // SetPayerAccount sets the "payer" account.
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) SetPayerAccount(payer ag_solanago.PublicKey) *AdminUpdateExtraAccountMetaListIfNeeded {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) SetPayerAccount(payer ag_solanago.PublicKey) *AdminUpdateExtraAccountMetaListIfNeededInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(payer).SIGNER()
 	return inst
 }
 
 // GetPayerAccount gets the "payer" account.
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) GetPayerAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) GetPayerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetAdminAccount sets the "admin" account.
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) SetAdminAccount(admin ag_solanago.PublicKey) *AdminUpdateExtraAccountMetaListIfNeeded {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) SetAdminAccount(admin ag_solanago.PublicKey) *AdminUpdateExtraAccountMetaListIfNeededInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(admin).SIGNER()
 	return inst
 }
 
 // GetAdminAccount gets the "admin" account.
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) GetAdminAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) GetAdminAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *AdminUpdateExtraAccountMetaListIfNeeded {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *AdminUpdateExtraAccountMetaListIfNeededInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetExtraAccountMetaListAccount sets the "extra_account_meta_list" account.
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) SetExtraAccountMetaListAccount(extraAccountMetaList ag_solanago.PublicKey) *AdminUpdateExtraAccountMetaListIfNeeded {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) SetExtraAccountMetaListAccount(extraAccountMetaList ag_solanago.PublicKey) *AdminUpdateExtraAccountMetaListIfNeededInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(extraAccountMetaList).WRITE()
 	return inst
 }
 
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) findFindExtraAccountMetaListAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) findFindExtraAccountMetaListAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: extra-account-metas
 	seeds = append(seeds, []byte{byte(0x65), byte(0x78), byte(0x74), byte(0x72), byte(0x61), byte(0x2d), byte(0x61), byte(0x63), byte(0x63), byte(0x6f), byte(0x75), byte(0x6e), byte(0x74), byte(0x2d), byte(0x6d), byte(0x65), byte(0x74), byte(0x61), byte(0x73)})
@@ -92,12 +92,12 @@ func (inst *AdminUpdateExtraAccountMetaListIfNeeded) findFindExtraAccountMetaLis
 }
 
 // FindExtraAccountMetaListAddressWithBumpSeed calculates ExtraAccountMetaList account address with given seeds and a known bump seed.
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) FindExtraAccountMetaListAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) FindExtraAccountMetaListAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindExtraAccountMetaListAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) MustFindExtraAccountMetaListAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) MustFindExtraAccountMetaListAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindExtraAccountMetaListAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -106,12 +106,12 @@ func (inst *AdminUpdateExtraAccountMetaListIfNeeded) MustFindExtraAccountMetaLis
 }
 
 // FindExtraAccountMetaListAddress finds ExtraAccountMetaList account address with given seeds.
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) FindExtraAccountMetaListAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) FindExtraAccountMetaListAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindExtraAccountMetaListAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) MustFindExtraAccountMetaListAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) MustFindExtraAccountMetaListAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindExtraAccountMetaListAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -120,17 +120,17 @@ func (inst *AdminUpdateExtraAccountMetaListIfNeeded) MustFindExtraAccountMetaLis
 }
 
 // GetExtraAccountMetaListAccount gets the "extra_account_meta_list" account.
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) GetExtraAccountMetaListAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) GetExtraAccountMetaListAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminUpdateExtraAccountMetaListIfNeeded {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminUpdateExtraAccountMetaListIfNeededInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -145,12 +145,12 @@ func (inst *AdminUpdateExtraAccountMetaListIfNeeded) findFindEventAuthorityAddre
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -159,12 +159,12 @@ func (inst *AdminUpdateExtraAccountMetaListIfNeeded) MustFindEventAuthorityAddre
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -173,22 +173,22 @@ func (inst *AdminUpdateExtraAccountMetaListIfNeeded) MustFindEventAuthorityAddre
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) SetProgramAccount(program ag_solanago.PublicKey) *AdminUpdateExtraAccountMetaListIfNeeded {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) SetProgramAccount(program ag_solanago.PublicKey) *AdminUpdateExtraAccountMetaListIfNeededInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
-func (inst AdminUpdateExtraAccountMetaListIfNeeded) Build() *Instruction {
+func (inst AdminUpdateExtraAccountMetaListIfNeededInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_AdminUpdateExtraAccountMetaListIfNeeded,
@@ -198,14 +198,14 @@ func (inst AdminUpdateExtraAccountMetaListIfNeeded) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst AdminUpdateExtraAccountMetaListIfNeeded) ValidateAndBuild() (*Instruction, error) {
+func (inst AdminUpdateExtraAccountMetaListIfNeededInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) Validate() error {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -230,7 +230,7 @@ func (inst *AdminUpdateExtraAccountMetaListIfNeeded) Validate() error {
 	return nil
 }
 
-func (inst *AdminUpdateExtraAccountMetaListIfNeeded) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *AdminUpdateExtraAccountMetaListIfNeededInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -254,10 +254,10 @@ func (inst *AdminUpdateExtraAccountMetaListIfNeeded) EncodeToTree(parent ag_tree
 		})
 }
 
-func (obj AdminUpdateExtraAccountMetaListIfNeeded) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj AdminUpdateExtraAccountMetaListIfNeededInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *AdminUpdateExtraAccountMetaListIfNeeded) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *AdminUpdateExtraAccountMetaListIfNeededInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -269,7 +269,7 @@ func NewAdminUpdateExtraAccountMetaListIfNeededInstruction(
 	receiptTokenMint ag_solanago.PublicKey,
 	extraAccountMetaList ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *AdminUpdateExtraAccountMetaListIfNeeded {
+	program ag_solanago.PublicKey) *AdminUpdateExtraAccountMetaListIfNeededInstruction {
 	return NewAdminUpdateExtraAccountMetaListIfNeededInstructionBuilder().
 		SetPayerAccount(payer).
 		SetAdminAccount(admin).

--- a/generated/restaking/adminupdateextraaccountmetalistifneeded_test.go
+++ b/generated/restaking/adminupdateextraaccountmetalistifneeded_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_AdminUpdateExtraAccountMetaListIfNeeded(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("AdminUpdateExtraAccountMetaListIfNeeded"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(AdminUpdateExtraAccountMetaListIfNeeded)
+				params := new(AdminUpdateExtraAccountMetaListIfNeededInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(AdminUpdateExtraAccountMetaListIfNeeded)
+				got := new(AdminUpdateExtraAccountMetaListIfNeededInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/adminupdatefundaccountifneeded.go
+++ b/generated/restaking/adminupdatefundaccountifneeded.go
@@ -11,7 +11,7 @@ import (
 )
 
 // AdminUpdateFundAccountIfNeeded is the `admin_update_fund_account_if_needed` instruction.
-type AdminUpdateFundAccountIfNeeded struct {
+type AdminUpdateFundAccountIfNeededInstruction struct {
 	DesiredAccountSize *uint32 `bin:"optional"`
 
 	// [0] = [WRITE, SIGNER] payer
@@ -32,9 +32,9 @@ type AdminUpdateFundAccountIfNeeded struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewAdminUpdateFundAccountIfNeededInstructionBuilder creates a new `AdminUpdateFundAccountIfNeeded` instruction builder.
-func NewAdminUpdateFundAccountIfNeededInstructionBuilder() *AdminUpdateFundAccountIfNeeded {
-	nd := &AdminUpdateFundAccountIfNeeded{
+// NewAdminUpdateFundAccountIfNeededInstructionBuilder creates a new `AdminUpdateFundAccountIfNeededInstruction` instruction builder.
+func NewAdminUpdateFundAccountIfNeededInstructionBuilder() *AdminUpdateFundAccountIfNeededInstruction {
+	nd := &AdminUpdateFundAccountIfNeededInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 8),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["fragkamrANLvuZYQPcmPsCATQAabkqNGH6gxqqPG3aP"]).SIGNER()
@@ -43,62 +43,62 @@ func NewAdminUpdateFundAccountIfNeededInstructionBuilder() *AdminUpdateFundAccou
 }
 
 // SetDesiredAccountSize sets the "desired_account_size" parameter.
-func (inst *AdminUpdateFundAccountIfNeeded) SetDesiredAccountSize(desired_account_size uint32) *AdminUpdateFundAccountIfNeeded {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) SetDesiredAccountSize(desired_account_size uint32) *AdminUpdateFundAccountIfNeededInstruction {
 	inst.DesiredAccountSize = &desired_account_size
 	return inst
 }
 
 // SetPayerAccount sets the "payer" account.
-func (inst *AdminUpdateFundAccountIfNeeded) SetPayerAccount(payer ag_solanago.PublicKey) *AdminUpdateFundAccountIfNeeded {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) SetPayerAccount(payer ag_solanago.PublicKey) *AdminUpdateFundAccountIfNeededInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(payer).WRITE().SIGNER()
 	return inst
 }
 
 // GetPayerAccount gets the "payer" account.
-func (inst *AdminUpdateFundAccountIfNeeded) GetPayerAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) GetPayerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetAdminAccount sets the "admin" account.
-func (inst *AdminUpdateFundAccountIfNeeded) SetAdminAccount(admin ag_solanago.PublicKey) *AdminUpdateFundAccountIfNeeded {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) SetAdminAccount(admin ag_solanago.PublicKey) *AdminUpdateFundAccountIfNeededInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(admin).SIGNER()
 	return inst
 }
 
 // GetAdminAccount gets the "admin" account.
-func (inst *AdminUpdateFundAccountIfNeeded) GetAdminAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) GetAdminAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *AdminUpdateFundAccountIfNeeded) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *AdminUpdateFundAccountIfNeeded {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *AdminUpdateFundAccountIfNeededInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *AdminUpdateFundAccountIfNeeded) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *AdminUpdateFundAccountIfNeeded) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *AdminUpdateFundAccountIfNeeded {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *AdminUpdateFundAccountIfNeededInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *AdminUpdateFundAccountIfNeeded) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *AdminUpdateFundAccountIfNeeded) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *AdminUpdateFundAccountIfNeeded {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *AdminUpdateFundAccountIfNeededInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *AdminUpdateFundAccountIfNeeded) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -115,12 +115,12 @@ func (inst *AdminUpdateFundAccountIfNeeded) findFindFundAccountAddress(receiptTo
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *AdminUpdateFundAccountIfNeeded) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminUpdateFundAccountIfNeeded) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -129,12 +129,12 @@ func (inst *AdminUpdateFundAccountIfNeeded) MustFindFundAccountAddressWithBumpSe
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *AdminUpdateFundAccountIfNeeded) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *AdminUpdateFundAccountIfNeeded) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -143,17 +143,17 @@ func (inst *AdminUpdateFundAccountIfNeeded) MustFindFundAccountAddress(receiptTo
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *AdminUpdateFundAccountIfNeeded) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetFundReserveAccountAccount sets the "fund_reserve_account" account.
-func (inst *AdminUpdateFundAccountIfNeeded) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *AdminUpdateFundAccountIfNeeded {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *AdminUpdateFundAccountIfNeededInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(fundReserveAccount)
 	return inst
 }
 
-func (inst *AdminUpdateFundAccountIfNeeded) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_reserve
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x72), byte(0x65), byte(0x73), byte(0x65), byte(0x72), byte(0x76), byte(0x65)})
@@ -170,12 +170,12 @@ func (inst *AdminUpdateFundAccountIfNeeded) findFindFundReserveAccountAddress(re
 }
 
 // FindFundReserveAccountAddressWithBumpSeed calculates FundReserveAccount account address with given seeds and a known bump seed.
-func (inst *AdminUpdateFundAccountIfNeeded) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminUpdateFundAccountIfNeeded) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -184,12 +184,12 @@ func (inst *AdminUpdateFundAccountIfNeeded) MustFindFundReserveAccountAddressWit
 }
 
 // FindFundReserveAccountAddress finds FundReserveAccount account address with given seeds.
-func (inst *AdminUpdateFundAccountIfNeeded) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *AdminUpdateFundAccountIfNeeded) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -198,17 +198,17 @@ func (inst *AdminUpdateFundAccountIfNeeded) MustFindFundReserveAccountAddress(re
 }
 
 // GetFundReserveAccountAccount gets the "fund_reserve_account" account.
-func (inst *AdminUpdateFundAccountIfNeeded) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *AdminUpdateFundAccountIfNeeded) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminUpdateFundAccountIfNeeded {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminUpdateFundAccountIfNeededInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *AdminUpdateFundAccountIfNeeded) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -223,12 +223,12 @@ func (inst *AdminUpdateFundAccountIfNeeded) findFindEventAuthorityAddress(knownB
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *AdminUpdateFundAccountIfNeeded) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *AdminUpdateFundAccountIfNeeded) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -237,12 +237,12 @@ func (inst *AdminUpdateFundAccountIfNeeded) MustFindEventAuthorityAddressWithBum
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *AdminUpdateFundAccountIfNeeded) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *AdminUpdateFundAccountIfNeeded) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -251,22 +251,22 @@ func (inst *AdminUpdateFundAccountIfNeeded) MustFindEventAuthorityAddress() (pda
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *AdminUpdateFundAccountIfNeeded) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *AdminUpdateFundAccountIfNeeded) SetProgramAccount(program ag_solanago.PublicKey) *AdminUpdateFundAccountIfNeeded {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) SetProgramAccount(program ag_solanago.PublicKey) *AdminUpdateFundAccountIfNeededInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *AdminUpdateFundAccountIfNeeded) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
-func (inst AdminUpdateFundAccountIfNeeded) Build() *Instruction {
+func (inst AdminUpdateFundAccountIfNeededInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_AdminUpdateFundAccountIfNeeded,
@@ -276,14 +276,14 @@ func (inst AdminUpdateFundAccountIfNeeded) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst AdminUpdateFundAccountIfNeeded) ValidateAndBuild() (*Instruction, error) {
+func (inst AdminUpdateFundAccountIfNeededInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *AdminUpdateFundAccountIfNeeded) Validate() error {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 	}
@@ -318,7 +318,7 @@ func (inst *AdminUpdateFundAccountIfNeeded) Validate() error {
 	return nil
 }
 
-func (inst *AdminUpdateFundAccountIfNeeded) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *AdminUpdateFundAccountIfNeededInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -346,7 +346,7 @@ func (inst *AdminUpdateFundAccountIfNeeded) EncodeToTree(parent ag_treeout.Branc
 		})
 }
 
-func (obj AdminUpdateFundAccountIfNeeded) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj AdminUpdateFundAccountIfNeededInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `DesiredAccountSize` param (optional):
 	{
 		if obj.DesiredAccountSize == nil {
@@ -367,7 +367,7 @@ func (obj AdminUpdateFundAccountIfNeeded) MarshalWithEncoder(encoder *ag_binary.
 	}
 	return nil
 }
-func (obj *AdminUpdateFundAccountIfNeeded) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *AdminUpdateFundAccountIfNeededInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `DesiredAccountSize` (optional):
 	{
 		ok, err := decoder.ReadBool()
@@ -396,7 +396,7 @@ func NewAdminUpdateFundAccountIfNeededInstruction(
 	fundAccount ag_solanago.PublicKey,
 	fundReserveAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *AdminUpdateFundAccountIfNeeded {
+	program ag_solanago.PublicKey) *AdminUpdateFundAccountIfNeededInstruction {
 	return NewAdminUpdateFundAccountIfNeededInstructionBuilder().
 		SetDesiredAccountSize(desired_account_size).
 		SetPayerAccount(payer).

--- a/generated/restaking/adminupdatefundaccountifneeded_test.go
+++ b/generated/restaking/adminupdatefundaccountifneeded_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_AdminUpdateFundAccountIfNeeded(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("AdminUpdateFundAccountIfNeeded"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(AdminUpdateFundAccountIfNeeded)
+				params := new(AdminUpdateFundAccountIfNeededInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(AdminUpdateFundAccountIfNeeded)
+				got := new(AdminUpdateFundAccountIfNeededInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/adminupdatefundwrapaccountrewardaccountifneeded.go
+++ b/generated/restaking/adminupdatefundwrapaccountrewardaccountifneeded.go
@@ -11,7 +11,7 @@ import (
 )
 
 // AdminUpdateFundWrapAccountRewardAccountIfNeeded is the `admin_update_fund_wrap_account_reward_account_if_needed` instruction.
-type AdminUpdateFundWrapAccountRewardAccountIfNeeded struct {
+type AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction struct {
 	DesiredAccountSize *uint32 `bin:"optional"`
 
 	// [0] = [WRITE, SIGNER] payer
@@ -38,9 +38,9 @@ type AdminUpdateFundWrapAccountRewardAccountIfNeeded struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewAdminUpdateFundWrapAccountRewardAccountIfNeededInstructionBuilder creates a new `AdminUpdateFundWrapAccountRewardAccountIfNeeded` instruction builder.
-func NewAdminUpdateFundWrapAccountRewardAccountIfNeededInstructionBuilder() *AdminUpdateFundWrapAccountRewardAccountIfNeeded {
-	nd := &AdminUpdateFundWrapAccountRewardAccountIfNeeded{
+// NewAdminUpdateFundWrapAccountRewardAccountIfNeededInstructionBuilder creates a new `AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction` instruction builder.
+func NewAdminUpdateFundWrapAccountRewardAccountIfNeededInstructionBuilder() *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction {
+	nd := &AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 11),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["fragkamrANLvuZYQPcmPsCATQAabkqNGH6gxqqPG3aP"]).SIGNER()
@@ -49,40 +49,40 @@ func NewAdminUpdateFundWrapAccountRewardAccountIfNeededInstructionBuilder() *Adm
 }
 
 // SetDesiredAccountSize sets the "desired_account_size" parameter.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) SetDesiredAccountSize(desired_account_size uint32) *AdminUpdateFundWrapAccountRewardAccountIfNeeded {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) SetDesiredAccountSize(desired_account_size uint32) *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction {
 	inst.DesiredAccountSize = &desired_account_size
 	return inst
 }
 
 // SetPayerAccount sets the "payer" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) SetPayerAccount(payer ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeeded {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) SetPayerAccount(payer ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(payer).WRITE().SIGNER()
 	return inst
 }
 
 // GetPayerAccount gets the "payer" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) GetPayerAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) GetPayerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetAdminAccount sets the "admin" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) SetAdminAccount(admin ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeeded {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) SetAdminAccount(admin ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(admin).SIGNER()
 	return inst
 }
 
 // GetAdminAccount gets the "admin" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) GetAdminAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) GetAdminAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetFundWrapAccountAccount sets the "fund_wrap_account" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) SetFundWrapAccountAccount(fundWrapAccount ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeeded {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) SetFundWrapAccountAccount(fundWrapAccount ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(fundWrapAccount)
 	return inst
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) findFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) findFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_wrap
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x77), byte(0x72), byte(0x61), byte(0x70)})
@@ -99,12 +99,12 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) findFindFundWrapAcc
 }
 
 // FindFundWrapAccountAddressWithBumpSeed calculates FundWrapAccount account address with given seeds and a known bump seed.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) FindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) FindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundWrapAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) MustFindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -113,12 +113,12 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindFundWrapAcc
 }
 
 // FindFundWrapAccountAddress finds FundWrapAccount account address with given seeds.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) FindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) FindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundWrapAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) MustFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -127,39 +127,39 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindFundWrapAcc
 }
 
 // GetFundWrapAccountAccount gets the "fund_wrap_account" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) GetFundWrapAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) GetFundWrapAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeeded {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeeded {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetReceiptTokenWrapAccountAccount sets the "receipt_token_wrap_account" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) SetReceiptTokenWrapAccountAccount(receiptTokenWrapAccount ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeeded {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) SetReceiptTokenWrapAccountAccount(receiptTokenWrapAccount ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(receiptTokenWrapAccount)
 	return inst
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) findFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) findFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: fundWrapAccount
 	seeds = append(seeds, fundWrapAccount.Bytes())
@@ -180,12 +180,12 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) findFindReceiptToke
 }
 
 // FindReceiptTokenWrapAccountAddressWithBumpSeed calculates ReceiptTokenWrapAccount account address with given seeds and a known bump seed.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) FindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) FindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) MustFindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -194,12 +194,12 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindReceiptToke
 }
 
 // FindReceiptTokenWrapAccountAddress finds ReceiptTokenWrapAccount account address with given seeds.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) FindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) FindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenMint, 0)
 	return
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) MustFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -208,17 +208,17 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindReceiptToke
 }
 
 // GetReceiptTokenWrapAccountAccount gets the "receipt_token_wrap_account" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) GetReceiptTokenWrapAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) GetReceiptTokenWrapAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeeded {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(fundAccount)
 	return inst
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -235,12 +235,12 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) findFindFundAccount
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -249,12 +249,12 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindFundAccount
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -263,17 +263,17 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindFundAccount
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeeded {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -290,12 +290,12 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) findFindRewardAccou
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -304,12 +304,12 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindRewardAccou
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -318,17 +318,17 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindRewardAccou
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetFundWrapAccountRewardAccountAccount sets the "fund_wrap_account_reward_account" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) SetFundWrapAccountRewardAccountAccount(fundWrapAccountRewardAccount ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeeded {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) SetFundWrapAccountRewardAccountAccount(fundWrapAccountRewardAccount ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(fundWrapAccountRewardAccount).WRITE()
 	return inst
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) findFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) findFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -347,12 +347,12 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) findFindFundWrapAcc
 }
 
 // FindFundWrapAccountRewardAccountAddressWithBumpSeed calculates FundWrapAccountRewardAccount account address with given seeds and a known bump seed.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) FindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) FindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, bumpSeed)
 	return
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) MustFindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -361,12 +361,12 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindFundWrapAcc
 }
 
 // FindFundWrapAccountRewardAccountAddress finds FundWrapAccountRewardAccount account address with given seeds.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) FindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) FindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, 0)
 	return
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) MustFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, 0)
 	if err != nil {
 		panic(err)
@@ -375,17 +375,17 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindFundWrapAcc
 }
 
 // GetFundWrapAccountRewardAccountAccount gets the "fund_wrap_account_reward_account" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) GetFundWrapAccountRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) GetFundWrapAccountRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeeded {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[9] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -400,12 +400,12 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) findFindEventAuthor
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -414,12 +414,12 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindEventAuthor
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -428,22 +428,22 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) MustFindEventAuthor
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(9)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) SetProgramAccount(program ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeeded {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) SetProgramAccount(program ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[10] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(10)
 }
 
-func (inst AdminUpdateFundWrapAccountRewardAccountIfNeeded) Build() *Instruction {
+func (inst AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_AdminUpdateFundWrapAccountRewardAccountIfNeeded,
@@ -453,14 +453,14 @@ func (inst AdminUpdateFundWrapAccountRewardAccountIfNeeded) Build() *Instruction
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst AdminUpdateFundWrapAccountRewardAccountIfNeeded) ValidateAndBuild() (*Instruction, error) {
+func (inst AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) Validate() error {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 	}
@@ -504,7 +504,7 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) Validate() error {
 	return nil
 }
 
-func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -535,7 +535,7 @@ func (inst *AdminUpdateFundWrapAccountRewardAccountIfNeeded) EncodeToTree(parent
 		})
 }
 
-func (obj AdminUpdateFundWrapAccountRewardAccountIfNeeded) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `DesiredAccountSize` param (optional):
 	{
 		if obj.DesiredAccountSize == nil {
@@ -556,7 +556,7 @@ func (obj AdminUpdateFundWrapAccountRewardAccountIfNeeded) MarshalWithEncoder(en
 	}
 	return nil
 }
-func (obj *AdminUpdateFundWrapAccountRewardAccountIfNeeded) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `DesiredAccountSize` (optional):
 	{
 		ok, err := decoder.ReadBool()
@@ -588,7 +588,7 @@ func NewAdminUpdateFundWrapAccountRewardAccountIfNeededInstruction(
 	rewardAccount ag_solanago.PublicKey,
 	fundWrapAccountRewardAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeeded {
+	program ag_solanago.PublicKey) *AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction {
 	return NewAdminUpdateFundWrapAccountRewardAccountIfNeededInstructionBuilder().
 		SetDesiredAccountSize(desired_account_size).
 		SetPayerAccount(payer).

--- a/generated/restaking/adminupdatefundwrapaccountrewardaccountifneeded_test.go
+++ b/generated/restaking/adminupdatefundwrapaccountrewardaccountifneeded_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_AdminUpdateFundWrapAccountRewardAccountIfNeeded(t *testing
 	for i := 0; i < 1; i++ {
 		t.Run("AdminUpdateFundWrapAccountRewardAccountIfNeeded"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(AdminUpdateFundWrapAccountRewardAccountIfNeeded)
+				params := new(AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(AdminUpdateFundWrapAccountRewardAccountIfNeeded)
+				got := new(AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/adminupdatenormalizedtokenpoolaccountifneeded.go
+++ b/generated/restaking/adminupdatenormalizedtokenpoolaccountifneeded.go
@@ -11,7 +11,7 @@ import (
 )
 
 // AdminUpdateNormalizedTokenPoolAccountIfNeeded is the `admin_update_normalized_token_pool_account_if_needed` instruction.
-type AdminUpdateNormalizedTokenPoolAccountIfNeeded struct {
+type AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction struct {
 
 	// [0] = [WRITE, SIGNER] payer
 	//
@@ -31,9 +31,9 @@ type AdminUpdateNormalizedTokenPoolAccountIfNeeded struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewAdminUpdateNormalizedTokenPoolAccountIfNeededInstructionBuilder creates a new `AdminUpdateNormalizedTokenPoolAccountIfNeeded` instruction builder.
-func NewAdminUpdateNormalizedTokenPoolAccountIfNeededInstructionBuilder() *AdminUpdateNormalizedTokenPoolAccountIfNeeded {
-	nd := &AdminUpdateNormalizedTokenPoolAccountIfNeeded{
+// NewAdminUpdateNormalizedTokenPoolAccountIfNeededInstructionBuilder creates a new `AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction` instruction builder.
+func NewAdminUpdateNormalizedTokenPoolAccountIfNeededInstructionBuilder() *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction {
+	nd := &AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 8),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["fragkamrANLvuZYQPcmPsCATQAabkqNGH6gxqqPG3aP"]).SIGNER()
@@ -43,67 +43,67 @@ func NewAdminUpdateNormalizedTokenPoolAccountIfNeededInstructionBuilder() *Admin
 }
 
 // SetPayerAccount sets the "payer" account.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) SetPayerAccount(payer ag_solanago.PublicKey) *AdminUpdateNormalizedTokenPoolAccountIfNeeded {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) SetPayerAccount(payer ag_solanago.PublicKey) *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(payer).WRITE().SIGNER()
 	return inst
 }
 
 // GetPayerAccount gets the "payer" account.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) GetPayerAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) GetPayerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetAdminAccount sets the "admin" account.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) SetAdminAccount(admin ag_solanago.PublicKey) *AdminUpdateNormalizedTokenPoolAccountIfNeeded {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) SetAdminAccount(admin ag_solanago.PublicKey) *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(admin).SIGNER()
 	return inst
 }
 
 // GetAdminAccount gets the "admin" account.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) GetAdminAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) GetAdminAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *AdminUpdateNormalizedTokenPoolAccountIfNeeded {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetNormalizedTokenProgramAccount sets the "normalized_token_program" account.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) SetNormalizedTokenProgramAccount(normalizedTokenProgram ag_solanago.PublicKey) *AdminUpdateNormalizedTokenPoolAccountIfNeeded {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) SetNormalizedTokenProgramAccount(normalizedTokenProgram ag_solanago.PublicKey) *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(normalizedTokenProgram)
 	return inst
 }
 
 // GetNormalizedTokenProgramAccount gets the "normalized_token_program" account.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) GetNormalizedTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) GetNormalizedTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetNormalizedTokenMintAccount sets the "normalized_token_mint" account.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) SetNormalizedTokenMintAccount(normalizedTokenMint ag_solanago.PublicKey) *AdminUpdateNormalizedTokenPoolAccountIfNeeded {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) SetNormalizedTokenMintAccount(normalizedTokenMint ag_solanago.PublicKey) *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(normalizedTokenMint)
 	return inst
 }
 
 // GetNormalizedTokenMintAccount gets the "normalized_token_mint" account.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) GetNormalizedTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) GetNormalizedTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetNormalizedTokenPoolAccountAccount sets the "normalized_token_pool_account" account.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) SetNormalizedTokenPoolAccountAccount(normalizedTokenPoolAccount ag_solanago.PublicKey) *AdminUpdateNormalizedTokenPoolAccountIfNeeded {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) SetNormalizedTokenPoolAccountAccount(normalizedTokenPoolAccount ag_solanago.PublicKey) *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(normalizedTokenPoolAccount).WRITE()
 	return inst
 }
 
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: nt_pool
 	seeds = append(seeds, []byte{byte(0x6e), byte(0x74), byte(0x5f), byte(0x70), byte(0x6f), byte(0x6f), byte(0x6c)})
@@ -120,12 +120,12 @@ func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) findFindNormalizedTok
 }
 
 // FindNormalizedTokenPoolAccountAddressWithBumpSeed calculates NormalizedTokenPoolAccount account address with given seeds and a known bump seed.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) FindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) FindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) MustFindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) MustFindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -134,12 +134,12 @@ func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) MustFindNormalizedTok
 }
 
 // FindNormalizedTokenPoolAccountAddress finds NormalizedTokenPoolAccount account address with given seeds.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) FindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) FindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, 0)
 	return
 }
 
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) MustFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) MustFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -148,17 +148,17 @@ func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) MustFindNormalizedTok
 }
 
 // GetNormalizedTokenPoolAccountAccount gets the "normalized_token_pool_account" account.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) GetNormalizedTokenPoolAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) GetNormalizedTokenPoolAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminUpdateNormalizedTokenPoolAccountIfNeeded {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -173,12 +173,12 @@ func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) findFindEventAuthorit
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -187,12 +187,12 @@ func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) MustFindEventAuthorit
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -201,22 +201,22 @@ func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) MustFindEventAuthorit
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) SetProgramAccount(program ag_solanago.PublicKey) *AdminUpdateNormalizedTokenPoolAccountIfNeeded {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) SetProgramAccount(program ag_solanago.PublicKey) *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
-func (inst AdminUpdateNormalizedTokenPoolAccountIfNeeded) Build() *Instruction {
+func (inst AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_AdminUpdateNormalizedTokenPoolAccountIfNeeded,
@@ -226,14 +226,14 @@ func (inst AdminUpdateNormalizedTokenPoolAccountIfNeeded) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst AdminUpdateNormalizedTokenPoolAccountIfNeeded) ValidateAndBuild() (*Instruction, error) {
+func (inst AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) Validate() error {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -264,7 +264,7 @@ func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) Validate() error {
 	return nil
 }
 
-func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -290,10 +290,10 @@ func (inst *AdminUpdateNormalizedTokenPoolAccountIfNeeded) EncodeToTree(parent a
 		})
 }
 
-func (obj AdminUpdateNormalizedTokenPoolAccountIfNeeded) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *AdminUpdateNormalizedTokenPoolAccountIfNeeded) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -307,7 +307,7 @@ func NewAdminUpdateNormalizedTokenPoolAccountIfNeededInstruction(
 	normalizedTokenMint ag_solanago.PublicKey,
 	normalizedTokenPoolAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *AdminUpdateNormalizedTokenPoolAccountIfNeeded {
+	program ag_solanago.PublicKey) *AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction {
 	return NewAdminUpdateNormalizedTokenPoolAccountIfNeededInstructionBuilder().
 		SetPayerAccount(payer).
 		SetAdminAccount(admin).

--- a/generated/restaking/adminupdatenormalizedtokenpoolaccountifneeded_test.go
+++ b/generated/restaking/adminupdatenormalizedtokenpoolaccountifneeded_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_AdminUpdateNormalizedTokenPoolAccountIfNeeded(t *testing.T
 	for i := 0; i < 1; i++ {
 		t.Run("AdminUpdateNormalizedTokenPoolAccountIfNeeded"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(AdminUpdateNormalizedTokenPoolAccountIfNeeded)
+				params := new(AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(AdminUpdateNormalizedTokenPoolAccountIfNeeded)
+				got := new(AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/adminupdaterewardaccountifneeded.go
+++ b/generated/restaking/adminupdaterewardaccountifneeded.go
@@ -11,7 +11,7 @@ import (
 )
 
 // AdminUpdateRewardAccountIfNeeded is the `admin_update_reward_account_if_needed` instruction.
-type AdminUpdateRewardAccountIfNeeded struct {
+type AdminUpdateRewardAccountIfNeededInstruction struct {
 	DesiredAccountSize *uint32 `bin:"optional"`
 
 	// [0] = [WRITE, SIGNER] payer
@@ -30,9 +30,9 @@ type AdminUpdateRewardAccountIfNeeded struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewAdminUpdateRewardAccountIfNeededInstructionBuilder creates a new `AdminUpdateRewardAccountIfNeeded` instruction builder.
-func NewAdminUpdateRewardAccountIfNeededInstructionBuilder() *AdminUpdateRewardAccountIfNeeded {
-	nd := &AdminUpdateRewardAccountIfNeeded{
+// NewAdminUpdateRewardAccountIfNeededInstructionBuilder creates a new `AdminUpdateRewardAccountIfNeededInstruction` instruction builder.
+func NewAdminUpdateRewardAccountIfNeededInstructionBuilder() *AdminUpdateRewardAccountIfNeededInstruction {
+	nd := &AdminUpdateRewardAccountIfNeededInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 7),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["fragkamrANLvuZYQPcmPsCATQAabkqNGH6gxqqPG3aP"]).SIGNER()
@@ -41,62 +41,62 @@ func NewAdminUpdateRewardAccountIfNeededInstructionBuilder() *AdminUpdateRewardA
 }
 
 // SetDesiredAccountSize sets the "desired_account_size" parameter.
-func (inst *AdminUpdateRewardAccountIfNeeded) SetDesiredAccountSize(desired_account_size uint32) *AdminUpdateRewardAccountIfNeeded {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) SetDesiredAccountSize(desired_account_size uint32) *AdminUpdateRewardAccountIfNeededInstruction {
 	inst.DesiredAccountSize = &desired_account_size
 	return inst
 }
 
 // SetPayerAccount sets the "payer" account.
-func (inst *AdminUpdateRewardAccountIfNeeded) SetPayerAccount(payer ag_solanago.PublicKey) *AdminUpdateRewardAccountIfNeeded {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) SetPayerAccount(payer ag_solanago.PublicKey) *AdminUpdateRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(payer).WRITE().SIGNER()
 	return inst
 }
 
 // GetPayerAccount gets the "payer" account.
-func (inst *AdminUpdateRewardAccountIfNeeded) GetPayerAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) GetPayerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetAdminAccount sets the "admin" account.
-func (inst *AdminUpdateRewardAccountIfNeeded) SetAdminAccount(admin ag_solanago.PublicKey) *AdminUpdateRewardAccountIfNeeded {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) SetAdminAccount(admin ag_solanago.PublicKey) *AdminUpdateRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(admin).SIGNER()
 	return inst
 }
 
 // GetAdminAccount gets the "admin" account.
-func (inst *AdminUpdateRewardAccountIfNeeded) GetAdminAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) GetAdminAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *AdminUpdateRewardAccountIfNeeded) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *AdminUpdateRewardAccountIfNeeded {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *AdminUpdateRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *AdminUpdateRewardAccountIfNeeded) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *AdminUpdateRewardAccountIfNeeded) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *AdminUpdateRewardAccountIfNeeded {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *AdminUpdateRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *AdminUpdateRewardAccountIfNeeded) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *AdminUpdateRewardAccountIfNeeded) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *AdminUpdateRewardAccountIfNeeded {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *AdminUpdateRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *AdminUpdateRewardAccountIfNeeded) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -113,12 +113,12 @@ func (inst *AdminUpdateRewardAccountIfNeeded) findFindRewardAccountAddress(recei
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *AdminUpdateRewardAccountIfNeeded) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *AdminUpdateRewardAccountIfNeeded) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -127,12 +127,12 @@ func (inst *AdminUpdateRewardAccountIfNeeded) MustFindRewardAccountAddressWithBu
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *AdminUpdateRewardAccountIfNeeded) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *AdminUpdateRewardAccountIfNeeded) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -141,17 +141,17 @@ func (inst *AdminUpdateRewardAccountIfNeeded) MustFindRewardAccountAddress(recei
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *AdminUpdateRewardAccountIfNeeded) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *AdminUpdateRewardAccountIfNeeded) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminUpdateRewardAccountIfNeeded {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *AdminUpdateRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *AdminUpdateRewardAccountIfNeeded) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -166,12 +166,12 @@ func (inst *AdminUpdateRewardAccountIfNeeded) findFindEventAuthorityAddress(know
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *AdminUpdateRewardAccountIfNeeded) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *AdminUpdateRewardAccountIfNeeded) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -180,12 +180,12 @@ func (inst *AdminUpdateRewardAccountIfNeeded) MustFindEventAuthorityAddressWithB
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *AdminUpdateRewardAccountIfNeeded) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *AdminUpdateRewardAccountIfNeeded) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -194,22 +194,22 @@ func (inst *AdminUpdateRewardAccountIfNeeded) MustFindEventAuthorityAddress() (p
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *AdminUpdateRewardAccountIfNeeded) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *AdminUpdateRewardAccountIfNeeded) SetProgramAccount(program ag_solanago.PublicKey) *AdminUpdateRewardAccountIfNeeded {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) SetProgramAccount(program ag_solanago.PublicKey) *AdminUpdateRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *AdminUpdateRewardAccountIfNeeded) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
-func (inst AdminUpdateRewardAccountIfNeeded) Build() *Instruction {
+func (inst AdminUpdateRewardAccountIfNeededInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_AdminUpdateRewardAccountIfNeeded,
@@ -219,14 +219,14 @@ func (inst AdminUpdateRewardAccountIfNeeded) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst AdminUpdateRewardAccountIfNeeded) ValidateAndBuild() (*Instruction, error) {
+func (inst AdminUpdateRewardAccountIfNeededInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *AdminUpdateRewardAccountIfNeeded) Validate() error {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 	}
@@ -258,7 +258,7 @@ func (inst *AdminUpdateRewardAccountIfNeeded) Validate() error {
 	return nil
 }
 
-func (inst *AdminUpdateRewardAccountIfNeeded) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *AdminUpdateRewardAccountIfNeededInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -285,7 +285,7 @@ func (inst *AdminUpdateRewardAccountIfNeeded) EncodeToTree(parent ag_treeout.Bra
 		})
 }
 
-func (obj AdminUpdateRewardAccountIfNeeded) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj AdminUpdateRewardAccountIfNeededInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `DesiredAccountSize` param (optional):
 	{
 		if obj.DesiredAccountSize == nil {
@@ -306,7 +306,7 @@ func (obj AdminUpdateRewardAccountIfNeeded) MarshalWithEncoder(encoder *ag_binar
 	}
 	return nil
 }
-func (obj *AdminUpdateRewardAccountIfNeeded) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *AdminUpdateRewardAccountIfNeededInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `DesiredAccountSize` (optional):
 	{
 		ok, err := decoder.ReadBool()
@@ -334,7 +334,7 @@ func NewAdminUpdateRewardAccountIfNeededInstruction(
 	receiptTokenMint ag_solanago.PublicKey,
 	rewardAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *AdminUpdateRewardAccountIfNeeded {
+	program ag_solanago.PublicKey) *AdminUpdateRewardAccountIfNeededInstruction {
 	return NewAdminUpdateRewardAccountIfNeededInstructionBuilder().
 		SetDesiredAccountSize(desired_account_size).
 		SetPayerAccount(payer).

--- a/generated/restaking/adminupdaterewardaccountifneeded_test.go
+++ b/generated/restaking/adminupdaterewardaccountifneeded_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_AdminUpdateRewardAccountIfNeeded(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("AdminUpdateRewardAccountIfNeeded"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(AdminUpdateRewardAccountIfNeeded)
+				params := new(AdminUpdateRewardAccountIfNeededInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(AdminUpdateRewardAccountIfNeeded)
+				got := new(AdminUpdateRewardAccountIfNeededInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/fundmanageraddnormalizedtokenpoolsupportedtoken.go
+++ b/generated/restaking/fundmanageraddnormalizedtokenpoolsupportedtoken.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FundManagerAddNormalizedTokenPoolSupportedToken is the `fund_manager_add_normalized_token_pool_supported_token` instruction.
-type FundManagerAddNormalizedTokenPoolSupportedToken struct {
+type FundManagerAddNormalizedTokenPoolSupportedTokenInstruction struct {
 	PricingSource *TokenPricingSource
 
 	// [0] = [SIGNER] fund_manager
@@ -34,9 +34,9 @@ type FundManagerAddNormalizedTokenPoolSupportedToken struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewFundManagerAddNormalizedTokenPoolSupportedTokenInstructionBuilder creates a new `FundManagerAddNormalizedTokenPoolSupportedToken` instruction builder.
-func NewFundManagerAddNormalizedTokenPoolSupportedTokenInstructionBuilder() *FundManagerAddNormalizedTokenPoolSupportedToken {
-	nd := &FundManagerAddNormalizedTokenPoolSupportedToken{
+// NewFundManagerAddNormalizedTokenPoolSupportedTokenInstructionBuilder creates a new `FundManagerAddNormalizedTokenPoolSupportedTokenInstruction` instruction builder.
+func NewFundManagerAddNormalizedTokenPoolSupportedTokenInstructionBuilder() *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction {
+	nd := &FundManagerAddNormalizedTokenPoolSupportedTokenInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 9),
 	}
 	nd.AccountMetaSlice[0] = ag_solanago.Meta(Addresses["5UpLTLA7Wjqp7qdfjuTtPcUw3aVtbqFA5Mgm34mxPNg2"]).SIGNER()
@@ -45,40 +45,40 @@ func NewFundManagerAddNormalizedTokenPoolSupportedTokenInstructionBuilder() *Fun
 }
 
 // SetPricingSource sets the "pricing_source" parameter.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) SetPricingSource(pricing_source TokenPricingSource) *FundManagerAddNormalizedTokenPoolSupportedToken {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) SetPricingSource(pricing_source TokenPricingSource) *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction {
 	inst.PricingSource = &pricing_source
 	return inst
 }
 
 // SetFundManagerAccount sets the "fund_manager" account.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedToken {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(fundManager).SIGNER()
 	return inst
 }
 
 // GetFundManagerAccount gets the "fund_manager" account.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) GetFundManagerAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) GetFundManagerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetNormalizedTokenMintAccount sets the "normalized_token_mint" account.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) SetNormalizedTokenMintAccount(normalizedTokenMint ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedToken {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) SetNormalizedTokenMintAccount(normalizedTokenMint ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(normalizedTokenMint)
 	return inst
 }
 
 // GetNormalizedTokenMintAccount gets the "normalized_token_mint" account.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) GetNormalizedTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) GetNormalizedTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetNormalizedTokenPoolAccountAccount sets the "normalized_token_pool_account" account.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) SetNormalizedTokenPoolAccountAccount(normalizedTokenPoolAccount ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedToken {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) SetNormalizedTokenPoolAccountAccount(normalizedTokenPoolAccount ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(normalizedTokenPoolAccount).WRITE()
 	return inst
 }
 
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: nt_pool
 	seeds = append(seeds, []byte{byte(0x6e), byte(0x74), byte(0x5f), byte(0x70), byte(0x6f), byte(0x6f), byte(0x6c)})
@@ -95,12 +95,12 @@ func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) findFindNormalizedT
 }
 
 // FindNormalizedTokenPoolAccountAddressWithBumpSeed calculates NormalizedTokenPoolAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) FindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) FindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) MustFindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) MustFindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -109,12 +109,12 @@ func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) MustFindNormalizedT
 }
 
 // FindNormalizedTokenPoolAccountAddress finds NormalizedTokenPoolAccount account address with given seeds.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) FindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) FindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) MustFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) MustFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -123,50 +123,50 @@ func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) MustFindNormalizedT
 }
 
 // GetNormalizedTokenPoolAccountAccount gets the "normalized_token_pool_account" account.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) GetNormalizedTokenPoolAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) GetNormalizedTokenPoolAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetNormalizedTokenProgramAccount sets the "normalized_token_program" account.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) SetNormalizedTokenProgramAccount(normalizedTokenProgram ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedToken {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) SetNormalizedTokenProgramAccount(normalizedTokenProgram ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(normalizedTokenProgram)
 	return inst
 }
 
 // GetNormalizedTokenProgramAccount gets the "normalized_token_program" account.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) GetNormalizedTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) GetNormalizedTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetSupportedTokenMintAccount sets the "supported_token_mint" account.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) SetSupportedTokenMintAccount(supportedTokenMint ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedToken {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) SetSupportedTokenMintAccount(supportedTokenMint ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(supportedTokenMint)
 	return inst
 }
 
 // GetSupportedTokenMintAccount gets the "supported_token_mint" account.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) GetSupportedTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) GetSupportedTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetSupportedTokenProgramAccount sets the "supported_token_program" account.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) SetSupportedTokenProgramAccount(supportedTokenProgram ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedToken {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) SetSupportedTokenProgramAccount(supportedTokenProgram ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(supportedTokenProgram)
 	return inst
 }
 
 // GetSupportedTokenProgramAccount gets the "supported_token_program" account.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) GetSupportedTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) GetSupportedTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetNormalizedTokenPoolSupportedTokenAccountAccount sets the "normalized_token_pool_supported_token_account" account.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) SetNormalizedTokenPoolSupportedTokenAccountAccount(normalizedTokenPoolSupportedTokenAccount ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedToken {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) SetNormalizedTokenPoolSupportedTokenAccountAccount(normalizedTokenPoolSupportedTokenAccount ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(normalizedTokenPoolSupportedTokenAccount)
 	return inst
 }
 
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) findFindNormalizedTokenPoolSupportedTokenAccountAddress(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) findFindNormalizedTokenPoolSupportedTokenAccountAddress(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: normalizedTokenPoolAccount
 	seeds = append(seeds, normalizedTokenPoolAccount.Bytes())
@@ -187,12 +187,12 @@ func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) findFindNormalizedT
 }
 
 // FindNormalizedTokenPoolSupportedTokenAccountAddressWithBumpSeed calculates NormalizedTokenPoolSupportedTokenAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) FindNormalizedTokenPoolSupportedTokenAccountAddressWithBumpSeed(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) FindNormalizedTokenPoolSupportedTokenAccountAddressWithBumpSeed(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindNormalizedTokenPoolSupportedTokenAccountAddress(normalizedTokenPoolAccount, supportedTokenProgram, supportedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) MustFindNormalizedTokenPoolSupportedTokenAccountAddressWithBumpSeed(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) MustFindNormalizedTokenPoolSupportedTokenAccountAddressWithBumpSeed(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindNormalizedTokenPoolSupportedTokenAccountAddress(normalizedTokenPoolAccount, supportedTokenProgram, supportedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -201,12 +201,12 @@ func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) MustFindNormalizedT
 }
 
 // FindNormalizedTokenPoolSupportedTokenAccountAddress finds NormalizedTokenPoolSupportedTokenAccount account address with given seeds.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) FindNormalizedTokenPoolSupportedTokenAccountAddress(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) FindNormalizedTokenPoolSupportedTokenAccountAddress(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindNormalizedTokenPoolSupportedTokenAccountAddress(normalizedTokenPoolAccount, supportedTokenProgram, supportedTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) MustFindNormalizedTokenPoolSupportedTokenAccountAddress(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) MustFindNormalizedTokenPoolSupportedTokenAccountAddress(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindNormalizedTokenPoolSupportedTokenAccountAddress(normalizedTokenPoolAccount, supportedTokenProgram, supportedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -215,17 +215,17 @@ func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) MustFindNormalizedT
 }
 
 // GetNormalizedTokenPoolSupportedTokenAccountAccount gets the "normalized_token_pool_supported_token_account" account.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) GetNormalizedTokenPoolSupportedTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) GetNormalizedTokenPoolSupportedTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedToken {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -240,12 +240,12 @@ func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) findFindEventAuthor
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -254,12 +254,12 @@ func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) MustFindEventAuthor
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -268,22 +268,22 @@ func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) MustFindEventAuthor
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedToken {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
-func (inst FundManagerAddNormalizedTokenPoolSupportedToken) Build() *Instruction {
+func (inst FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_FundManagerAddNormalizedTokenPoolSupportedToken,
@@ -293,14 +293,14 @@ func (inst FundManagerAddNormalizedTokenPoolSupportedToken) Build() *Instruction
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst FundManagerAddNormalizedTokenPoolSupportedToken) ValidateAndBuild() (*Instruction, error) {
+func (inst FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) Validate() error {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.PricingSource == nil {
@@ -341,7 +341,7 @@ func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) Validate() error {
 	return nil
 }
 
-func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -370,7 +370,7 @@ func (inst *FundManagerAddNormalizedTokenPoolSupportedToken) EncodeToTree(parent
 		})
 }
 
-func (obj FundManagerAddNormalizedTokenPoolSupportedToken) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `PricingSource` param:
 	err = encoder.Encode(obj.PricingSource)
 	if err != nil {
@@ -378,7 +378,7 @@ func (obj FundManagerAddNormalizedTokenPoolSupportedToken) MarshalWithEncoder(en
 	}
 	return nil
 }
-func (obj *FundManagerAddNormalizedTokenPoolSupportedToken) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `PricingSource`:
 	err = decoder.Decode(&obj.PricingSource)
 	if err != nil {
@@ -400,7 +400,7 @@ func NewFundManagerAddNormalizedTokenPoolSupportedTokenInstruction(
 	supportedTokenProgram ag_solanago.PublicKey,
 	normalizedTokenPoolSupportedTokenAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedToken {
+	program ag_solanago.PublicKey) *FundManagerAddNormalizedTokenPoolSupportedTokenInstruction {
 	return NewFundManagerAddNormalizedTokenPoolSupportedTokenInstructionBuilder().
 		SetPricingSource(pricing_source).
 		SetFundManagerAccount(fundManager).

--- a/generated/restaking/fundmanageraddnormalizedtokenpoolsupportedtoken_test.go
+++ b/generated/restaking/fundmanageraddnormalizedtokenpoolsupportedtoken_test.go
@@ -18,7 +18,7 @@ func TestEncodeDecode_FundManagerAddNormalizedTokenPoolSupportedToken(t *testing
 			{
 				{
 					{
-						params := new(FundManagerAddNormalizedTokenPoolSupportedToken)
+						params := new(FundManagerAddNormalizedTokenPoolSupportedTokenInstruction)
 						fu.Fuzz(params)
 						params.AccountMetaSlice = nil
 						tmp := new(TokenPricingSourceSPLStakePoolTuple)
@@ -27,7 +27,7 @@ func TestEncodeDecode_FundManagerAddNormalizedTokenPoolSupportedToken(t *testing
 						buf := new(bytes.Buffer)
 						err := encodeT(*params, buf)
 						ag_require.NoError(t, err)
-						got := new(FundManagerAddNormalizedTokenPoolSupportedToken)
+						got := new(FundManagerAddNormalizedTokenPoolSupportedTokenInstruction)
 						err = decodeT(got, buf.Bytes())
 						got.AccountMetaSlice = nil
 						ag_require.NoError(t, err)
@@ -38,7 +38,7 @@ func TestEncodeDecode_FundManagerAddNormalizedTokenPoolSupportedToken(t *testing
 						ag_require.Equal(t, params, got)
 					}
 					{
-						params := new(FundManagerAddNormalizedTokenPoolSupportedToken)
+						params := new(FundManagerAddNormalizedTokenPoolSupportedTokenInstruction)
 						fu.Fuzz(params)
 						params.AccountMetaSlice = nil
 						tmp := new(TokenPricingSourceMarinadeStakePoolTuple)
@@ -47,7 +47,7 @@ func TestEncodeDecode_FundManagerAddNormalizedTokenPoolSupportedToken(t *testing
 						buf := new(bytes.Buffer)
 						err := encodeT(*params, buf)
 						ag_require.NoError(t, err)
-						got := new(FundManagerAddNormalizedTokenPoolSupportedToken)
+						got := new(FundManagerAddNormalizedTokenPoolSupportedTokenInstruction)
 						err = decodeT(got, buf.Bytes())
 						got.AccountMetaSlice = nil
 						ag_require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestEncodeDecode_FundManagerAddNormalizedTokenPoolSupportedToken(t *testing
 						ag_require.Equal(t, params, got)
 					}
 					{
-						params := new(FundManagerAddNormalizedTokenPoolSupportedToken)
+						params := new(FundManagerAddNormalizedTokenPoolSupportedTokenInstruction)
 						fu.Fuzz(params)
 						params.AccountMetaSlice = nil
 						tmp := new(TokenPricingSourceJitoRestakingVaultTuple)
@@ -67,7 +67,7 @@ func TestEncodeDecode_FundManagerAddNormalizedTokenPoolSupportedToken(t *testing
 						buf := new(bytes.Buffer)
 						err := encodeT(*params, buf)
 						ag_require.NoError(t, err)
-						got := new(FundManagerAddNormalizedTokenPoolSupportedToken)
+						got := new(FundManagerAddNormalizedTokenPoolSupportedTokenInstruction)
 						err = decodeT(got, buf.Bytes())
 						got.AccountMetaSlice = nil
 						ag_require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestEncodeDecode_FundManagerAddNormalizedTokenPoolSupportedToken(t *testing
 						ag_require.Equal(t, params, got)
 					}
 					{
-						params := new(FundManagerAddNormalizedTokenPoolSupportedToken)
+						params := new(FundManagerAddNormalizedTokenPoolSupportedTokenInstruction)
 						fu.Fuzz(params)
 						params.AccountMetaSlice = nil
 						tmp := new(TokenPricingSourceFragmetricNormalizedTokenPoolTuple)
@@ -87,7 +87,7 @@ func TestEncodeDecode_FundManagerAddNormalizedTokenPoolSupportedToken(t *testing
 						buf := new(bytes.Buffer)
 						err := encodeT(*params, buf)
 						ag_require.NoError(t, err)
-						got := new(FundManagerAddNormalizedTokenPoolSupportedToken)
+						got := new(FundManagerAddNormalizedTokenPoolSupportedTokenInstruction)
 						err = decodeT(got, buf.Bytes())
 						got.AccountMetaSlice = nil
 						ag_require.NoError(t, err)
@@ -98,7 +98,7 @@ func TestEncodeDecode_FundManagerAddNormalizedTokenPoolSupportedToken(t *testing
 						ag_require.Equal(t, params, got)
 					}
 					{
-						params := new(FundManagerAddNormalizedTokenPoolSupportedToken)
+						params := new(FundManagerAddNormalizedTokenPoolSupportedTokenInstruction)
 						fu.Fuzz(params)
 						params.AccountMetaSlice = nil
 						tmp := new(TokenPricingSourceFragmetricRestakingFundTuple)
@@ -107,7 +107,7 @@ func TestEncodeDecode_FundManagerAddNormalizedTokenPoolSupportedToken(t *testing
 						buf := new(bytes.Buffer)
 						err := encodeT(*params, buf)
 						ag_require.NoError(t, err)
-						got := new(FundManagerAddNormalizedTokenPoolSupportedToken)
+						got := new(FundManagerAddNormalizedTokenPoolSupportedTokenInstruction)
 						err = decodeT(got, buf.Bytes())
 						got.AccountMetaSlice = nil
 						ag_require.NoError(t, err)
@@ -118,7 +118,7 @@ func TestEncodeDecode_FundManagerAddNormalizedTokenPoolSupportedToken(t *testing
 						ag_require.Equal(t, params, got)
 					}
 					{
-						params := new(FundManagerAddNormalizedTokenPoolSupportedToken)
+						params := new(FundManagerAddNormalizedTokenPoolSupportedTokenInstruction)
 						fu.Fuzz(params)
 						params.AccountMetaSlice = nil
 						tmp := new(TokenPricingSourceOrcaDEXLiquidityPoolTuple)
@@ -127,7 +127,7 @@ func TestEncodeDecode_FundManagerAddNormalizedTokenPoolSupportedToken(t *testing
 						buf := new(bytes.Buffer)
 						err := encodeT(*params, buf)
 						ag_require.NoError(t, err)
-						got := new(FundManagerAddNormalizedTokenPoolSupportedToken)
+						got := new(FundManagerAddNormalizedTokenPoolSupportedTokenInstruction)
 						err = decodeT(got, buf.Bytes())
 						got.AccountMetaSlice = nil
 						ag_require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestEncodeDecode_FundManagerAddNormalizedTokenPoolSupportedToken(t *testing
 						ag_require.Equal(t, params, got)
 					}
 					{
-						params := new(FundManagerAddNormalizedTokenPoolSupportedToken)
+						params := new(FundManagerAddNormalizedTokenPoolSupportedTokenInstruction)
 						fu.Fuzz(params)
 						params.AccountMetaSlice = nil
 						tmp := new(TokenPricingSourceSanctumSingleValidatorSPLStakePoolTuple)
@@ -147,7 +147,7 @@ func TestEncodeDecode_FundManagerAddNormalizedTokenPoolSupportedToken(t *testing
 						buf := new(bytes.Buffer)
 						err := encodeT(*params, buf)
 						ag_require.NoError(t, err)
-						got := new(FundManagerAddNormalizedTokenPoolSupportedToken)
+						got := new(FundManagerAddNormalizedTokenPoolSupportedTokenInstruction)
 						err = decodeT(got, buf.Bytes())
 						got.AccountMetaSlice = nil
 						ag_require.NoError(t, err)

--- a/generated/restaking/fundmanageraddrestakingvaultcompoundingrewardtoken.go
+++ b/generated/restaking/fundmanageraddrestakingvaultcompoundingrewardtoken.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FundManagerAddRestakingVaultCompoundingRewardToken is the `fund_manager_add_restaking_vault_compounding_reward_token` instruction.
-type FundManagerAddRestakingVaultCompoundingRewardToken struct {
+type FundManagerAddRestakingVaultCompoundingRewardTokenInstruction struct {
 	Vault                      *ag_solanago.PublicKey
 	CompoundingRewardTokenMint *ag_solanago.PublicKey
 
@@ -27,9 +27,9 @@ type FundManagerAddRestakingVaultCompoundingRewardToken struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewFundManagerAddRestakingVaultCompoundingRewardTokenInstructionBuilder creates a new `FundManagerAddRestakingVaultCompoundingRewardToken` instruction builder.
-func NewFundManagerAddRestakingVaultCompoundingRewardTokenInstructionBuilder() *FundManagerAddRestakingVaultCompoundingRewardToken {
-	nd := &FundManagerAddRestakingVaultCompoundingRewardToken{
+// NewFundManagerAddRestakingVaultCompoundingRewardTokenInstructionBuilder creates a new `FundManagerAddRestakingVaultCompoundingRewardTokenInstruction` instruction builder.
+func NewFundManagerAddRestakingVaultCompoundingRewardTokenInstructionBuilder() *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction {
+	nd := &FundManagerAddRestakingVaultCompoundingRewardTokenInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 5),
 	}
 	nd.AccountMetaSlice[0] = ag_solanago.Meta(Addresses["5UpLTLA7Wjqp7qdfjuTtPcUw3aVtbqFA5Mgm34mxPNg2"]).SIGNER()
@@ -37,46 +37,46 @@ func NewFundManagerAddRestakingVaultCompoundingRewardTokenInstructionBuilder() *
 }
 
 // SetVault sets the "vault" parameter.
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) SetVault(vault ag_solanago.PublicKey) *FundManagerAddRestakingVaultCompoundingRewardToken {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) SetVault(vault ag_solanago.PublicKey) *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction {
 	inst.Vault = &vault
 	return inst
 }
 
 // SetCompoundingRewardTokenMint sets the "compounding_reward_token_mint" parameter.
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) SetCompoundingRewardTokenMint(compounding_reward_token_mint ag_solanago.PublicKey) *FundManagerAddRestakingVaultCompoundingRewardToken {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) SetCompoundingRewardTokenMint(compounding_reward_token_mint ag_solanago.PublicKey) *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction {
 	inst.CompoundingRewardTokenMint = &compounding_reward_token_mint
 	return inst
 }
 
 // SetFundManagerAccount sets the "fund_manager" account.
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerAddRestakingVaultCompoundingRewardToken {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(fundManager).SIGNER()
 	return inst
 }
 
 // GetFundManagerAccount gets the "fund_manager" account.
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) GetFundManagerAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) GetFundManagerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerAddRestakingVaultCompoundingRewardToken {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerAddRestakingVaultCompoundingRewardToken {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -93,12 +93,12 @@ func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) findFindFundAcco
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -107,12 +107,12 @@ func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) MustFindFundAcco
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -121,17 +121,17 @@ func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) MustFindFundAcco
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerAddRestakingVaultCompoundingRewardToken {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -146,12 +146,12 @@ func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) findFindEventAut
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -160,12 +160,12 @@ func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) MustFindEventAut
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -174,22 +174,22 @@ func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) MustFindEventAut
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerAddRestakingVaultCompoundingRewardToken {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
-func (inst FundManagerAddRestakingVaultCompoundingRewardToken) Build() *Instruction {
+func (inst FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_FundManagerAddRestakingVaultCompoundingRewardToken,
@@ -199,14 +199,14 @@ func (inst FundManagerAddRestakingVaultCompoundingRewardToken) Build() *Instruct
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst FundManagerAddRestakingVaultCompoundingRewardToken) ValidateAndBuild() (*Instruction, error) {
+func (inst FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) Validate() error {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.Vault == nil {
@@ -238,7 +238,7 @@ func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) Validate() error
 	return nil
 }
 
-func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -264,7 +264,7 @@ func (inst *FundManagerAddRestakingVaultCompoundingRewardToken) EncodeToTree(par
 		})
 }
 
-func (obj FundManagerAddRestakingVaultCompoundingRewardToken) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `Vault` param:
 	err = encoder.Encode(obj.Vault)
 	if err != nil {
@@ -277,7 +277,7 @@ func (obj FundManagerAddRestakingVaultCompoundingRewardToken) MarshalWithEncoder
 	}
 	return nil
 }
-func (obj *FundManagerAddRestakingVaultCompoundingRewardToken) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `Vault`:
 	err = decoder.Decode(&obj.Vault)
 	if err != nil {
@@ -301,7 +301,7 @@ func NewFundManagerAddRestakingVaultCompoundingRewardTokenInstruction(
 	receiptTokenMint ag_solanago.PublicKey,
 	fundAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *FundManagerAddRestakingVaultCompoundingRewardToken {
+	program ag_solanago.PublicKey) *FundManagerAddRestakingVaultCompoundingRewardTokenInstruction {
 	return NewFundManagerAddRestakingVaultCompoundingRewardTokenInstructionBuilder().
 		SetVault(vault).
 		SetCompoundingRewardTokenMint(compounding_reward_token_mint).

--- a/generated/restaking/fundmanageraddrestakingvaultcompoundingrewardtoken_test.go
+++ b/generated/restaking/fundmanageraddrestakingvaultcompoundingrewardtoken_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_FundManagerAddRestakingVaultCompoundingRewardToken(t *test
 	for i := 0; i < 1; i++ {
 		t.Run("FundManagerAddRestakingVaultCompoundingRewardToken"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(FundManagerAddRestakingVaultCompoundingRewardToken)
+				params := new(FundManagerAddRestakingVaultCompoundingRewardTokenInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(FundManagerAddRestakingVaultCompoundingRewardToken)
+				got := new(FundManagerAddRestakingVaultCompoundingRewardTokenInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/fundmanageraddreward.go
+++ b/generated/restaking/fundmanageraddreward.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FundManagerAddReward is the `fund_manager_add_reward` instruction.
-type FundManagerAddReward struct {
+type FundManagerAddRewardInstruction struct {
 	Name        *string
 	Description *string
 	RewardType  *RewardType
@@ -32,9 +32,9 @@ type FundManagerAddReward struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewFundManagerAddRewardInstructionBuilder creates a new `FundManagerAddReward` instruction builder.
-func NewFundManagerAddRewardInstructionBuilder() *FundManagerAddReward {
-	nd := &FundManagerAddReward{
+// NewFundManagerAddRewardInstructionBuilder creates a new `FundManagerAddRewardInstruction` instruction builder.
+func NewFundManagerAddRewardInstructionBuilder() *FundManagerAddRewardInstruction {
+	nd := &FundManagerAddRewardInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 7),
 	}
 	nd.AccountMetaSlice[0] = ag_solanago.Meta(Addresses["5UpLTLA7Wjqp7qdfjuTtPcUw3aVtbqFA5Mgm34mxPNg2"]).SIGNER()
@@ -42,52 +42,52 @@ func NewFundManagerAddRewardInstructionBuilder() *FundManagerAddReward {
 }
 
 // SetName sets the "name" parameter.
-func (inst *FundManagerAddReward) SetName(name string) *FundManagerAddReward {
+func (inst *FundManagerAddRewardInstruction) SetName(name string) *FundManagerAddRewardInstruction {
 	inst.Name = &name
 	return inst
 }
 
 // SetDescription sets the "description" parameter.
-func (inst *FundManagerAddReward) SetDescription(description string) *FundManagerAddReward {
+func (inst *FundManagerAddRewardInstruction) SetDescription(description string) *FundManagerAddRewardInstruction {
 	inst.Description = &description
 	return inst
 }
 
 // SetRewardType sets the "reward_type" parameter.
-func (inst *FundManagerAddReward) SetRewardType(reward_type RewardType) *FundManagerAddReward {
+func (inst *FundManagerAddRewardInstruction) SetRewardType(reward_type RewardType) *FundManagerAddRewardInstruction {
 	inst.RewardType = &reward_type
 	return inst
 }
 
 // SetFundManagerAccount sets the "fund_manager" account.
-func (inst *FundManagerAddReward) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerAddReward {
+func (inst *FundManagerAddRewardInstruction) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerAddRewardInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(fundManager).SIGNER()
 	return inst
 }
 
 // GetFundManagerAccount gets the "fund_manager" account.
-func (inst *FundManagerAddReward) GetFundManagerAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRewardInstruction) GetFundManagerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *FundManagerAddReward) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerAddReward {
+func (inst *FundManagerAddRewardInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerAddRewardInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *FundManagerAddReward) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRewardInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *FundManagerAddReward) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *FundManagerAddReward {
+func (inst *FundManagerAddRewardInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *FundManagerAddRewardInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *FundManagerAddReward) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddRewardInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -104,12 +104,12 @@ func (inst *FundManagerAddReward) findFindRewardAccountAddress(receiptTokenMint 
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerAddReward) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerAddRewardInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerAddReward) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddRewardInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -118,12 +118,12 @@ func (inst *FundManagerAddReward) MustFindRewardAccountAddressWithBumpSeed(recei
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *FundManagerAddReward) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddRewardInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerAddReward) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddRewardInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -132,39 +132,39 @@ func (inst *FundManagerAddReward) MustFindRewardAccountAddress(receiptTokenMint 
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *FundManagerAddReward) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRewardInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetRewardTokenMintAccount sets the "reward_token_mint" account.
-func (inst *FundManagerAddReward) SetRewardTokenMintAccount(rewardTokenMint ag_solanago.PublicKey) *FundManagerAddReward {
+func (inst *FundManagerAddRewardInstruction) SetRewardTokenMintAccount(rewardTokenMint ag_solanago.PublicKey) *FundManagerAddRewardInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(rewardTokenMint)
 	return inst
 }
 
 // GetRewardTokenMintAccount gets the "reward_token_mint" account (optional).
-func (inst *FundManagerAddReward) GetRewardTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRewardInstruction) GetRewardTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetRewardTokenProgramAccount sets the "reward_token_program" account.
-func (inst *FundManagerAddReward) SetRewardTokenProgramAccount(rewardTokenProgram ag_solanago.PublicKey) *FundManagerAddReward {
+func (inst *FundManagerAddRewardInstruction) SetRewardTokenProgramAccount(rewardTokenProgram ag_solanago.PublicKey) *FundManagerAddRewardInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(rewardTokenProgram)
 	return inst
 }
 
 // GetRewardTokenProgramAccount gets the "reward_token_program" account (optional).
-func (inst *FundManagerAddReward) GetRewardTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRewardInstruction) GetRewardTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *FundManagerAddReward) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerAddReward {
+func (inst *FundManagerAddRewardInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerAddRewardInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *FundManagerAddReward) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddRewardInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -179,12 +179,12 @@ func (inst *FundManagerAddReward) findFindEventAuthorityAddress(knownBumpSeed ui
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *FundManagerAddReward) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerAddRewardInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *FundManagerAddReward) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddRewardInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -193,12 +193,12 @@ func (inst *FundManagerAddReward) MustFindEventAuthorityAddressWithBumpSeed(bump
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *FundManagerAddReward) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddRewardInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *FundManagerAddReward) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddRewardInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -207,22 +207,22 @@ func (inst *FundManagerAddReward) MustFindEventAuthorityAddress() (pda ag_solana
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *FundManagerAddReward) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRewardInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *FundManagerAddReward) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerAddReward {
+func (inst *FundManagerAddRewardInstruction) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerAddRewardInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *FundManagerAddReward) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRewardInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
-func (inst FundManagerAddReward) Build() *Instruction {
+func (inst FundManagerAddRewardInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_FundManagerAddReward,
@@ -232,14 +232,14 @@ func (inst FundManagerAddReward) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst FundManagerAddReward) ValidateAndBuild() (*Instruction, error) {
+func (inst FundManagerAddRewardInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *FundManagerAddReward) Validate() error {
+func (inst *FundManagerAddRewardInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.Name == nil {
@@ -279,7 +279,7 @@ func (inst *FundManagerAddReward) Validate() error {
 	return nil
 }
 
-func (inst *FundManagerAddReward) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *FundManagerAddRewardInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -308,7 +308,7 @@ func (inst *FundManagerAddReward) EncodeToTree(parent ag_treeout.Branches) {
 		})
 }
 
-func (obj FundManagerAddReward) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj FundManagerAddRewardInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `Name` param:
 	err = encoder.Encode(obj.Name)
 	if err != nil {
@@ -326,7 +326,7 @@ func (obj FundManagerAddReward) MarshalWithEncoder(encoder *ag_binary.Encoder) (
 	}
 	return nil
 }
-func (obj *FundManagerAddReward) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *FundManagerAddRewardInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `Name`:
 	err = decoder.Decode(&obj.Name)
 	if err != nil {
@@ -358,7 +358,7 @@ func NewFundManagerAddRewardInstruction(
 	rewardTokenMint ag_solanago.PublicKey,
 	rewardTokenProgram ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *FundManagerAddReward {
+	program ag_solanago.PublicKey) *FundManagerAddRewardInstruction {
 	return NewFundManagerAddRewardInstructionBuilder().
 		SetName(name).
 		SetDescription(description).

--- a/generated/restaking/fundmanageraddreward_test.go
+++ b/generated/restaking/fundmanageraddreward_test.go
@@ -18,7 +18,7 @@ func TestEncodeDecode_FundManagerAddReward(t *testing.T) {
 			{
 				{
 					{
-						params := new(FundManagerAddReward)
+						params := new(FundManagerAddRewardInstruction)
 						fu.Fuzz(params)
 						params.AccountMetaSlice = nil
 						tmp := new(RewardTypePointTuple)
@@ -27,7 +27,7 @@ func TestEncodeDecode_FundManagerAddReward(t *testing.T) {
 						buf := new(bytes.Buffer)
 						err := encodeT(*params, buf)
 						ag_require.NoError(t, err)
-						got := new(FundManagerAddReward)
+						got := new(FundManagerAddRewardInstruction)
 						err = decodeT(got, buf.Bytes())
 						got.AccountMetaSlice = nil
 						ag_require.NoError(t, err)
@@ -38,7 +38,7 @@ func TestEncodeDecode_FundManagerAddReward(t *testing.T) {
 						ag_require.Equal(t, params, got)
 					}
 					{
-						params := new(FundManagerAddReward)
+						params := new(FundManagerAddRewardInstruction)
 						fu.Fuzz(params)
 						params.AccountMetaSlice = nil
 						tmp := new(RewardTypeTokenTuple)
@@ -47,7 +47,7 @@ func TestEncodeDecode_FundManagerAddReward(t *testing.T) {
 						buf := new(bytes.Buffer)
 						err := encodeT(*params, buf)
 						ag_require.NoError(t, err)
-						got := new(FundManagerAddReward)
+						got := new(FundManagerAddRewardInstruction)
 						err = decodeT(got, buf.Bytes())
 						got.AccountMetaSlice = nil
 						ag_require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestEncodeDecode_FundManagerAddReward(t *testing.T) {
 						ag_require.Equal(t, params, got)
 					}
 					{
-						params := new(FundManagerAddReward)
+						params := new(FundManagerAddRewardInstruction)
 						fu.Fuzz(params)
 						params.AccountMetaSlice = nil
 						tmp := new(RewardTypeSOLTuple)
@@ -67,7 +67,7 @@ func TestEncodeDecode_FundManagerAddReward(t *testing.T) {
 						buf := new(bytes.Buffer)
 						err := encodeT(*params, buf)
 						ag_require.NoError(t, err)
-						got := new(FundManagerAddReward)
+						got := new(FundManagerAddRewardInstruction)
 						err = decodeT(got, buf.Bytes())
 						got.AccountMetaSlice = nil
 						ag_require.NoError(t, err)

--- a/generated/restaking/fundmanageraddrewardpool.go
+++ b/generated/restaking/fundmanageraddrewardpool.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FundManagerAddRewardPool is the `fund_manager_add_reward_pool` instruction.
-type FundManagerAddRewardPool struct {
+type FundManagerAddRewardPoolInstruction struct {
 	Name                                 *string
 	HolderId                             *uint8 `bin:"optional"`
 	CustomContributionAccrualRateEnabled *bool
@@ -28,9 +28,9 @@ type FundManagerAddRewardPool struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewFundManagerAddRewardPoolInstructionBuilder creates a new `FundManagerAddRewardPool` instruction builder.
-func NewFundManagerAddRewardPoolInstructionBuilder() *FundManagerAddRewardPool {
-	nd := &FundManagerAddRewardPool{
+// NewFundManagerAddRewardPoolInstructionBuilder creates a new `FundManagerAddRewardPoolInstruction` instruction builder.
+func NewFundManagerAddRewardPoolInstructionBuilder() *FundManagerAddRewardPoolInstruction {
+	nd := &FundManagerAddRewardPoolInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 5),
 	}
 	nd.AccountMetaSlice[0] = ag_solanago.Meta(Addresses["5UpLTLA7Wjqp7qdfjuTtPcUw3aVtbqFA5Mgm34mxPNg2"]).SIGNER()
@@ -38,52 +38,52 @@ func NewFundManagerAddRewardPoolInstructionBuilder() *FundManagerAddRewardPool {
 }
 
 // SetName sets the "name" parameter.
-func (inst *FundManagerAddRewardPool) SetName(name string) *FundManagerAddRewardPool {
+func (inst *FundManagerAddRewardPoolInstruction) SetName(name string) *FundManagerAddRewardPoolInstruction {
 	inst.Name = &name
 	return inst
 }
 
 // SetHolderId sets the "holder_id" parameter.
-func (inst *FundManagerAddRewardPool) SetHolderId(holder_id uint8) *FundManagerAddRewardPool {
+func (inst *FundManagerAddRewardPoolInstruction) SetHolderId(holder_id uint8) *FundManagerAddRewardPoolInstruction {
 	inst.HolderId = &holder_id
 	return inst
 }
 
 // SetCustomContributionAccrualRateEnabled sets the "custom_contribution_accrual_rate_enabled" parameter.
-func (inst *FundManagerAddRewardPool) SetCustomContributionAccrualRateEnabled(custom_contribution_accrual_rate_enabled bool) *FundManagerAddRewardPool {
+func (inst *FundManagerAddRewardPoolInstruction) SetCustomContributionAccrualRateEnabled(custom_contribution_accrual_rate_enabled bool) *FundManagerAddRewardPoolInstruction {
 	inst.CustomContributionAccrualRateEnabled = &custom_contribution_accrual_rate_enabled
 	return inst
 }
 
 // SetFundManagerAccount sets the "fund_manager" account.
-func (inst *FundManagerAddRewardPool) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerAddRewardPool {
+func (inst *FundManagerAddRewardPoolInstruction) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerAddRewardPoolInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(fundManager).SIGNER()
 	return inst
 }
 
 // GetFundManagerAccount gets the "fund_manager" account.
-func (inst *FundManagerAddRewardPool) GetFundManagerAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRewardPoolInstruction) GetFundManagerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *FundManagerAddRewardPool) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerAddRewardPool {
+func (inst *FundManagerAddRewardPoolInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerAddRewardPoolInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *FundManagerAddRewardPool) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRewardPoolInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *FundManagerAddRewardPool) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *FundManagerAddRewardPool {
+func (inst *FundManagerAddRewardPoolInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *FundManagerAddRewardPoolInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *FundManagerAddRewardPool) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddRewardPoolInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -100,12 +100,12 @@ func (inst *FundManagerAddRewardPool) findFindRewardAccountAddress(receiptTokenM
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerAddRewardPool) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerAddRewardPoolInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerAddRewardPool) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddRewardPoolInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -114,12 +114,12 @@ func (inst *FundManagerAddRewardPool) MustFindRewardAccountAddressWithBumpSeed(r
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *FundManagerAddRewardPool) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddRewardPoolInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerAddRewardPool) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddRewardPoolInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -128,17 +128,17 @@ func (inst *FundManagerAddRewardPool) MustFindRewardAccountAddress(receiptTokenM
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *FundManagerAddRewardPool) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRewardPoolInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *FundManagerAddRewardPool) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerAddRewardPool {
+func (inst *FundManagerAddRewardPoolInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerAddRewardPoolInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *FundManagerAddRewardPool) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddRewardPoolInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -153,12 +153,12 @@ func (inst *FundManagerAddRewardPool) findFindEventAuthorityAddress(knownBumpSee
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *FundManagerAddRewardPool) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerAddRewardPoolInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *FundManagerAddRewardPool) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddRewardPoolInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -167,12 +167,12 @@ func (inst *FundManagerAddRewardPool) MustFindEventAuthorityAddressWithBumpSeed(
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *FundManagerAddRewardPool) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddRewardPoolInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *FundManagerAddRewardPool) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddRewardPoolInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -181,22 +181,22 @@ func (inst *FundManagerAddRewardPool) MustFindEventAuthorityAddress() (pda ag_so
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *FundManagerAddRewardPool) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRewardPoolInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *FundManagerAddRewardPool) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerAddRewardPool {
+func (inst *FundManagerAddRewardPoolInstruction) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerAddRewardPoolInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *FundManagerAddRewardPool) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRewardPoolInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
-func (inst FundManagerAddRewardPool) Build() *Instruction {
+func (inst FundManagerAddRewardPoolInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_FundManagerAddRewardPool,
@@ -206,14 +206,14 @@ func (inst FundManagerAddRewardPool) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst FundManagerAddRewardPool) ValidateAndBuild() (*Instruction, error) {
+func (inst FundManagerAddRewardPoolInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *FundManagerAddRewardPool) Validate() error {
+func (inst *FundManagerAddRewardPoolInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.Name == nil {
@@ -245,7 +245,7 @@ func (inst *FundManagerAddRewardPool) Validate() error {
 	return nil
 }
 
-func (inst *FundManagerAddRewardPool) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *FundManagerAddRewardPoolInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -272,7 +272,7 @@ func (inst *FundManagerAddRewardPool) EncodeToTree(parent ag_treeout.Branches) {
 		})
 }
 
-func (obj FundManagerAddRewardPool) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj FundManagerAddRewardPoolInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `Name` param:
 	err = encoder.Encode(obj.Name)
 	if err != nil {
@@ -303,7 +303,7 @@ func (obj FundManagerAddRewardPool) MarshalWithEncoder(encoder *ag_binary.Encode
 	}
 	return nil
 }
-func (obj *FundManagerAddRewardPool) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *FundManagerAddRewardPoolInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `Name`:
 	err = decoder.Decode(&obj.Name)
 	if err != nil {
@@ -341,7 +341,7 @@ func NewFundManagerAddRewardPoolInstruction(
 	receiptTokenMint ag_solanago.PublicKey,
 	rewardAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *FundManagerAddRewardPool {
+	program ag_solanago.PublicKey) *FundManagerAddRewardPoolInstruction {
 	return NewFundManagerAddRewardPoolInstructionBuilder().
 		SetName(name).
 		SetHolderId(holder_id).

--- a/generated/restaking/fundmanageraddrewardpool_test.go
+++ b/generated/restaking/fundmanageraddrewardpool_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_FundManagerAddRewardPool(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("FundManagerAddRewardPool"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(FundManagerAddRewardPool)
+				params := new(FundManagerAddRewardPoolInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(FundManagerAddRewardPool)
+				got := new(FundManagerAddRewardPoolInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/fundmanageraddrewardpoolholder.go
+++ b/generated/restaking/fundmanageraddrewardpoolholder.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FundManagerAddRewardPoolHolder is the `fund_manager_add_reward_pool_holder` instruction.
-type FundManagerAddRewardPoolHolder struct {
+type FundManagerAddRewardPoolHolderInstruction struct {
 	Name        *string
 	Description *string
 	Pubkeys     *[]ag_solanago.PublicKey
@@ -28,9 +28,9 @@ type FundManagerAddRewardPoolHolder struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewFundManagerAddRewardPoolHolderInstructionBuilder creates a new `FundManagerAddRewardPoolHolder` instruction builder.
-func NewFundManagerAddRewardPoolHolderInstructionBuilder() *FundManagerAddRewardPoolHolder {
-	nd := &FundManagerAddRewardPoolHolder{
+// NewFundManagerAddRewardPoolHolderInstructionBuilder creates a new `FundManagerAddRewardPoolHolderInstruction` instruction builder.
+func NewFundManagerAddRewardPoolHolderInstructionBuilder() *FundManagerAddRewardPoolHolderInstruction {
+	nd := &FundManagerAddRewardPoolHolderInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 5),
 	}
 	nd.AccountMetaSlice[0] = ag_solanago.Meta(Addresses["5UpLTLA7Wjqp7qdfjuTtPcUw3aVtbqFA5Mgm34mxPNg2"]).SIGNER()
@@ -38,52 +38,52 @@ func NewFundManagerAddRewardPoolHolderInstructionBuilder() *FundManagerAddReward
 }
 
 // SetName sets the "name" parameter.
-func (inst *FundManagerAddRewardPoolHolder) SetName(name string) *FundManagerAddRewardPoolHolder {
+func (inst *FundManagerAddRewardPoolHolderInstruction) SetName(name string) *FundManagerAddRewardPoolHolderInstruction {
 	inst.Name = &name
 	return inst
 }
 
 // SetDescription sets the "description" parameter.
-func (inst *FundManagerAddRewardPoolHolder) SetDescription(description string) *FundManagerAddRewardPoolHolder {
+func (inst *FundManagerAddRewardPoolHolderInstruction) SetDescription(description string) *FundManagerAddRewardPoolHolderInstruction {
 	inst.Description = &description
 	return inst
 }
 
 // SetPubkeys sets the "pubkeys" parameter.
-func (inst *FundManagerAddRewardPoolHolder) SetPubkeys(pubkeys []ag_solanago.PublicKey) *FundManagerAddRewardPoolHolder {
+func (inst *FundManagerAddRewardPoolHolderInstruction) SetPubkeys(pubkeys []ag_solanago.PublicKey) *FundManagerAddRewardPoolHolderInstruction {
 	inst.Pubkeys = &pubkeys
 	return inst
 }
 
 // SetFundManagerAccount sets the "fund_manager" account.
-func (inst *FundManagerAddRewardPoolHolder) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerAddRewardPoolHolder {
+func (inst *FundManagerAddRewardPoolHolderInstruction) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerAddRewardPoolHolderInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(fundManager).SIGNER()
 	return inst
 }
 
 // GetFundManagerAccount gets the "fund_manager" account.
-func (inst *FundManagerAddRewardPoolHolder) GetFundManagerAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRewardPoolHolderInstruction) GetFundManagerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *FundManagerAddRewardPoolHolder) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerAddRewardPoolHolder {
+func (inst *FundManagerAddRewardPoolHolderInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerAddRewardPoolHolderInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *FundManagerAddRewardPoolHolder) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRewardPoolHolderInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *FundManagerAddRewardPoolHolder) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *FundManagerAddRewardPoolHolder {
+func (inst *FundManagerAddRewardPoolHolderInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *FundManagerAddRewardPoolHolderInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *FundManagerAddRewardPoolHolder) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddRewardPoolHolderInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -100,12 +100,12 @@ func (inst *FundManagerAddRewardPoolHolder) findFindRewardAccountAddress(receipt
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerAddRewardPoolHolder) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerAddRewardPoolHolderInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerAddRewardPoolHolder) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddRewardPoolHolderInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -114,12 +114,12 @@ func (inst *FundManagerAddRewardPoolHolder) MustFindRewardAccountAddressWithBump
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *FundManagerAddRewardPoolHolder) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddRewardPoolHolderInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerAddRewardPoolHolder) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddRewardPoolHolderInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -128,17 +128,17 @@ func (inst *FundManagerAddRewardPoolHolder) MustFindRewardAccountAddress(receipt
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *FundManagerAddRewardPoolHolder) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRewardPoolHolderInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *FundManagerAddRewardPoolHolder) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerAddRewardPoolHolder {
+func (inst *FundManagerAddRewardPoolHolderInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerAddRewardPoolHolderInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *FundManagerAddRewardPoolHolder) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddRewardPoolHolderInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -153,12 +153,12 @@ func (inst *FundManagerAddRewardPoolHolder) findFindEventAuthorityAddress(knownB
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *FundManagerAddRewardPoolHolder) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerAddRewardPoolHolderInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *FundManagerAddRewardPoolHolder) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddRewardPoolHolderInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -167,12 +167,12 @@ func (inst *FundManagerAddRewardPoolHolder) MustFindEventAuthorityAddressWithBum
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *FundManagerAddRewardPoolHolder) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddRewardPoolHolderInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *FundManagerAddRewardPoolHolder) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddRewardPoolHolderInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -181,22 +181,22 @@ func (inst *FundManagerAddRewardPoolHolder) MustFindEventAuthorityAddress() (pda
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *FundManagerAddRewardPoolHolder) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRewardPoolHolderInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *FundManagerAddRewardPoolHolder) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerAddRewardPoolHolder {
+func (inst *FundManagerAddRewardPoolHolderInstruction) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerAddRewardPoolHolderInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *FundManagerAddRewardPoolHolder) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddRewardPoolHolderInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
-func (inst FundManagerAddRewardPoolHolder) Build() *Instruction {
+func (inst FundManagerAddRewardPoolHolderInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_FundManagerAddRewardPoolHolder,
@@ -206,14 +206,14 @@ func (inst FundManagerAddRewardPoolHolder) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst FundManagerAddRewardPoolHolder) ValidateAndBuild() (*Instruction, error) {
+func (inst FundManagerAddRewardPoolHolderInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *FundManagerAddRewardPoolHolder) Validate() error {
+func (inst *FundManagerAddRewardPoolHolderInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.Name == nil {
@@ -248,7 +248,7 @@ func (inst *FundManagerAddRewardPoolHolder) Validate() error {
 	return nil
 }
 
-func (inst *FundManagerAddRewardPoolHolder) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *FundManagerAddRewardPoolHolderInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -275,7 +275,7 @@ func (inst *FundManagerAddRewardPoolHolder) EncodeToTree(parent ag_treeout.Branc
 		})
 }
 
-func (obj FundManagerAddRewardPoolHolder) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj FundManagerAddRewardPoolHolderInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `Name` param:
 	err = encoder.Encode(obj.Name)
 	if err != nil {
@@ -293,7 +293,7 @@ func (obj FundManagerAddRewardPoolHolder) MarshalWithEncoder(encoder *ag_binary.
 	}
 	return nil
 }
-func (obj *FundManagerAddRewardPoolHolder) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *FundManagerAddRewardPoolHolderInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `Name`:
 	err = decoder.Decode(&obj.Name)
 	if err != nil {
@@ -323,7 +323,7 @@ func NewFundManagerAddRewardPoolHolderInstruction(
 	receiptTokenMint ag_solanago.PublicKey,
 	rewardAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *FundManagerAddRewardPoolHolder {
+	program ag_solanago.PublicKey) *FundManagerAddRewardPoolHolderInstruction {
 	return NewFundManagerAddRewardPoolHolderInstructionBuilder().
 		SetName(name).
 		SetDescription(description).

--- a/generated/restaking/fundmanageraddrewardpoolholder_test.go
+++ b/generated/restaking/fundmanageraddrewardpoolholder_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_FundManagerAddRewardPoolHolder(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("FundManagerAddRewardPoolHolder"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(FundManagerAddRewardPoolHolder)
+				params := new(FundManagerAddRewardPoolHolderInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(FundManagerAddRewardPoolHolder)
+				got := new(FundManagerAddRewardPoolHolderInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/fundmanageraddsupportedtoken.go
+++ b/generated/restaking/fundmanageraddsupportedtoken.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FundManagerAddSupportedToken is the `fund_manager_add_supported_token` instruction.
-type FundManagerAddSupportedToken struct {
+type FundManagerAddSupportedTokenInstruction struct {
 	PricingSource *TokenPricingSource
 
 	// [0] = [SIGNER] fund_manager
@@ -38,9 +38,9 @@ type FundManagerAddSupportedToken struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewFundManagerAddSupportedTokenInstructionBuilder creates a new `FundManagerAddSupportedToken` instruction builder.
-func NewFundManagerAddSupportedTokenInstructionBuilder() *FundManagerAddSupportedToken {
-	nd := &FundManagerAddSupportedToken{
+// NewFundManagerAddSupportedTokenInstructionBuilder creates a new `FundManagerAddSupportedTokenInstruction` instruction builder.
+func NewFundManagerAddSupportedTokenInstructionBuilder() *FundManagerAddSupportedTokenInstruction {
+	nd := &FundManagerAddSupportedTokenInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 11),
 	}
 	nd.AccountMetaSlice[0] = ag_solanago.Meta(Addresses["5UpLTLA7Wjqp7qdfjuTtPcUw3aVtbqFA5Mgm34mxPNg2"]).SIGNER()
@@ -48,40 +48,40 @@ func NewFundManagerAddSupportedTokenInstructionBuilder() *FundManagerAddSupporte
 }
 
 // SetPricingSource sets the "pricing_source" parameter.
-func (inst *FundManagerAddSupportedToken) SetPricingSource(pricing_source TokenPricingSource) *FundManagerAddSupportedToken {
+func (inst *FundManagerAddSupportedTokenInstruction) SetPricingSource(pricing_source TokenPricingSource) *FundManagerAddSupportedTokenInstruction {
 	inst.PricingSource = &pricing_source
 	return inst
 }
 
 // SetFundManagerAccount sets the "fund_manager" account.
-func (inst *FundManagerAddSupportedToken) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerAddSupportedToken {
+func (inst *FundManagerAddSupportedTokenInstruction) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerAddSupportedTokenInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(fundManager).SIGNER()
 	return inst
 }
 
 // GetFundManagerAccount gets the "fund_manager" account.
-func (inst *FundManagerAddSupportedToken) GetFundManagerAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddSupportedTokenInstruction) GetFundManagerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *FundManagerAddSupportedToken) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerAddSupportedToken {
+func (inst *FundManagerAddSupportedTokenInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerAddSupportedTokenInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *FundManagerAddSupportedToken) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddSupportedTokenInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *FundManagerAddSupportedToken) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerAddSupportedToken {
+func (inst *FundManagerAddSupportedTokenInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerAddSupportedTokenInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *FundManagerAddSupportedToken) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddSupportedTokenInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -98,12 +98,12 @@ func (inst *FundManagerAddSupportedToken) findFindFundAccountAddress(receiptToke
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerAddSupportedToken) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerAddSupportedTokenInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerAddSupportedToken) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddSupportedTokenInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -112,12 +112,12 @@ func (inst *FundManagerAddSupportedToken) MustFindFundAccountAddressWithBumpSeed
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *FundManagerAddSupportedToken) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddSupportedTokenInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerAddSupportedToken) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddSupportedTokenInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -126,17 +126,17 @@ func (inst *FundManagerAddSupportedToken) MustFindFundAccountAddress(receiptToke
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *FundManagerAddSupportedToken) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddSupportedTokenInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetFundReserveAccountAccount sets the "fund_reserve_account" account.
-func (inst *FundManagerAddSupportedToken) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *FundManagerAddSupportedToken {
+func (inst *FundManagerAddSupportedTokenInstruction) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *FundManagerAddSupportedTokenInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(fundReserveAccount)
 	return inst
 }
 
-func (inst *FundManagerAddSupportedToken) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddSupportedTokenInstruction) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_reserve
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x72), byte(0x65), byte(0x73), byte(0x65), byte(0x72), byte(0x76), byte(0x65)})
@@ -153,12 +153,12 @@ func (inst *FundManagerAddSupportedToken) findFindFundReserveAccountAddress(rece
 }
 
 // FindFundReserveAccountAddressWithBumpSeed calculates FundReserveAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerAddSupportedToken) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerAddSupportedTokenInstruction) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerAddSupportedToken) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddSupportedTokenInstruction) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -167,12 +167,12 @@ func (inst *FundManagerAddSupportedToken) MustFindFundReserveAccountAddressWithB
 }
 
 // FindFundReserveAccountAddress finds FundReserveAccount account address with given seeds.
-func (inst *FundManagerAddSupportedToken) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddSupportedTokenInstruction) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerAddSupportedToken) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddSupportedTokenInstruction) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -181,17 +181,17 @@ func (inst *FundManagerAddSupportedToken) MustFindFundReserveAccountAddress(rece
 }
 
 // GetFundReserveAccountAccount gets the "fund_reserve_account" account.
-func (inst *FundManagerAddSupportedToken) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddSupportedTokenInstruction) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetFundTreasuryAccountAccount sets the "fund_treasury_account" account.
-func (inst *FundManagerAddSupportedToken) SetFundTreasuryAccountAccount(fundTreasuryAccount ag_solanago.PublicKey) *FundManagerAddSupportedToken {
+func (inst *FundManagerAddSupportedTokenInstruction) SetFundTreasuryAccountAccount(fundTreasuryAccount ag_solanago.PublicKey) *FundManagerAddSupportedTokenInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(fundTreasuryAccount)
 	return inst
 }
 
-func (inst *FundManagerAddSupportedToken) findFindFundTreasuryAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddSupportedTokenInstruction) findFindFundTreasuryAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_treasury
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x74), byte(0x72), byte(0x65), byte(0x61), byte(0x73), byte(0x75), byte(0x72), byte(0x79)})
@@ -208,12 +208,12 @@ func (inst *FundManagerAddSupportedToken) findFindFundTreasuryAccountAddress(rec
 }
 
 // FindFundTreasuryAccountAddressWithBumpSeed calculates FundTreasuryAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerAddSupportedToken) FindFundTreasuryAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerAddSupportedTokenInstruction) FindFundTreasuryAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundTreasuryAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerAddSupportedToken) MustFindFundTreasuryAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddSupportedTokenInstruction) MustFindFundTreasuryAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundTreasuryAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -222,12 +222,12 @@ func (inst *FundManagerAddSupportedToken) MustFindFundTreasuryAccountAddressWith
 }
 
 // FindFundTreasuryAccountAddress finds FundTreasuryAccount account address with given seeds.
-func (inst *FundManagerAddSupportedToken) FindFundTreasuryAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddSupportedTokenInstruction) FindFundTreasuryAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundTreasuryAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerAddSupportedToken) MustFindFundTreasuryAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddSupportedTokenInstruction) MustFindFundTreasuryAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundTreasuryAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -236,39 +236,39 @@ func (inst *FundManagerAddSupportedToken) MustFindFundTreasuryAccountAddress(rec
 }
 
 // GetFundTreasuryAccountAccount gets the "fund_treasury_account" account.
-func (inst *FundManagerAddSupportedToken) GetFundTreasuryAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddSupportedTokenInstruction) GetFundTreasuryAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetSupportedTokenMintAccount sets the "supported_token_mint" account.
-func (inst *FundManagerAddSupportedToken) SetSupportedTokenMintAccount(supportedTokenMint ag_solanago.PublicKey) *FundManagerAddSupportedToken {
+func (inst *FundManagerAddSupportedTokenInstruction) SetSupportedTokenMintAccount(supportedTokenMint ag_solanago.PublicKey) *FundManagerAddSupportedTokenInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(supportedTokenMint)
 	return inst
 }
 
 // GetSupportedTokenMintAccount gets the "supported_token_mint" account.
-func (inst *FundManagerAddSupportedToken) GetSupportedTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddSupportedTokenInstruction) GetSupportedTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetSupportedTokenProgramAccount sets the "supported_token_program" account.
-func (inst *FundManagerAddSupportedToken) SetSupportedTokenProgramAccount(supportedTokenProgram ag_solanago.PublicKey) *FundManagerAddSupportedToken {
+func (inst *FundManagerAddSupportedTokenInstruction) SetSupportedTokenProgramAccount(supportedTokenProgram ag_solanago.PublicKey) *FundManagerAddSupportedTokenInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(supportedTokenProgram)
 	return inst
 }
 
 // GetSupportedTokenProgramAccount gets the "supported_token_program" account.
-func (inst *FundManagerAddSupportedToken) GetSupportedTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddSupportedTokenInstruction) GetSupportedTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetSupportedTokenReserveAccountAccount sets the "supported_token_reserve_account" account.
-func (inst *FundManagerAddSupportedToken) SetSupportedTokenReserveAccountAccount(supportedTokenReserveAccount ag_solanago.PublicKey) *FundManagerAddSupportedToken {
+func (inst *FundManagerAddSupportedTokenInstruction) SetSupportedTokenReserveAccountAccount(supportedTokenReserveAccount ag_solanago.PublicKey) *FundManagerAddSupportedTokenInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(supportedTokenReserveAccount)
 	return inst
 }
 
-func (inst *FundManagerAddSupportedToken) findFindSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddSupportedTokenInstruction) findFindSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: fundReserveAccount
 	seeds = append(seeds, fundReserveAccount.Bytes())
@@ -289,12 +289,12 @@ func (inst *FundManagerAddSupportedToken) findFindSupportedTokenReserveAccountAd
 }
 
 // FindSupportedTokenReserveAccountAddressWithBumpSeed calculates SupportedTokenReserveAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerAddSupportedToken) FindSupportedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerAddSupportedTokenInstruction) FindSupportedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindSupportedTokenReserveAccountAddress(fundReserveAccount, supportedTokenProgram, supportedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerAddSupportedToken) MustFindSupportedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddSupportedTokenInstruction) MustFindSupportedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindSupportedTokenReserveAccountAddress(fundReserveAccount, supportedTokenProgram, supportedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -303,12 +303,12 @@ func (inst *FundManagerAddSupportedToken) MustFindSupportedTokenReserveAccountAd
 }
 
 // FindSupportedTokenReserveAccountAddress finds SupportedTokenReserveAccount account address with given seeds.
-func (inst *FundManagerAddSupportedToken) FindSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddSupportedTokenInstruction) FindSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindSupportedTokenReserveAccountAddress(fundReserveAccount, supportedTokenProgram, supportedTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerAddSupportedToken) MustFindSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddSupportedTokenInstruction) MustFindSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindSupportedTokenReserveAccountAddress(fundReserveAccount, supportedTokenProgram, supportedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -317,17 +317,17 @@ func (inst *FundManagerAddSupportedToken) MustFindSupportedTokenReserveAccountAd
 }
 
 // GetSupportedTokenReserveAccountAccount gets the "supported_token_reserve_account" account.
-func (inst *FundManagerAddSupportedToken) GetSupportedTokenReserveAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddSupportedTokenInstruction) GetSupportedTokenReserveAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetSupportedTokenTreasuryAccountAccount sets the "supported_token_treasury_account" account.
-func (inst *FundManagerAddSupportedToken) SetSupportedTokenTreasuryAccountAccount(supportedTokenTreasuryAccount ag_solanago.PublicKey) *FundManagerAddSupportedToken {
+func (inst *FundManagerAddSupportedTokenInstruction) SetSupportedTokenTreasuryAccountAccount(supportedTokenTreasuryAccount ag_solanago.PublicKey) *FundManagerAddSupportedTokenInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(supportedTokenTreasuryAccount)
 	return inst
 }
 
-func (inst *FundManagerAddSupportedToken) findFindSupportedTokenTreasuryAccountAddress(fundTreasuryAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddSupportedTokenInstruction) findFindSupportedTokenTreasuryAccountAddress(fundTreasuryAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: fundTreasuryAccount
 	seeds = append(seeds, fundTreasuryAccount.Bytes())
@@ -348,12 +348,12 @@ func (inst *FundManagerAddSupportedToken) findFindSupportedTokenTreasuryAccountA
 }
 
 // FindSupportedTokenTreasuryAccountAddressWithBumpSeed calculates SupportedTokenTreasuryAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerAddSupportedToken) FindSupportedTokenTreasuryAccountAddressWithBumpSeed(fundTreasuryAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerAddSupportedTokenInstruction) FindSupportedTokenTreasuryAccountAddressWithBumpSeed(fundTreasuryAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindSupportedTokenTreasuryAccountAddress(fundTreasuryAccount, supportedTokenProgram, supportedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerAddSupportedToken) MustFindSupportedTokenTreasuryAccountAddressWithBumpSeed(fundTreasuryAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddSupportedTokenInstruction) MustFindSupportedTokenTreasuryAccountAddressWithBumpSeed(fundTreasuryAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindSupportedTokenTreasuryAccountAddress(fundTreasuryAccount, supportedTokenProgram, supportedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -362,12 +362,12 @@ func (inst *FundManagerAddSupportedToken) MustFindSupportedTokenTreasuryAccountA
 }
 
 // FindSupportedTokenTreasuryAccountAddress finds SupportedTokenTreasuryAccount account address with given seeds.
-func (inst *FundManagerAddSupportedToken) FindSupportedTokenTreasuryAccountAddress(fundTreasuryAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddSupportedTokenInstruction) FindSupportedTokenTreasuryAccountAddress(fundTreasuryAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindSupportedTokenTreasuryAccountAddress(fundTreasuryAccount, supportedTokenProgram, supportedTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerAddSupportedToken) MustFindSupportedTokenTreasuryAccountAddress(fundTreasuryAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddSupportedTokenInstruction) MustFindSupportedTokenTreasuryAccountAddress(fundTreasuryAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindSupportedTokenTreasuryAccountAddress(fundTreasuryAccount, supportedTokenProgram, supportedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -376,17 +376,17 @@ func (inst *FundManagerAddSupportedToken) MustFindSupportedTokenTreasuryAccountA
 }
 
 // GetSupportedTokenTreasuryAccountAccount gets the "supported_token_treasury_account" account.
-func (inst *FundManagerAddSupportedToken) GetSupportedTokenTreasuryAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddSupportedTokenInstruction) GetSupportedTokenTreasuryAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *FundManagerAddSupportedToken) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerAddSupportedToken {
+func (inst *FundManagerAddSupportedTokenInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerAddSupportedTokenInstruction {
 	inst.AccountMetaSlice[9] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *FundManagerAddSupportedToken) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddSupportedTokenInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -401,12 +401,12 @@ func (inst *FundManagerAddSupportedToken) findFindEventAuthorityAddress(knownBum
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *FundManagerAddSupportedToken) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerAddSupportedTokenInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *FundManagerAddSupportedToken) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddSupportedTokenInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -415,12 +415,12 @@ func (inst *FundManagerAddSupportedToken) MustFindEventAuthorityAddressWithBumpS
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *FundManagerAddSupportedToken) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddSupportedTokenInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *FundManagerAddSupportedToken) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddSupportedTokenInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -429,22 +429,22 @@ func (inst *FundManagerAddSupportedToken) MustFindEventAuthorityAddress() (pda a
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *FundManagerAddSupportedToken) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddSupportedTokenInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(9)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *FundManagerAddSupportedToken) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerAddSupportedToken {
+func (inst *FundManagerAddSupportedTokenInstruction) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerAddSupportedTokenInstruction {
 	inst.AccountMetaSlice[10] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *FundManagerAddSupportedToken) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddSupportedTokenInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(10)
 }
 
-func (inst FundManagerAddSupportedToken) Build() *Instruction {
+func (inst FundManagerAddSupportedTokenInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_FundManagerAddSupportedToken,
@@ -454,14 +454,14 @@ func (inst FundManagerAddSupportedToken) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst FundManagerAddSupportedToken) ValidateAndBuild() (*Instruction, error) {
+func (inst FundManagerAddSupportedTokenInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *FundManagerAddSupportedToken) Validate() error {
+func (inst *FundManagerAddSupportedTokenInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.PricingSource == nil {
@@ -508,7 +508,7 @@ func (inst *FundManagerAddSupportedToken) Validate() error {
 	return nil
 }
 
-func (inst *FundManagerAddSupportedToken) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *FundManagerAddSupportedTokenInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -539,7 +539,7 @@ func (inst *FundManagerAddSupportedToken) EncodeToTree(parent ag_treeout.Branche
 		})
 }
 
-func (obj FundManagerAddSupportedToken) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj FundManagerAddSupportedTokenInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `PricingSource` param:
 	err = encoder.Encode(obj.PricingSource)
 	if err != nil {
@@ -547,7 +547,7 @@ func (obj FundManagerAddSupportedToken) MarshalWithEncoder(encoder *ag_binary.En
 	}
 	return nil
 }
-func (obj *FundManagerAddSupportedToken) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *FundManagerAddSupportedTokenInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `PricingSource`:
 	err = decoder.Decode(&obj.PricingSource)
 	if err != nil {
@@ -571,7 +571,7 @@ func NewFundManagerAddSupportedTokenInstruction(
 	supportedTokenReserveAccount ag_solanago.PublicKey,
 	supportedTokenTreasuryAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *FundManagerAddSupportedToken {
+	program ag_solanago.PublicKey) *FundManagerAddSupportedTokenInstruction {
 	return NewFundManagerAddSupportedTokenInstructionBuilder().
 		SetPricingSource(pricing_source).
 		SetFundManagerAccount(fundManager).

--- a/generated/restaking/fundmanageraddsupportedtoken_test.go
+++ b/generated/restaking/fundmanageraddsupportedtoken_test.go
@@ -18,7 +18,7 @@ func TestEncodeDecode_FundManagerAddSupportedToken(t *testing.T) {
 			{
 				{
 					{
-						params := new(FundManagerAddSupportedToken)
+						params := new(FundManagerAddSupportedTokenInstruction)
 						fu.Fuzz(params)
 						params.AccountMetaSlice = nil
 						tmp := new(TokenPricingSourceSPLStakePoolTuple)
@@ -27,7 +27,7 @@ func TestEncodeDecode_FundManagerAddSupportedToken(t *testing.T) {
 						buf := new(bytes.Buffer)
 						err := encodeT(*params, buf)
 						ag_require.NoError(t, err)
-						got := new(FundManagerAddSupportedToken)
+						got := new(FundManagerAddSupportedTokenInstruction)
 						err = decodeT(got, buf.Bytes())
 						got.AccountMetaSlice = nil
 						ag_require.NoError(t, err)
@@ -38,7 +38,7 @@ func TestEncodeDecode_FundManagerAddSupportedToken(t *testing.T) {
 						ag_require.Equal(t, params, got)
 					}
 					{
-						params := new(FundManagerAddSupportedToken)
+						params := new(FundManagerAddSupportedTokenInstruction)
 						fu.Fuzz(params)
 						params.AccountMetaSlice = nil
 						tmp := new(TokenPricingSourceMarinadeStakePoolTuple)
@@ -47,7 +47,7 @@ func TestEncodeDecode_FundManagerAddSupportedToken(t *testing.T) {
 						buf := new(bytes.Buffer)
 						err := encodeT(*params, buf)
 						ag_require.NoError(t, err)
-						got := new(FundManagerAddSupportedToken)
+						got := new(FundManagerAddSupportedTokenInstruction)
 						err = decodeT(got, buf.Bytes())
 						got.AccountMetaSlice = nil
 						ag_require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestEncodeDecode_FundManagerAddSupportedToken(t *testing.T) {
 						ag_require.Equal(t, params, got)
 					}
 					{
-						params := new(FundManagerAddSupportedToken)
+						params := new(FundManagerAddSupportedTokenInstruction)
 						fu.Fuzz(params)
 						params.AccountMetaSlice = nil
 						tmp := new(TokenPricingSourceJitoRestakingVaultTuple)
@@ -67,7 +67,7 @@ func TestEncodeDecode_FundManagerAddSupportedToken(t *testing.T) {
 						buf := new(bytes.Buffer)
 						err := encodeT(*params, buf)
 						ag_require.NoError(t, err)
-						got := new(FundManagerAddSupportedToken)
+						got := new(FundManagerAddSupportedTokenInstruction)
 						err = decodeT(got, buf.Bytes())
 						got.AccountMetaSlice = nil
 						ag_require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestEncodeDecode_FundManagerAddSupportedToken(t *testing.T) {
 						ag_require.Equal(t, params, got)
 					}
 					{
-						params := new(FundManagerAddSupportedToken)
+						params := new(FundManagerAddSupportedTokenInstruction)
 						fu.Fuzz(params)
 						params.AccountMetaSlice = nil
 						tmp := new(TokenPricingSourceFragmetricNormalizedTokenPoolTuple)
@@ -87,7 +87,7 @@ func TestEncodeDecode_FundManagerAddSupportedToken(t *testing.T) {
 						buf := new(bytes.Buffer)
 						err := encodeT(*params, buf)
 						ag_require.NoError(t, err)
-						got := new(FundManagerAddSupportedToken)
+						got := new(FundManagerAddSupportedTokenInstruction)
 						err = decodeT(got, buf.Bytes())
 						got.AccountMetaSlice = nil
 						ag_require.NoError(t, err)
@@ -98,7 +98,7 @@ func TestEncodeDecode_FundManagerAddSupportedToken(t *testing.T) {
 						ag_require.Equal(t, params, got)
 					}
 					{
-						params := new(FundManagerAddSupportedToken)
+						params := new(FundManagerAddSupportedTokenInstruction)
 						fu.Fuzz(params)
 						params.AccountMetaSlice = nil
 						tmp := new(TokenPricingSourceFragmetricRestakingFundTuple)
@@ -107,7 +107,7 @@ func TestEncodeDecode_FundManagerAddSupportedToken(t *testing.T) {
 						buf := new(bytes.Buffer)
 						err := encodeT(*params, buf)
 						ag_require.NoError(t, err)
-						got := new(FundManagerAddSupportedToken)
+						got := new(FundManagerAddSupportedTokenInstruction)
 						err = decodeT(got, buf.Bytes())
 						got.AccountMetaSlice = nil
 						ag_require.NoError(t, err)
@@ -118,7 +118,7 @@ func TestEncodeDecode_FundManagerAddSupportedToken(t *testing.T) {
 						ag_require.Equal(t, params, got)
 					}
 					{
-						params := new(FundManagerAddSupportedToken)
+						params := new(FundManagerAddSupportedTokenInstruction)
 						fu.Fuzz(params)
 						params.AccountMetaSlice = nil
 						tmp := new(TokenPricingSourceOrcaDEXLiquidityPoolTuple)
@@ -127,7 +127,7 @@ func TestEncodeDecode_FundManagerAddSupportedToken(t *testing.T) {
 						buf := new(bytes.Buffer)
 						err := encodeT(*params, buf)
 						ag_require.NoError(t, err)
-						got := new(FundManagerAddSupportedToken)
+						got := new(FundManagerAddSupportedTokenInstruction)
 						err = decodeT(got, buf.Bytes())
 						got.AccountMetaSlice = nil
 						ag_require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestEncodeDecode_FundManagerAddSupportedToken(t *testing.T) {
 						ag_require.Equal(t, params, got)
 					}
 					{
-						params := new(FundManagerAddSupportedToken)
+						params := new(FundManagerAddSupportedTokenInstruction)
 						fu.Fuzz(params)
 						params.AccountMetaSlice = nil
 						tmp := new(TokenPricingSourceSanctumSingleValidatorSPLStakePoolTuple)
@@ -147,7 +147,7 @@ func TestEncodeDecode_FundManagerAddSupportedToken(t *testing.T) {
 						buf := new(bytes.Buffer)
 						err := encodeT(*params, buf)
 						ag_require.NoError(t, err)
-						got := new(FundManagerAddSupportedToken)
+						got := new(FundManagerAddSupportedTokenInstruction)
 						err = decodeT(got, buf.Bytes())
 						got.AccountMetaSlice = nil
 						ag_require.NoError(t, err)

--- a/generated/restaking/fundmanageraddtokenswapstrategy.go
+++ b/generated/restaking/fundmanageraddtokenswapstrategy.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FundManagerAddTokenSwapStrategy is the `fund_manager_add_token_swap_strategy` instruction.
-type FundManagerAddTokenSwapStrategy struct {
+type FundManagerAddTokenSwapStrategyInstruction struct {
 	FromTokenMint *ag_solanago.PublicKey
 	ToTokenMint   *ag_solanago.PublicKey
 	SwapSource    *TokenSwapSource
@@ -28,9 +28,9 @@ type FundManagerAddTokenSwapStrategy struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewFundManagerAddTokenSwapStrategyInstructionBuilder creates a new `FundManagerAddTokenSwapStrategy` instruction builder.
-func NewFundManagerAddTokenSwapStrategyInstructionBuilder() *FundManagerAddTokenSwapStrategy {
-	nd := &FundManagerAddTokenSwapStrategy{
+// NewFundManagerAddTokenSwapStrategyInstructionBuilder creates a new `FundManagerAddTokenSwapStrategyInstruction` instruction builder.
+func NewFundManagerAddTokenSwapStrategyInstructionBuilder() *FundManagerAddTokenSwapStrategyInstruction {
+	nd := &FundManagerAddTokenSwapStrategyInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 5),
 	}
 	nd.AccountMetaSlice[0] = ag_solanago.Meta(Addresses["5UpLTLA7Wjqp7qdfjuTtPcUw3aVtbqFA5Mgm34mxPNg2"]).SIGNER()
@@ -38,52 +38,52 @@ func NewFundManagerAddTokenSwapStrategyInstructionBuilder() *FundManagerAddToken
 }
 
 // SetFromTokenMint sets the "from_token_mint" parameter.
-func (inst *FundManagerAddTokenSwapStrategy) SetFromTokenMint(from_token_mint ag_solanago.PublicKey) *FundManagerAddTokenSwapStrategy {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) SetFromTokenMint(from_token_mint ag_solanago.PublicKey) *FundManagerAddTokenSwapStrategyInstruction {
 	inst.FromTokenMint = &from_token_mint
 	return inst
 }
 
 // SetToTokenMint sets the "to_token_mint" parameter.
-func (inst *FundManagerAddTokenSwapStrategy) SetToTokenMint(to_token_mint ag_solanago.PublicKey) *FundManagerAddTokenSwapStrategy {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) SetToTokenMint(to_token_mint ag_solanago.PublicKey) *FundManagerAddTokenSwapStrategyInstruction {
 	inst.ToTokenMint = &to_token_mint
 	return inst
 }
 
 // SetSwapSource sets the "swap_source" parameter.
-func (inst *FundManagerAddTokenSwapStrategy) SetSwapSource(swap_source TokenSwapSource) *FundManagerAddTokenSwapStrategy {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) SetSwapSource(swap_source TokenSwapSource) *FundManagerAddTokenSwapStrategyInstruction {
 	inst.SwapSource = &swap_source
 	return inst
 }
 
 // SetFundManagerAccount sets the "fund_manager" account.
-func (inst *FundManagerAddTokenSwapStrategy) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerAddTokenSwapStrategy {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerAddTokenSwapStrategyInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(fundManager).SIGNER()
 	return inst
 }
 
 // GetFundManagerAccount gets the "fund_manager" account.
-func (inst *FundManagerAddTokenSwapStrategy) GetFundManagerAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) GetFundManagerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *FundManagerAddTokenSwapStrategy) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerAddTokenSwapStrategy {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerAddTokenSwapStrategyInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *FundManagerAddTokenSwapStrategy) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *FundManagerAddTokenSwapStrategy) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerAddTokenSwapStrategy {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerAddTokenSwapStrategyInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *FundManagerAddTokenSwapStrategy) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -100,12 +100,12 @@ func (inst *FundManagerAddTokenSwapStrategy) findFindFundAccountAddress(receiptT
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerAddTokenSwapStrategy) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerAddTokenSwapStrategy) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -114,12 +114,12 @@ func (inst *FundManagerAddTokenSwapStrategy) MustFindFundAccountAddressWithBumpS
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *FundManagerAddTokenSwapStrategy) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerAddTokenSwapStrategy) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -128,17 +128,17 @@ func (inst *FundManagerAddTokenSwapStrategy) MustFindFundAccountAddress(receiptT
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *FundManagerAddTokenSwapStrategy) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *FundManagerAddTokenSwapStrategy) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerAddTokenSwapStrategy {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerAddTokenSwapStrategyInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *FundManagerAddTokenSwapStrategy) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -153,12 +153,12 @@ func (inst *FundManagerAddTokenSwapStrategy) findFindEventAuthorityAddress(known
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *FundManagerAddTokenSwapStrategy) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *FundManagerAddTokenSwapStrategy) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -167,12 +167,12 @@ func (inst *FundManagerAddTokenSwapStrategy) MustFindEventAuthorityAddressWithBu
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *FundManagerAddTokenSwapStrategy) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *FundManagerAddTokenSwapStrategy) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -181,22 +181,22 @@ func (inst *FundManagerAddTokenSwapStrategy) MustFindEventAuthorityAddress() (pd
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *FundManagerAddTokenSwapStrategy) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *FundManagerAddTokenSwapStrategy) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerAddTokenSwapStrategy {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerAddTokenSwapStrategyInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *FundManagerAddTokenSwapStrategy) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
-func (inst FundManagerAddTokenSwapStrategy) Build() *Instruction {
+func (inst FundManagerAddTokenSwapStrategyInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_FundManagerAddTokenSwapStrategy,
@@ -206,14 +206,14 @@ func (inst FundManagerAddTokenSwapStrategy) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst FundManagerAddTokenSwapStrategy) ValidateAndBuild() (*Instruction, error) {
+func (inst FundManagerAddTokenSwapStrategyInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *FundManagerAddTokenSwapStrategy) Validate() error {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.FromTokenMint == nil {
@@ -248,7 +248,7 @@ func (inst *FundManagerAddTokenSwapStrategy) Validate() error {
 	return nil
 }
 
-func (inst *FundManagerAddTokenSwapStrategy) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *FundManagerAddTokenSwapStrategyInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -275,7 +275,7 @@ func (inst *FundManagerAddTokenSwapStrategy) EncodeToTree(parent ag_treeout.Bran
 		})
 }
 
-func (obj FundManagerAddTokenSwapStrategy) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj FundManagerAddTokenSwapStrategyInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `FromTokenMint` param:
 	err = encoder.Encode(obj.FromTokenMint)
 	if err != nil {
@@ -293,7 +293,7 @@ func (obj FundManagerAddTokenSwapStrategy) MarshalWithEncoder(encoder *ag_binary
 	}
 	return nil
 }
-func (obj *FundManagerAddTokenSwapStrategy) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *FundManagerAddTokenSwapStrategyInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `FromTokenMint`:
 	err = decoder.Decode(&obj.FromTokenMint)
 	if err != nil {
@@ -323,7 +323,7 @@ func NewFundManagerAddTokenSwapStrategyInstruction(
 	receiptTokenMint ag_solanago.PublicKey,
 	fundAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *FundManagerAddTokenSwapStrategy {
+	program ag_solanago.PublicKey) *FundManagerAddTokenSwapStrategyInstruction {
 	return NewFundManagerAddTokenSwapStrategyInstructionBuilder().
 		SetFromTokenMint(from_token_mint).
 		SetToTokenMint(to_token_mint).

--- a/generated/restaking/fundmanageraddtokenswapstrategy_test.go
+++ b/generated/restaking/fundmanageraddtokenswapstrategy_test.go
@@ -18,7 +18,7 @@ func TestEncodeDecode_FundManagerAddTokenSwapStrategy(t *testing.T) {
 			{
 				{
 					{
-						params := new(FundManagerAddTokenSwapStrategy)
+						params := new(FundManagerAddTokenSwapStrategyInstruction)
 						fu.Fuzz(params)
 						params.AccountMetaSlice = nil
 						tmp := new(TokenSwapSourceOrcaDEXLiquidityPoolTuple)
@@ -27,7 +27,7 @@ func TestEncodeDecode_FundManagerAddTokenSwapStrategy(t *testing.T) {
 						buf := new(bytes.Buffer)
 						err := encodeT(*params, buf)
 						ag_require.NoError(t, err)
-						got := new(FundManagerAddTokenSwapStrategy)
+						got := new(FundManagerAddTokenSwapStrategyInstruction)
 						err = decodeT(got, buf.Bytes())
 						got.AccountMetaSlice = nil
 						ag_require.NoError(t, err)

--- a/generated/restaking/fundmanagercloserewardpool.go
+++ b/generated/restaking/fundmanagercloserewardpool.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FundManagerCloseRewardPool is the `fund_manager_close_reward_pool` instruction.
-type FundManagerCloseRewardPool struct {
+type FundManagerCloseRewardPoolInstruction struct {
 	RewardPoolId *uint8
 
 	// [0] = [SIGNER] fund_manager
@@ -26,9 +26,9 @@ type FundManagerCloseRewardPool struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewFundManagerCloseRewardPoolInstructionBuilder creates a new `FundManagerCloseRewardPool` instruction builder.
-func NewFundManagerCloseRewardPoolInstructionBuilder() *FundManagerCloseRewardPool {
-	nd := &FundManagerCloseRewardPool{
+// NewFundManagerCloseRewardPoolInstructionBuilder creates a new `FundManagerCloseRewardPoolInstruction` instruction builder.
+func NewFundManagerCloseRewardPoolInstructionBuilder() *FundManagerCloseRewardPoolInstruction {
+	nd := &FundManagerCloseRewardPoolInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 5),
 	}
 	nd.AccountMetaSlice[0] = ag_solanago.Meta(Addresses["5UpLTLA7Wjqp7qdfjuTtPcUw3aVtbqFA5Mgm34mxPNg2"]).SIGNER()
@@ -36,40 +36,40 @@ func NewFundManagerCloseRewardPoolInstructionBuilder() *FundManagerCloseRewardPo
 }
 
 // SetRewardPoolId sets the "reward_pool_id" parameter.
-func (inst *FundManagerCloseRewardPool) SetRewardPoolId(reward_pool_id uint8) *FundManagerCloseRewardPool {
+func (inst *FundManagerCloseRewardPoolInstruction) SetRewardPoolId(reward_pool_id uint8) *FundManagerCloseRewardPoolInstruction {
 	inst.RewardPoolId = &reward_pool_id
 	return inst
 }
 
 // SetFundManagerAccount sets the "fund_manager" account.
-func (inst *FundManagerCloseRewardPool) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerCloseRewardPool {
+func (inst *FundManagerCloseRewardPoolInstruction) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerCloseRewardPoolInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(fundManager).SIGNER()
 	return inst
 }
 
 // GetFundManagerAccount gets the "fund_manager" account.
-func (inst *FundManagerCloseRewardPool) GetFundManagerAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerCloseRewardPoolInstruction) GetFundManagerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *FundManagerCloseRewardPool) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerCloseRewardPool {
+func (inst *FundManagerCloseRewardPoolInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerCloseRewardPoolInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *FundManagerCloseRewardPool) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerCloseRewardPoolInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *FundManagerCloseRewardPool) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *FundManagerCloseRewardPool {
+func (inst *FundManagerCloseRewardPoolInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *FundManagerCloseRewardPoolInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *FundManagerCloseRewardPool) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerCloseRewardPoolInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -86,12 +86,12 @@ func (inst *FundManagerCloseRewardPool) findFindRewardAccountAddress(receiptToke
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerCloseRewardPool) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerCloseRewardPoolInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerCloseRewardPool) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerCloseRewardPoolInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -100,12 +100,12 @@ func (inst *FundManagerCloseRewardPool) MustFindRewardAccountAddressWithBumpSeed
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *FundManagerCloseRewardPool) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerCloseRewardPoolInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerCloseRewardPool) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerCloseRewardPoolInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -114,17 +114,17 @@ func (inst *FundManagerCloseRewardPool) MustFindRewardAccountAddress(receiptToke
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *FundManagerCloseRewardPool) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerCloseRewardPoolInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *FundManagerCloseRewardPool) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerCloseRewardPool {
+func (inst *FundManagerCloseRewardPoolInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerCloseRewardPoolInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *FundManagerCloseRewardPool) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerCloseRewardPoolInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -139,12 +139,12 @@ func (inst *FundManagerCloseRewardPool) findFindEventAuthorityAddress(knownBumpS
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *FundManagerCloseRewardPool) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerCloseRewardPoolInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *FundManagerCloseRewardPool) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerCloseRewardPoolInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -153,12 +153,12 @@ func (inst *FundManagerCloseRewardPool) MustFindEventAuthorityAddressWithBumpSee
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *FundManagerCloseRewardPool) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerCloseRewardPoolInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *FundManagerCloseRewardPool) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *FundManagerCloseRewardPoolInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -167,22 +167,22 @@ func (inst *FundManagerCloseRewardPool) MustFindEventAuthorityAddress() (pda ag_
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *FundManagerCloseRewardPool) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerCloseRewardPoolInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *FundManagerCloseRewardPool) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerCloseRewardPool {
+func (inst *FundManagerCloseRewardPoolInstruction) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerCloseRewardPoolInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *FundManagerCloseRewardPool) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerCloseRewardPoolInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
-func (inst FundManagerCloseRewardPool) Build() *Instruction {
+func (inst FundManagerCloseRewardPoolInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_FundManagerCloseRewardPool,
@@ -192,14 +192,14 @@ func (inst FundManagerCloseRewardPool) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst FundManagerCloseRewardPool) ValidateAndBuild() (*Instruction, error) {
+func (inst FundManagerCloseRewardPoolInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *FundManagerCloseRewardPool) Validate() error {
+func (inst *FundManagerCloseRewardPoolInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.RewardPoolId == nil {
@@ -228,7 +228,7 @@ func (inst *FundManagerCloseRewardPool) Validate() error {
 	return nil
 }
 
-func (inst *FundManagerCloseRewardPool) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *FundManagerCloseRewardPoolInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -253,7 +253,7 @@ func (inst *FundManagerCloseRewardPool) EncodeToTree(parent ag_treeout.Branches)
 		})
 }
 
-func (obj FundManagerCloseRewardPool) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj FundManagerCloseRewardPoolInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `RewardPoolId` param:
 	err = encoder.Encode(obj.RewardPoolId)
 	if err != nil {
@@ -261,7 +261,7 @@ func (obj FundManagerCloseRewardPool) MarshalWithEncoder(encoder *ag_binary.Enco
 	}
 	return nil
 }
-func (obj *FundManagerCloseRewardPool) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *FundManagerCloseRewardPoolInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `RewardPoolId`:
 	err = decoder.Decode(&obj.RewardPoolId)
 	if err != nil {
@@ -279,7 +279,7 @@ func NewFundManagerCloseRewardPoolInstruction(
 	receiptTokenMint ag_solanago.PublicKey,
 	rewardAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *FundManagerCloseRewardPool {
+	program ag_solanago.PublicKey) *FundManagerCloseRewardPoolInstruction {
 	return NewFundManagerCloseRewardPoolInstructionBuilder().
 		SetRewardPoolId(reward_pool_id).
 		SetFundManagerAccount(fundManager).

--- a/generated/restaking/fundmanagercloserewardpool_test.go
+++ b/generated/restaking/fundmanagercloserewardpool_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_FundManagerCloseRewardPool(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("FundManagerCloseRewardPool"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(FundManagerCloseRewardPool)
+				params := new(FundManagerCloseRewardPoolInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(FundManagerCloseRewardPool)
+				got := new(FundManagerCloseRewardPoolInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/fundmanagerinitializefundjitorestakingvault.go
+++ b/generated/restaking/fundmanagerinitializefundjitorestakingvault.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FundManagerInitializeFundJitoRestakingVault is the `fund_manager_initialize_fund_jito_restaking_vault` instruction.
-type FundManagerInitializeFundJitoRestakingVault struct {
+type FundManagerInitializeFundJitoRestakingVaultInstruction struct {
 
 	// [0] = [SIGNER] fund_manager
 	//
@@ -47,9 +47,9 @@ type FundManagerInitializeFundJitoRestakingVault struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewFundManagerInitializeFundJitoRestakingVaultInstructionBuilder creates a new `FundManagerInitializeFundJitoRestakingVault` instruction builder.
-func NewFundManagerInitializeFundJitoRestakingVaultInstructionBuilder() *FundManagerInitializeFundJitoRestakingVault {
-	nd := &FundManagerInitializeFundJitoRestakingVault{
+// NewFundManagerInitializeFundJitoRestakingVaultInstructionBuilder creates a new `FundManagerInitializeFundJitoRestakingVaultInstruction` instruction builder.
+func NewFundManagerInitializeFundJitoRestakingVaultInstructionBuilder() *FundManagerInitializeFundJitoRestakingVaultInstruction {
+	nd := &FundManagerInitializeFundJitoRestakingVaultInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 16),
 	}
 	nd.AccountMetaSlice[0] = ag_solanago.Meta(Addresses["5UpLTLA7Wjqp7qdfjuTtPcUw3aVtbqFA5Mgm34mxPNg2"]).SIGNER()
@@ -61,34 +61,34 @@ func NewFundManagerInitializeFundJitoRestakingVaultInstructionBuilder() *FundMan
 }
 
 // SetFundManagerAccount sets the "fund_manager" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVault {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(fundManager).SIGNER()
 	return inst
 }
 
 // GetFundManagerAccount gets the "fund_manager" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) GetFundManagerAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) GetFundManagerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVault {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVault {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -105,12 +105,12 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) findFindFundAccountAddr
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundJitoRestakingVault) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -119,12 +119,12 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindFundAccountAddr
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *FundManagerInitializeFundJitoRestakingVault) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -133,17 +133,17 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindFundAccountAddr
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetFundReserveAccountAccount sets the "fund_reserve_account" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVault {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(fundReserveAccount)
 	return inst
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_reserve
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x72), byte(0x65), byte(0x73), byte(0x65), byte(0x72), byte(0x76), byte(0x65)})
@@ -160,12 +160,12 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) findFindFundReserveAcco
 }
 
 // FindFundReserveAccountAddressWithBumpSeed calculates FundReserveAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundJitoRestakingVault) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -174,12 +174,12 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindFundReserveAcco
 }
 
 // FindFundReserveAccountAddress finds FundReserveAccount account address with given seeds.
-func (inst *FundManagerInitializeFundJitoRestakingVault) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -188,94 +188,94 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindFundReserveAcco
 }
 
 // GetFundReserveAccountAccount gets the "fund_reserve_account" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVault {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetVaultProgramAccount sets the "vault_program" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) SetVaultProgramAccount(vaultProgram ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVault {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) SetVaultProgramAccount(vaultProgram ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(vaultProgram)
 	return inst
 }
 
 // GetVaultProgramAccount gets the "vault_program" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) GetVaultProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) GetVaultProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetVaultAccountAccount sets the "vault_account" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) SetVaultAccountAccount(vaultAccount ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVault {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) SetVaultAccountAccount(vaultAccount ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(vaultAccount)
 	return inst
 }
 
 // GetVaultAccountAccount gets the "vault_account" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) GetVaultAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) GetVaultAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetVaultReceiptTokenMintAccount sets the "vault_receipt_token_mint" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) SetVaultReceiptTokenMintAccount(vaultReceiptTokenMint ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVault {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) SetVaultReceiptTokenMintAccount(vaultReceiptTokenMint ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(vaultReceiptTokenMint)
 	return inst
 }
 
 // GetVaultReceiptTokenMintAccount gets the "vault_receipt_token_mint" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) GetVaultReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) GetVaultReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetVaultReceiptTokenProgramAccount sets the "vault_receipt_token_program" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) SetVaultReceiptTokenProgramAccount(vaultReceiptTokenProgram ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVault {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) SetVaultReceiptTokenProgramAccount(vaultReceiptTokenProgram ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(vaultReceiptTokenProgram)
 	return inst
 }
 
 // GetVaultReceiptTokenProgramAccount gets the "vault_receipt_token_program" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) GetVaultReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) GetVaultReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
 // SetVaultSupportedTokenMintAccount sets the "vault_supported_token_mint" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) SetVaultSupportedTokenMintAccount(vaultSupportedTokenMint ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVault {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) SetVaultSupportedTokenMintAccount(vaultSupportedTokenMint ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultInstruction {
 	inst.AccountMetaSlice[9] = ag_solanago.Meta(vaultSupportedTokenMint)
 	return inst
 }
 
 // GetVaultSupportedTokenMintAccount gets the "vault_supported_token_mint" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) GetVaultSupportedTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) GetVaultSupportedTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(9)
 }
 
 // SetVaultSupportedTokenProgramAccount sets the "vault_supported_token_program" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) SetVaultSupportedTokenProgramAccount(vaultSupportedTokenProgram ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVault {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) SetVaultSupportedTokenProgramAccount(vaultSupportedTokenProgram ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultInstruction {
 	inst.AccountMetaSlice[10] = ag_solanago.Meta(vaultSupportedTokenProgram)
 	return inst
 }
 
 // GetVaultSupportedTokenProgramAccount gets the "vault_supported_token_program" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) GetVaultSupportedTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) GetVaultSupportedTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(10)
 }
 
 // SetFundVaultReceiptTokenAccountAccount sets the "fund_vault_receipt_token_account" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) SetFundVaultReceiptTokenAccountAccount(fundVaultReceiptTokenAccount ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVault {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) SetFundVaultReceiptTokenAccountAccount(fundVaultReceiptTokenAccount ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultInstruction {
 	inst.AccountMetaSlice[11] = ag_solanago.Meta(fundVaultReceiptTokenAccount)
 	return inst
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) findFindFundVaultReceiptTokenAccountAddress(fundReserveAccount ag_solanago.PublicKey, vaultReceiptTokenProgram ag_solanago.PublicKey, vaultReceiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) findFindFundVaultReceiptTokenAccountAddress(fundReserveAccount ag_solanago.PublicKey, vaultReceiptTokenProgram ag_solanago.PublicKey, vaultReceiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: fundReserveAccount
 	seeds = append(seeds, fundReserveAccount.Bytes())
@@ -296,12 +296,12 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) findFindFundVaultReceip
 }
 
 // FindFundVaultReceiptTokenAccountAddressWithBumpSeed calculates FundVaultReceiptTokenAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundJitoRestakingVault) FindFundVaultReceiptTokenAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, vaultReceiptTokenProgram ag_solanago.PublicKey, vaultReceiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) FindFundVaultReceiptTokenAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, vaultReceiptTokenProgram ag_solanago.PublicKey, vaultReceiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundVaultReceiptTokenAccountAddress(fundReserveAccount, vaultReceiptTokenProgram, vaultReceiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindFundVaultReceiptTokenAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, vaultReceiptTokenProgram ag_solanago.PublicKey, vaultReceiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) MustFindFundVaultReceiptTokenAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, vaultReceiptTokenProgram ag_solanago.PublicKey, vaultReceiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundVaultReceiptTokenAccountAddress(fundReserveAccount, vaultReceiptTokenProgram, vaultReceiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -310,12 +310,12 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindFundVaultReceip
 }
 
 // FindFundVaultReceiptTokenAccountAddress finds FundVaultReceiptTokenAccount account address with given seeds.
-func (inst *FundManagerInitializeFundJitoRestakingVault) FindFundVaultReceiptTokenAccountAddress(fundReserveAccount ag_solanago.PublicKey, vaultReceiptTokenProgram ag_solanago.PublicKey, vaultReceiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) FindFundVaultReceiptTokenAccountAddress(fundReserveAccount ag_solanago.PublicKey, vaultReceiptTokenProgram ag_solanago.PublicKey, vaultReceiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundVaultReceiptTokenAccountAddress(fundReserveAccount, vaultReceiptTokenProgram, vaultReceiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindFundVaultReceiptTokenAccountAddress(fundReserveAccount ag_solanago.PublicKey, vaultReceiptTokenProgram ag_solanago.PublicKey, vaultReceiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) MustFindFundVaultReceiptTokenAccountAddress(fundReserveAccount ag_solanago.PublicKey, vaultReceiptTokenProgram ag_solanago.PublicKey, vaultReceiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundVaultReceiptTokenAccountAddress(fundReserveAccount, vaultReceiptTokenProgram, vaultReceiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -324,17 +324,17 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindFundVaultReceip
 }
 
 // GetFundVaultReceiptTokenAccountAccount gets the "fund_vault_receipt_token_account" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) GetFundVaultReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) GetFundVaultReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(11)
 }
 
 // SetFundVaultSupportedTokenAccountAccount sets the "fund_vault_supported_token_account" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) SetFundVaultSupportedTokenAccountAccount(fundVaultSupportedTokenAccount ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVault {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) SetFundVaultSupportedTokenAccountAccount(fundVaultSupportedTokenAccount ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultInstruction {
 	inst.AccountMetaSlice[12] = ag_solanago.Meta(fundVaultSupportedTokenAccount)
 	return inst
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) findFindFundVaultSupportedTokenAccountAddress(fundReserveAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) findFindFundVaultSupportedTokenAccountAddress(fundReserveAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: fundReserveAccount
 	seeds = append(seeds, fundReserveAccount.Bytes())
@@ -355,12 +355,12 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) findFindFundVaultSuppor
 }
 
 // FindFundVaultSupportedTokenAccountAddressWithBumpSeed calculates FundVaultSupportedTokenAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundJitoRestakingVault) FindFundVaultSupportedTokenAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) FindFundVaultSupportedTokenAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundVaultSupportedTokenAccountAddress(fundReserveAccount, vaultSupportedTokenProgram, vaultSupportedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindFundVaultSupportedTokenAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) MustFindFundVaultSupportedTokenAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundVaultSupportedTokenAccountAddress(fundReserveAccount, vaultSupportedTokenProgram, vaultSupportedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -369,12 +369,12 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindFundVaultSuppor
 }
 
 // FindFundVaultSupportedTokenAccountAddress finds FundVaultSupportedTokenAccount account address with given seeds.
-func (inst *FundManagerInitializeFundJitoRestakingVault) FindFundVaultSupportedTokenAccountAddress(fundReserveAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) FindFundVaultSupportedTokenAccountAddress(fundReserveAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundVaultSupportedTokenAccountAddress(fundReserveAccount, vaultSupportedTokenProgram, vaultSupportedTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindFundVaultSupportedTokenAccountAddress(fundReserveAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) MustFindFundVaultSupportedTokenAccountAddress(fundReserveAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundVaultSupportedTokenAccountAddress(fundReserveAccount, vaultSupportedTokenProgram, vaultSupportedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -383,17 +383,17 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindFundVaultSuppor
 }
 
 // GetFundVaultSupportedTokenAccountAccount gets the "fund_vault_supported_token_account" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) GetFundVaultSupportedTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) GetFundVaultSupportedTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(12)
 }
 
 // SetVaultVaultSupportedTokenAccountAccount sets the "vault_vault_supported_token_account" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) SetVaultVaultSupportedTokenAccountAccount(vaultVaultSupportedTokenAccount ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVault {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) SetVaultVaultSupportedTokenAccountAccount(vaultVaultSupportedTokenAccount ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultInstruction {
 	inst.AccountMetaSlice[13] = ag_solanago.Meta(vaultVaultSupportedTokenAccount)
 	return inst
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) findFindVaultVaultSupportedTokenAccountAddress(vaultAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) findFindVaultVaultSupportedTokenAccountAddress(vaultAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: vaultAccount
 	seeds = append(seeds, vaultAccount.Bytes())
@@ -414,12 +414,12 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) findFindVaultVaultSuppo
 }
 
 // FindVaultVaultSupportedTokenAccountAddressWithBumpSeed calculates VaultVaultSupportedTokenAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundJitoRestakingVault) FindVaultVaultSupportedTokenAccountAddressWithBumpSeed(vaultAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) FindVaultVaultSupportedTokenAccountAddressWithBumpSeed(vaultAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindVaultVaultSupportedTokenAccountAddress(vaultAccount, vaultSupportedTokenProgram, vaultSupportedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindVaultVaultSupportedTokenAccountAddressWithBumpSeed(vaultAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) MustFindVaultVaultSupportedTokenAccountAddressWithBumpSeed(vaultAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindVaultVaultSupportedTokenAccountAddress(vaultAccount, vaultSupportedTokenProgram, vaultSupportedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -428,12 +428,12 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindVaultVaultSuppo
 }
 
 // FindVaultVaultSupportedTokenAccountAddress finds VaultVaultSupportedTokenAccount account address with given seeds.
-func (inst *FundManagerInitializeFundJitoRestakingVault) FindVaultVaultSupportedTokenAccountAddress(vaultAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) FindVaultVaultSupportedTokenAccountAddress(vaultAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindVaultVaultSupportedTokenAccountAddress(vaultAccount, vaultSupportedTokenProgram, vaultSupportedTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindVaultVaultSupportedTokenAccountAddress(vaultAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) MustFindVaultVaultSupportedTokenAccountAddress(vaultAccount ag_solanago.PublicKey, vaultSupportedTokenProgram ag_solanago.PublicKey, vaultSupportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindVaultVaultSupportedTokenAccountAddress(vaultAccount, vaultSupportedTokenProgram, vaultSupportedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -442,17 +442,17 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindVaultVaultSuppo
 }
 
 // GetVaultVaultSupportedTokenAccountAccount gets the "vault_vault_supported_token_account" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) GetVaultVaultSupportedTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) GetVaultVaultSupportedTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(13)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVault {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultInstruction {
 	inst.AccountMetaSlice[14] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -467,12 +467,12 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) findFindEventAuthorityA
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundJitoRestakingVault) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -481,12 +481,12 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindEventAuthorityA
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *FundManagerInitializeFundJitoRestakingVault) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -495,22 +495,22 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) MustFindEventAuthorityA
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(14)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVault {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultInstruction {
 	inst.AccountMetaSlice[15] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *FundManagerInitializeFundJitoRestakingVault) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(15)
 }
 
-func (inst FundManagerInitializeFundJitoRestakingVault) Build() *Instruction {
+func (inst FundManagerInitializeFundJitoRestakingVaultInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_FundManagerInitializeFundJitoRestakingVault,
@@ -520,14 +520,14 @@ func (inst FundManagerInitializeFundJitoRestakingVault) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst FundManagerInitializeFundJitoRestakingVault) ValidateAndBuild() (*Instruction, error) {
+func (inst FundManagerInitializeFundJitoRestakingVaultInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) Validate() error {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -582,7 +582,7 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) Validate() error {
 	return nil
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVault) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -616,10 +616,10 @@ func (inst *FundManagerInitializeFundJitoRestakingVault) EncodeToTree(parent ag_
 		})
 }
 
-func (obj FundManagerInitializeFundJitoRestakingVault) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj FundManagerInitializeFundJitoRestakingVaultInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *FundManagerInitializeFundJitoRestakingVault) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *FundManagerInitializeFundJitoRestakingVaultInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -641,7 +641,7 @@ func NewFundManagerInitializeFundJitoRestakingVaultInstruction(
 	fundVaultSupportedTokenAccount ag_solanago.PublicKey,
 	vaultVaultSupportedTokenAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVault {
+	program ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultInstruction {
 	return NewFundManagerInitializeFundJitoRestakingVaultInstructionBuilder().
 		SetFundManagerAccount(fundManager).
 		SetSystemProgramAccount(systemProgram).

--- a/generated/restaking/fundmanagerinitializefundjitorestakingvault_test.go
+++ b/generated/restaking/fundmanagerinitializefundjitorestakingvault_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_FundManagerInitializeFundJitoRestakingVault(t *testing.T) 
 	for i := 0; i < 1; i++ {
 		t.Run("FundManagerInitializeFundJitoRestakingVault"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(FundManagerInitializeFundJitoRestakingVault)
+				params := new(FundManagerInitializeFundJitoRestakingVaultInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(FundManagerInitializeFundJitoRestakingVault)
+				got := new(FundManagerInitializeFundJitoRestakingVaultInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/fundmanagerinitializefundjitorestakingvaultdelegation.go
+++ b/generated/restaking/fundmanagerinitializefundjitorestakingvaultdelegation.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FundManagerInitializeFundJitoRestakingVaultDelegation is the `fund_manager_initialize_fund_jito_restaking_vault_delegation` instruction.
-type FundManagerInitializeFundJitoRestakingVaultDelegation struct {
+type FundManagerInitializeFundJitoRestakingVaultDelegationInstruction struct {
 
 	// [0] = [SIGNER] fund_manager
 	//
@@ -31,9 +31,9 @@ type FundManagerInitializeFundJitoRestakingVaultDelegation struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewFundManagerInitializeFundJitoRestakingVaultDelegationInstructionBuilder creates a new `FundManagerInitializeFundJitoRestakingVaultDelegation` instruction builder.
-func NewFundManagerInitializeFundJitoRestakingVaultDelegationInstructionBuilder() *FundManagerInitializeFundJitoRestakingVaultDelegation {
-	nd := &FundManagerInitializeFundJitoRestakingVaultDelegation{
+// NewFundManagerInitializeFundJitoRestakingVaultDelegationInstructionBuilder creates a new `FundManagerInitializeFundJitoRestakingVaultDelegationInstruction` instruction builder.
+func NewFundManagerInitializeFundJitoRestakingVaultDelegationInstructionBuilder() *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction {
+	nd := &FundManagerInitializeFundJitoRestakingVaultDelegationInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 8),
 	}
 	nd.AccountMetaSlice[0] = ag_solanago.Meta(Addresses["5UpLTLA7Wjqp7qdfjuTtPcUw3aVtbqFA5Mgm34mxPNg2"]).SIGNER()
@@ -41,23 +41,23 @@ func NewFundManagerInitializeFundJitoRestakingVaultDelegationInstructionBuilder(
 }
 
 // SetFundManagerAccount sets the "fund_manager" account.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultDelegation {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(fundManager).SIGNER()
 	return inst
 }
 
 // GetFundManagerAccount gets the "fund_manager" account.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) GetFundManagerAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) GetFundManagerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultDelegation {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -74,12 +74,12 @@ func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) findFindFundA
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -88,12 +88,12 @@ func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) MustFindFundA
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -102,50 +102,50 @@ func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) MustFindFundA
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultDelegation {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetVaultAccountAccount sets the "vault_account" account.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) SetVaultAccountAccount(vaultAccount ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultDelegation {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) SetVaultAccountAccount(vaultAccount ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(vaultAccount)
 	return inst
 }
 
 // GetVaultAccountAccount gets the "vault_account" account.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) GetVaultAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) GetVaultAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetOperatorAccountAccount sets the "operator_account" account.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) SetOperatorAccountAccount(operatorAccount ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultDelegation {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) SetOperatorAccountAccount(operatorAccount ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(operatorAccount)
 	return inst
 }
 
 // GetOperatorAccountAccount gets the "operator_account" account.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) GetOperatorAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) GetOperatorAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetVaultOperatorDelegationAccount sets the "vault_operator_delegation" account.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) SetVaultOperatorDelegationAccount(vaultOperatorDelegation ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultDelegation {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) SetVaultOperatorDelegationAccount(vaultOperatorDelegation ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(vaultOperatorDelegation)
 	return inst
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) findFindVaultOperatorDelegationAddress(vaultAccount ag_solanago.PublicKey, operatorAccount ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) findFindVaultOperatorDelegationAddress(vaultAccount ag_solanago.PublicKey, operatorAccount ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: vault_operator_delegation
 	seeds = append(seeds, []byte{byte(0x76), byte(0x61), byte(0x75), byte(0x6c), byte(0x74), byte(0x5f), byte(0x6f), byte(0x70), byte(0x65), byte(0x72), byte(0x61), byte(0x74), byte(0x6f), byte(0x72), byte(0x5f), byte(0x64), byte(0x65), byte(0x6c), byte(0x65), byte(0x67), byte(0x61), byte(0x74), byte(0x69), byte(0x6f), byte(0x6e)})
@@ -166,12 +166,12 @@ func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) findFindVault
 }
 
 // FindVaultOperatorDelegationAddressWithBumpSeed calculates VaultOperatorDelegation account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) FindVaultOperatorDelegationAddressWithBumpSeed(vaultAccount ag_solanago.PublicKey, operatorAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) FindVaultOperatorDelegationAddressWithBumpSeed(vaultAccount ag_solanago.PublicKey, operatorAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindVaultOperatorDelegationAddress(vaultAccount, operatorAccount, bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) MustFindVaultOperatorDelegationAddressWithBumpSeed(vaultAccount ag_solanago.PublicKey, operatorAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) MustFindVaultOperatorDelegationAddressWithBumpSeed(vaultAccount ag_solanago.PublicKey, operatorAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindVaultOperatorDelegationAddress(vaultAccount, operatorAccount, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -180,12 +180,12 @@ func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) MustFindVault
 }
 
 // FindVaultOperatorDelegationAddress finds VaultOperatorDelegation account address with given seeds.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) FindVaultOperatorDelegationAddress(vaultAccount ag_solanago.PublicKey, operatorAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) FindVaultOperatorDelegationAddress(vaultAccount ag_solanago.PublicKey, operatorAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindVaultOperatorDelegationAddress(vaultAccount, operatorAccount, 0)
 	return
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) MustFindVaultOperatorDelegationAddress(vaultAccount ag_solanago.PublicKey, operatorAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) MustFindVaultOperatorDelegationAddress(vaultAccount ag_solanago.PublicKey, operatorAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindVaultOperatorDelegationAddress(vaultAccount, operatorAccount, 0)
 	if err != nil {
 		panic(err)
@@ -194,17 +194,17 @@ func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) MustFindVault
 }
 
 // GetVaultOperatorDelegationAccount gets the "vault_operator_delegation" account.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) GetVaultOperatorDelegationAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) GetVaultOperatorDelegationAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultDelegation {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -219,12 +219,12 @@ func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) findFindEvent
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -233,12 +233,12 @@ func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) MustFindEvent
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -247,22 +247,22 @@ func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) MustFindEvent
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultDelegation {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
-func (inst FundManagerInitializeFundJitoRestakingVaultDelegation) Build() *Instruction {
+func (inst FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_FundManagerInitializeFundJitoRestakingVaultDelegation,
@@ -272,14 +272,14 @@ func (inst FundManagerInitializeFundJitoRestakingVaultDelegation) Build() *Instr
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst FundManagerInitializeFundJitoRestakingVaultDelegation) ValidateAndBuild() (*Instruction, error) {
+func (inst FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) Validate() error {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -310,7 +310,7 @@ func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) Validate() er
 	return nil
 }
 
-func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -336,10 +336,10 @@ func (inst *FundManagerInitializeFundJitoRestakingVaultDelegation) EncodeToTree(
 		})
 }
 
-func (obj FundManagerInitializeFundJitoRestakingVaultDelegation) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *FundManagerInitializeFundJitoRestakingVaultDelegation) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -353,7 +353,7 @@ func NewFundManagerInitializeFundJitoRestakingVaultDelegationInstruction(
 	operatorAccount ag_solanago.PublicKey,
 	vaultOperatorDelegation ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultDelegation {
+	program ag_solanago.PublicKey) *FundManagerInitializeFundJitoRestakingVaultDelegationInstruction {
 	return NewFundManagerInitializeFundJitoRestakingVaultDelegationInstructionBuilder().
 		SetFundManagerAccount(fundManager).
 		SetFundAccountAccount(fundAccount).

--- a/generated/restaking/fundmanagerinitializefundjitorestakingvaultdelegation_test.go
+++ b/generated/restaking/fundmanagerinitializefundjitorestakingvaultdelegation_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_FundManagerInitializeFundJitoRestakingVaultDelegation(t *t
 	for i := 0; i < 1; i++ {
 		t.Run("FundManagerInitializeFundJitoRestakingVaultDelegation"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(FundManagerInitializeFundJitoRestakingVaultDelegation)
+				params := new(FundManagerInitializeFundJitoRestakingVaultDelegationInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(FundManagerInitializeFundJitoRestakingVaultDelegation)
+				got := new(FundManagerInitializeFundJitoRestakingVaultDelegationInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/fundmanagerinitializefundnormalizedtoken.go
+++ b/generated/restaking/fundmanagerinitializefundnormalizedtoken.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FundManagerInitializeFundNormalizedToken is the `fund_manager_initialize_fund_normalized_token` instruction.
-type FundManagerInitializeFundNormalizedToken struct {
+type FundManagerInitializeFundNormalizedTokenInstruction struct {
 
 	// [0] = [SIGNER] fund_manager
 	//
@@ -37,9 +37,9 @@ type FundManagerInitializeFundNormalizedToken struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewFundManagerInitializeFundNormalizedTokenInstructionBuilder creates a new `FundManagerInitializeFundNormalizedToken` instruction builder.
-func NewFundManagerInitializeFundNormalizedTokenInstructionBuilder() *FundManagerInitializeFundNormalizedToken {
-	nd := &FundManagerInitializeFundNormalizedToken{
+// NewFundManagerInitializeFundNormalizedTokenInstructionBuilder creates a new `FundManagerInitializeFundNormalizedTokenInstruction` instruction builder.
+func NewFundManagerInitializeFundNormalizedTokenInstructionBuilder() *FundManagerInitializeFundNormalizedTokenInstruction {
+	nd := &FundManagerInitializeFundNormalizedTokenInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 11),
 	}
 	nd.AccountMetaSlice[0] = ag_solanago.Meta(Addresses["5UpLTLA7Wjqp7qdfjuTtPcUw3aVtbqFA5Mgm34mxPNg2"]).SIGNER()
@@ -49,34 +49,34 @@ func NewFundManagerInitializeFundNormalizedTokenInstructionBuilder() *FundManage
 }
 
 // SetFundManagerAccount sets the "fund_manager" account.
-func (inst *FundManagerInitializeFundNormalizedToken) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedToken {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedTokenInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(fundManager).SIGNER()
 	return inst
 }
 
 // GetFundManagerAccount gets the "fund_manager" account.
-func (inst *FundManagerInitializeFundNormalizedToken) GetFundManagerAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) GetFundManagerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *FundManagerInitializeFundNormalizedToken) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedToken {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedTokenInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *FundManagerInitializeFundNormalizedToken) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *FundManagerInitializeFundNormalizedToken) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedToken {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedTokenInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *FundManagerInitializeFundNormalizedToken) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -93,12 +93,12 @@ func (inst *FundManagerInitializeFundNormalizedToken) findFindFundAccountAddress
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundNormalizedToken) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundNormalizedToken) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -107,12 +107,12 @@ func (inst *FundManagerInitializeFundNormalizedToken) MustFindFundAccountAddress
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *FundManagerInitializeFundNormalizedToken) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerInitializeFundNormalizedToken) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -121,17 +121,17 @@ func (inst *FundManagerInitializeFundNormalizedToken) MustFindFundAccountAddress
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *FundManagerInitializeFundNormalizedToken) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetFundReserveAccountAccount sets the "fund_reserve_account" account.
-func (inst *FundManagerInitializeFundNormalizedToken) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedToken {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedTokenInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(fundReserveAccount)
 	return inst
 }
 
-func (inst *FundManagerInitializeFundNormalizedToken) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_reserve
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x72), byte(0x65), byte(0x73), byte(0x65), byte(0x72), byte(0x76), byte(0x65)})
@@ -148,12 +148,12 @@ func (inst *FundManagerInitializeFundNormalizedToken) findFindFundReserveAccount
 }
 
 // FindFundReserveAccountAddressWithBumpSeed calculates FundReserveAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundNormalizedToken) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundNormalizedToken) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -162,12 +162,12 @@ func (inst *FundManagerInitializeFundNormalizedToken) MustFindFundReserveAccount
 }
 
 // FindFundReserveAccountAddress finds FundReserveAccount account address with given seeds.
-func (inst *FundManagerInitializeFundNormalizedToken) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerInitializeFundNormalizedToken) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -176,50 +176,50 @@ func (inst *FundManagerInitializeFundNormalizedToken) MustFindFundReserveAccount
 }
 
 // GetFundReserveAccountAccount gets the "fund_reserve_account" account.
-func (inst *FundManagerInitializeFundNormalizedToken) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *FundManagerInitializeFundNormalizedToken) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedToken {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedTokenInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *FundManagerInitializeFundNormalizedToken) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetNormalizedTokenMintAccount sets the "normalized_token_mint" account.
-func (inst *FundManagerInitializeFundNormalizedToken) SetNormalizedTokenMintAccount(normalizedTokenMint ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedToken {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) SetNormalizedTokenMintAccount(normalizedTokenMint ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedTokenInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(normalizedTokenMint)
 	return inst
 }
 
 // GetNormalizedTokenMintAccount gets the "normalized_token_mint" account.
-func (inst *FundManagerInitializeFundNormalizedToken) GetNormalizedTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) GetNormalizedTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetNormalizedTokenProgramAccount sets the "normalized_token_program" account.
-func (inst *FundManagerInitializeFundNormalizedToken) SetNormalizedTokenProgramAccount(normalizedTokenProgram ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedToken {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) SetNormalizedTokenProgramAccount(normalizedTokenProgram ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedTokenInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(normalizedTokenProgram)
 	return inst
 }
 
 // GetNormalizedTokenProgramAccount gets the "normalized_token_program" account.
-func (inst *FundManagerInitializeFundNormalizedToken) GetNormalizedTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) GetNormalizedTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetFundNormalizedTokenReserveAccountAccount sets the "fund_normalized_token_reserve_account" account.
-func (inst *FundManagerInitializeFundNormalizedToken) SetFundNormalizedTokenReserveAccountAccount(fundNormalizedTokenReserveAccount ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedToken {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) SetFundNormalizedTokenReserveAccountAccount(fundNormalizedTokenReserveAccount ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedTokenInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(fundNormalizedTokenReserveAccount)
 	return inst
 }
 
-func (inst *FundManagerInitializeFundNormalizedToken) findFindFundNormalizedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, normalizedTokenProgram ag_solanago.PublicKey, normalizedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) findFindFundNormalizedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, normalizedTokenProgram ag_solanago.PublicKey, normalizedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: fundReserveAccount
 	seeds = append(seeds, fundReserveAccount.Bytes())
@@ -240,12 +240,12 @@ func (inst *FundManagerInitializeFundNormalizedToken) findFindFundNormalizedToke
 }
 
 // FindFundNormalizedTokenReserveAccountAddressWithBumpSeed calculates FundNormalizedTokenReserveAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundNormalizedToken) FindFundNormalizedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, normalizedTokenProgram ag_solanago.PublicKey, normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) FindFundNormalizedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, normalizedTokenProgram ag_solanago.PublicKey, normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundNormalizedTokenReserveAccountAddress(fundReserveAccount, normalizedTokenProgram, normalizedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundNormalizedToken) MustFindFundNormalizedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, normalizedTokenProgram ag_solanago.PublicKey, normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) MustFindFundNormalizedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, normalizedTokenProgram ag_solanago.PublicKey, normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundNormalizedTokenReserveAccountAddress(fundReserveAccount, normalizedTokenProgram, normalizedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -254,12 +254,12 @@ func (inst *FundManagerInitializeFundNormalizedToken) MustFindFundNormalizedToke
 }
 
 // FindFundNormalizedTokenReserveAccountAddress finds FundNormalizedTokenReserveAccount account address with given seeds.
-func (inst *FundManagerInitializeFundNormalizedToken) FindFundNormalizedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, normalizedTokenProgram ag_solanago.PublicKey, normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) FindFundNormalizedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, normalizedTokenProgram ag_solanago.PublicKey, normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundNormalizedTokenReserveAccountAddress(fundReserveAccount, normalizedTokenProgram, normalizedTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerInitializeFundNormalizedToken) MustFindFundNormalizedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, normalizedTokenProgram ag_solanago.PublicKey, normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) MustFindFundNormalizedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, normalizedTokenProgram ag_solanago.PublicKey, normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundNormalizedTokenReserveAccountAddress(fundReserveAccount, normalizedTokenProgram, normalizedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -268,17 +268,17 @@ func (inst *FundManagerInitializeFundNormalizedToken) MustFindFundNormalizedToke
 }
 
 // GetFundNormalizedTokenReserveAccountAccount gets the "fund_normalized_token_reserve_account" account.
-func (inst *FundManagerInitializeFundNormalizedToken) GetFundNormalizedTokenReserveAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) GetFundNormalizedTokenReserveAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetNormalizedTokenPoolAccountAccount sets the "normalized_token_pool_account" account.
-func (inst *FundManagerInitializeFundNormalizedToken) SetNormalizedTokenPoolAccountAccount(normalizedTokenPoolAccount ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedToken {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) SetNormalizedTokenPoolAccountAccount(normalizedTokenPoolAccount ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedTokenInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(normalizedTokenPoolAccount)
 	return inst
 }
 
-func (inst *FundManagerInitializeFundNormalizedToken) findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: nt_pool
 	seeds = append(seeds, []byte{byte(0x6e), byte(0x74), byte(0x5f), byte(0x70), byte(0x6f), byte(0x6f), byte(0x6c)})
@@ -295,12 +295,12 @@ func (inst *FundManagerInitializeFundNormalizedToken) findFindNormalizedTokenPoo
 }
 
 // FindNormalizedTokenPoolAccountAddressWithBumpSeed calculates NormalizedTokenPoolAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundNormalizedToken) FindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) FindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundNormalizedToken) MustFindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) MustFindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -309,12 +309,12 @@ func (inst *FundManagerInitializeFundNormalizedToken) MustFindNormalizedTokenPoo
 }
 
 // FindNormalizedTokenPoolAccountAddress finds NormalizedTokenPoolAccount account address with given seeds.
-func (inst *FundManagerInitializeFundNormalizedToken) FindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) FindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerInitializeFundNormalizedToken) MustFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) MustFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -323,17 +323,17 @@ func (inst *FundManagerInitializeFundNormalizedToken) MustFindNormalizedTokenPoo
 }
 
 // GetNormalizedTokenPoolAccountAccount gets the "normalized_token_pool_account" account.
-func (inst *FundManagerInitializeFundNormalizedToken) GetNormalizedTokenPoolAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) GetNormalizedTokenPoolAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *FundManagerInitializeFundNormalizedToken) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedToken {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedTokenInstruction {
 	inst.AccountMetaSlice[9] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *FundManagerInitializeFundNormalizedToken) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -348,12 +348,12 @@ func (inst *FundManagerInitializeFundNormalizedToken) findFindEventAuthorityAddr
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundNormalizedToken) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundNormalizedToken) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -362,12 +362,12 @@ func (inst *FundManagerInitializeFundNormalizedToken) MustFindEventAuthorityAddr
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *FundManagerInitializeFundNormalizedToken) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *FundManagerInitializeFundNormalizedToken) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -376,22 +376,22 @@ func (inst *FundManagerInitializeFundNormalizedToken) MustFindEventAuthorityAddr
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *FundManagerInitializeFundNormalizedToken) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(9)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *FundManagerInitializeFundNormalizedToken) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedToken {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedTokenInstruction {
 	inst.AccountMetaSlice[10] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *FundManagerInitializeFundNormalizedToken) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(10)
 }
 
-func (inst FundManagerInitializeFundNormalizedToken) Build() *Instruction {
+func (inst FundManagerInitializeFundNormalizedTokenInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_FundManagerInitializeFundNormalizedToken,
@@ -401,14 +401,14 @@ func (inst FundManagerInitializeFundNormalizedToken) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst FundManagerInitializeFundNormalizedToken) ValidateAndBuild() (*Instruction, error) {
+func (inst FundManagerInitializeFundNormalizedTokenInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *FundManagerInitializeFundNormalizedToken) Validate() error {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -448,7 +448,7 @@ func (inst *FundManagerInitializeFundNormalizedToken) Validate() error {
 	return nil
 }
 
-func (inst *FundManagerInitializeFundNormalizedToken) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *FundManagerInitializeFundNormalizedTokenInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -477,10 +477,10 @@ func (inst *FundManagerInitializeFundNormalizedToken) EncodeToTree(parent ag_tre
 		})
 }
 
-func (obj FundManagerInitializeFundNormalizedToken) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj FundManagerInitializeFundNormalizedTokenInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *FundManagerInitializeFundNormalizedToken) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *FundManagerInitializeFundNormalizedTokenInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -497,7 +497,7 @@ func NewFundManagerInitializeFundNormalizedTokenInstruction(
 	fundNormalizedTokenReserveAccount ag_solanago.PublicKey,
 	normalizedTokenPoolAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedToken {
+	program ag_solanago.PublicKey) *FundManagerInitializeFundNormalizedTokenInstruction {
 	return NewFundManagerInitializeFundNormalizedTokenInstructionBuilder().
 		SetFundManagerAccount(fundManager).
 		SetSystemProgramAccount(systemProgram).

--- a/generated/restaking/fundmanagerinitializefundnormalizedtoken_test.go
+++ b/generated/restaking/fundmanagerinitializefundnormalizedtoken_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_FundManagerInitializeFundNormalizedToken(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("FundManagerInitializeFundNormalizedToken"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(FundManagerInitializeFundNormalizedToken)
+				params := new(FundManagerInitializeFundNormalizedTokenInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(FundManagerInitializeFundNormalizedToken)
+				got := new(FundManagerInitializeFundNormalizedTokenInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/fundmanagerinitializefundwrappedtoken.go
+++ b/generated/restaking/fundmanagerinitializefundwrappedtoken.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FundManagerInitializeFundWrappedToken is the `fund_manager_initialize_fund_wrapped_token` instruction.
-type FundManagerInitializeFundWrappedToken struct {
+type FundManagerInitializeFundWrappedTokenInstruction struct {
 
 	// [0] = [SIGNER] admin
 	//
@@ -39,9 +39,9 @@ type FundManagerInitializeFundWrappedToken struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewFundManagerInitializeFundWrappedTokenInstructionBuilder creates a new `FundManagerInitializeFundWrappedToken` instruction builder.
-func NewFundManagerInitializeFundWrappedTokenInstructionBuilder() *FundManagerInitializeFundWrappedToken {
-	nd := &FundManagerInitializeFundWrappedToken{
+// NewFundManagerInitializeFundWrappedTokenInstructionBuilder creates a new `FundManagerInitializeFundWrappedTokenInstruction` instruction builder.
+func NewFundManagerInitializeFundWrappedTokenInstructionBuilder() *FundManagerInitializeFundWrappedTokenInstruction {
+	nd := &FundManagerInitializeFundWrappedTokenInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 12),
 	}
 	nd.AccountMetaSlice[0] = ag_solanago.Meta(Addresses["fragkamrANLvuZYQPcmPsCATQAabkqNGH6gxqqPG3aP"]).SIGNER()
@@ -51,34 +51,34 @@ func NewFundManagerInitializeFundWrappedTokenInstructionBuilder() *FundManagerIn
 }
 
 // SetAdminAccount sets the "admin" account.
-func (inst *FundManagerInitializeFundWrappedToken) SetAdminAccount(admin ag_solanago.PublicKey) *FundManagerInitializeFundWrappedToken {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) SetAdminAccount(admin ag_solanago.PublicKey) *FundManagerInitializeFundWrappedTokenInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(admin).SIGNER()
 	return inst
 }
 
 // GetAdminAccount gets the "admin" account.
-func (inst *FundManagerInitializeFundWrappedToken) GetAdminAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) GetAdminAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetFundManagerAccount sets the "fund_manager" account.
-func (inst *FundManagerInitializeFundWrappedToken) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerInitializeFundWrappedToken {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerInitializeFundWrappedTokenInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(fundManager).SIGNER()
 	return inst
 }
 
 // GetFundManagerAccount gets the "fund_manager" account.
-func (inst *FundManagerInitializeFundWrappedToken) GetFundManagerAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) GetFundManagerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetFundWrapAccountAccount sets the "fund_wrap_account" account.
-func (inst *FundManagerInitializeFundWrappedToken) SetFundWrapAccountAccount(fundWrapAccount ag_solanago.PublicKey) *FundManagerInitializeFundWrappedToken {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) SetFundWrapAccountAccount(fundWrapAccount ag_solanago.PublicKey) *FundManagerInitializeFundWrappedTokenInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(fundWrapAccount)
 	return inst
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) findFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) findFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_wrap
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x77), byte(0x72), byte(0x61), byte(0x70)})
@@ -95,12 +95,12 @@ func (inst *FundManagerInitializeFundWrappedToken) findFindFundWrapAccountAddres
 }
 
 // FindFundWrapAccountAddressWithBumpSeed calculates FundWrapAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundWrappedToken) FindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) FindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundWrapAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) MustFindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) MustFindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -109,12 +109,12 @@ func (inst *FundManagerInitializeFundWrappedToken) MustFindFundWrapAccountAddres
 }
 
 // FindFundWrapAccountAddress finds FundWrapAccount account address with given seeds.
-func (inst *FundManagerInitializeFundWrappedToken) FindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) FindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundWrapAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) MustFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) MustFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -123,28 +123,28 @@ func (inst *FundManagerInitializeFundWrappedToken) MustFindFundWrapAccountAddres
 }
 
 // GetFundWrapAccountAccount gets the "fund_wrap_account" account.
-func (inst *FundManagerInitializeFundWrappedToken) GetFundWrapAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) GetFundWrapAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *FundManagerInitializeFundWrappedToken) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerInitializeFundWrappedToken {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerInitializeFundWrappedTokenInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *FundManagerInitializeFundWrappedToken) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetReceiptTokenWrapAccountAccount sets the "receipt_token_wrap_account" account.
-func (inst *FundManagerInitializeFundWrappedToken) SetReceiptTokenWrapAccountAccount(receiptTokenWrapAccount ag_solanago.PublicKey) *FundManagerInitializeFundWrappedToken {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) SetReceiptTokenWrapAccountAccount(receiptTokenWrapAccount ag_solanago.PublicKey) *FundManagerInitializeFundWrappedTokenInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(receiptTokenWrapAccount)
 	return inst
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) findFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) findFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: fundWrapAccount
 	seeds = append(seeds, fundWrapAccount.Bytes())
@@ -165,12 +165,12 @@ func (inst *FundManagerInitializeFundWrappedToken) findFindReceiptTokenWrapAccou
 }
 
 // FindReceiptTokenWrapAccountAddressWithBumpSeed calculates ReceiptTokenWrapAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundWrappedToken) FindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) FindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) MustFindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) MustFindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -179,12 +179,12 @@ func (inst *FundManagerInitializeFundWrappedToken) MustFindReceiptTokenWrapAccou
 }
 
 // FindReceiptTokenWrapAccountAddress finds ReceiptTokenWrapAccount account address with given seeds.
-func (inst *FundManagerInitializeFundWrappedToken) FindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) FindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) MustFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) MustFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -193,39 +193,39 @@ func (inst *FundManagerInitializeFundWrappedToken) MustFindReceiptTokenWrapAccou
 }
 
 // GetReceiptTokenWrapAccountAccount gets the "receipt_token_wrap_account" account.
-func (inst *FundManagerInitializeFundWrappedToken) GetReceiptTokenWrapAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) GetReceiptTokenWrapAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetWrappedTokenMintAccount sets the "wrapped_token_mint" account.
-func (inst *FundManagerInitializeFundWrappedToken) SetWrappedTokenMintAccount(wrappedTokenMint ag_solanago.PublicKey) *FundManagerInitializeFundWrappedToken {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) SetWrappedTokenMintAccount(wrappedTokenMint ag_solanago.PublicKey) *FundManagerInitializeFundWrappedTokenInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(wrappedTokenMint).WRITE()
 	return inst
 }
 
 // GetWrappedTokenMintAccount gets the "wrapped_token_mint" account.
-func (inst *FundManagerInitializeFundWrappedToken) GetWrappedTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) GetWrappedTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetWrappedTokenProgramAccount sets the "wrapped_token_program" account.
-func (inst *FundManagerInitializeFundWrappedToken) SetWrappedTokenProgramAccount(wrappedTokenProgram ag_solanago.PublicKey) *FundManagerInitializeFundWrappedToken {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) SetWrappedTokenProgramAccount(wrappedTokenProgram ag_solanago.PublicKey) *FundManagerInitializeFundWrappedTokenInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(wrappedTokenProgram)
 	return inst
 }
 
 // GetWrappedTokenProgramAccount gets the "wrapped_token_program" account.
-func (inst *FundManagerInitializeFundWrappedToken) GetWrappedTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) GetWrappedTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *FundManagerInitializeFundWrappedToken) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerInitializeFundWrappedToken {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerInitializeFundWrappedTokenInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -242,12 +242,12 @@ func (inst *FundManagerInitializeFundWrappedToken) findFindFundAccountAddress(re
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundWrappedToken) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -256,12 +256,12 @@ func (inst *FundManagerInitializeFundWrappedToken) MustFindFundAccountAddressWit
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *FundManagerInitializeFundWrappedToken) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -270,17 +270,17 @@ func (inst *FundManagerInitializeFundWrappedToken) MustFindFundAccountAddress(re
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *FundManagerInitializeFundWrappedToken) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *FundManagerInitializeFundWrappedToken) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *FundManagerInitializeFundWrappedToken {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *FundManagerInitializeFundWrappedTokenInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(rewardAccount)
 	return inst
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -297,12 +297,12 @@ func (inst *FundManagerInitializeFundWrappedToken) findFindRewardAccountAddress(
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundWrappedToken) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -311,12 +311,12 @@ func (inst *FundManagerInitializeFundWrappedToken) MustFindRewardAccountAddressW
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *FundManagerInitializeFundWrappedToken) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -325,17 +325,17 @@ func (inst *FundManagerInitializeFundWrappedToken) MustFindRewardAccountAddress(
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *FundManagerInitializeFundWrappedToken) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
 // SetFundWrapAccountRewardAccountAccount sets the "fund_wrap_account_reward_account" account.
-func (inst *FundManagerInitializeFundWrappedToken) SetFundWrapAccountRewardAccountAccount(fundWrapAccountRewardAccount ag_solanago.PublicKey) *FundManagerInitializeFundWrappedToken {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) SetFundWrapAccountRewardAccountAccount(fundWrapAccountRewardAccount ag_solanago.PublicKey) *FundManagerInitializeFundWrappedTokenInstruction {
 	inst.AccountMetaSlice[9] = ag_solanago.Meta(fundWrapAccountRewardAccount)
 	return inst
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) findFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) findFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -354,12 +354,12 @@ func (inst *FundManagerInitializeFundWrappedToken) findFindFundWrapAccountReward
 }
 
 // FindFundWrapAccountRewardAccountAddressWithBumpSeed calculates FundWrapAccountRewardAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundWrappedToken) FindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) FindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) MustFindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) MustFindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -368,12 +368,12 @@ func (inst *FundManagerInitializeFundWrappedToken) MustFindFundWrapAccountReward
 }
 
 // FindFundWrapAccountRewardAccountAddress finds FundWrapAccountRewardAccount account address with given seeds.
-func (inst *FundManagerInitializeFundWrappedToken) FindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) FindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, 0)
 	return
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) MustFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) MustFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, 0)
 	if err != nil {
 		panic(err)
@@ -382,17 +382,17 @@ func (inst *FundManagerInitializeFundWrappedToken) MustFindFundWrapAccountReward
 }
 
 // GetFundWrapAccountRewardAccountAccount gets the "fund_wrap_account_reward_account" account.
-func (inst *FundManagerInitializeFundWrappedToken) GetFundWrapAccountRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) GetFundWrapAccountRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(9)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *FundManagerInitializeFundWrappedToken) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerInitializeFundWrappedToken {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerInitializeFundWrappedTokenInstruction {
 	inst.AccountMetaSlice[10] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -407,12 +407,12 @@ func (inst *FundManagerInitializeFundWrappedToken) findFindEventAuthorityAddress
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *FundManagerInitializeFundWrappedToken) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -421,12 +421,12 @@ func (inst *FundManagerInitializeFundWrappedToken) MustFindEventAuthorityAddress
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *FundManagerInitializeFundWrappedToken) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -435,22 +435,22 @@ func (inst *FundManagerInitializeFundWrappedToken) MustFindEventAuthorityAddress
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *FundManagerInitializeFundWrappedToken) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(10)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *FundManagerInitializeFundWrappedToken) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerInitializeFundWrappedToken {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerInitializeFundWrappedTokenInstruction {
 	inst.AccountMetaSlice[11] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *FundManagerInitializeFundWrappedToken) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(11)
 }
 
-func (inst FundManagerInitializeFundWrappedToken) Build() *Instruction {
+func (inst FundManagerInitializeFundWrappedTokenInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_FundManagerInitializeFundWrappedToken,
@@ -460,14 +460,14 @@ func (inst FundManagerInitializeFundWrappedToken) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst FundManagerInitializeFundWrappedToken) ValidateAndBuild() (*Instruction, error) {
+func (inst FundManagerInitializeFundWrappedTokenInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) Validate() error {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -510,7 +510,7 @@ func (inst *FundManagerInitializeFundWrappedToken) Validate() error {
 	return nil
 }
 
-func (inst *FundManagerInitializeFundWrappedToken) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *FundManagerInitializeFundWrappedTokenInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -540,10 +540,10 @@ func (inst *FundManagerInitializeFundWrappedToken) EncodeToTree(parent ag_treeou
 		})
 }
 
-func (obj FundManagerInitializeFundWrappedToken) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj FundManagerInitializeFundWrappedTokenInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *FundManagerInitializeFundWrappedToken) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *FundManagerInitializeFundWrappedTokenInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -561,7 +561,7 @@ func NewFundManagerInitializeFundWrappedTokenInstruction(
 	rewardAccount ag_solanago.PublicKey,
 	fundWrapAccountRewardAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *FundManagerInitializeFundWrappedToken {
+	program ag_solanago.PublicKey) *FundManagerInitializeFundWrappedTokenInstruction {
 	return NewFundManagerInitializeFundWrappedTokenInstructionBuilder().
 		SetAdminAccount(admin).
 		SetFundManagerAccount(fundManager).

--- a/generated/restaking/fundmanagerinitializefundwrappedtoken_test.go
+++ b/generated/restaking/fundmanagerinitializefundwrappedtoken_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_FundManagerInitializeFundWrappedToken(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("FundManagerInitializeFundWrappedToken"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(FundManagerInitializeFundWrappedToken)
+				params := new(FundManagerInitializeFundWrappedTokenInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(FundManagerInitializeFundWrappedToken)
+				got := new(FundManagerInitializeFundWrappedTokenInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/fundmanagersettlereward.go
+++ b/generated/restaking/fundmanagersettlereward.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FundManagerSettleReward is the `fund_manager_settle_reward` instruction.
-type FundManagerSettleReward struct {
+type FundManagerSettleRewardInstruction struct {
 	RewardPoolId *uint8
 	RewardId     *uint16
 	Amount       *uint64
@@ -32,9 +32,9 @@ type FundManagerSettleReward struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewFundManagerSettleRewardInstructionBuilder creates a new `FundManagerSettleReward` instruction builder.
-func NewFundManagerSettleRewardInstructionBuilder() *FundManagerSettleReward {
-	nd := &FundManagerSettleReward{
+// NewFundManagerSettleRewardInstructionBuilder creates a new `FundManagerSettleRewardInstruction` instruction builder.
+func NewFundManagerSettleRewardInstructionBuilder() *FundManagerSettleRewardInstruction {
+	nd := &FundManagerSettleRewardInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 7),
 	}
 	nd.AccountMetaSlice[0] = ag_solanago.Meta(Addresses["5UpLTLA7Wjqp7qdfjuTtPcUw3aVtbqFA5Mgm34mxPNg2"]).SIGNER()
@@ -42,52 +42,52 @@ func NewFundManagerSettleRewardInstructionBuilder() *FundManagerSettleReward {
 }
 
 // SetRewardPoolId sets the "reward_pool_id" parameter.
-func (inst *FundManagerSettleReward) SetRewardPoolId(reward_pool_id uint8) *FundManagerSettleReward {
+func (inst *FundManagerSettleRewardInstruction) SetRewardPoolId(reward_pool_id uint8) *FundManagerSettleRewardInstruction {
 	inst.RewardPoolId = &reward_pool_id
 	return inst
 }
 
 // SetRewardId sets the "reward_id" parameter.
-func (inst *FundManagerSettleReward) SetRewardId(reward_id uint16) *FundManagerSettleReward {
+func (inst *FundManagerSettleRewardInstruction) SetRewardId(reward_id uint16) *FundManagerSettleRewardInstruction {
 	inst.RewardId = &reward_id
 	return inst
 }
 
 // SetAmount sets the "amount" parameter.
-func (inst *FundManagerSettleReward) SetAmount(amount uint64) *FundManagerSettleReward {
+func (inst *FundManagerSettleRewardInstruction) SetAmount(amount uint64) *FundManagerSettleRewardInstruction {
 	inst.Amount = &amount
 	return inst
 }
 
 // SetFundManagerAccount sets the "fund_manager" account.
-func (inst *FundManagerSettleReward) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerSettleReward {
+func (inst *FundManagerSettleRewardInstruction) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerSettleRewardInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(fundManager).SIGNER()
 	return inst
 }
 
 // GetFundManagerAccount gets the "fund_manager" account.
-func (inst *FundManagerSettleReward) GetFundManagerAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerSettleRewardInstruction) GetFundManagerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *FundManagerSettleReward) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerSettleReward {
+func (inst *FundManagerSettleRewardInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerSettleRewardInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *FundManagerSettleReward) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerSettleRewardInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *FundManagerSettleReward) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *FundManagerSettleReward {
+func (inst *FundManagerSettleRewardInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *FundManagerSettleRewardInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *FundManagerSettleReward) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerSettleRewardInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -104,12 +104,12 @@ func (inst *FundManagerSettleReward) findFindRewardAccountAddress(receiptTokenMi
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerSettleReward) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerSettleRewardInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerSettleReward) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerSettleRewardInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -118,12 +118,12 @@ func (inst *FundManagerSettleReward) MustFindRewardAccountAddressWithBumpSeed(re
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *FundManagerSettleReward) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerSettleRewardInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerSettleReward) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerSettleRewardInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -132,39 +132,39 @@ func (inst *FundManagerSettleReward) MustFindRewardAccountAddress(receiptTokenMi
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *FundManagerSettleReward) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerSettleRewardInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetRewardTokenMintAccount sets the "reward_token_mint" account.
-func (inst *FundManagerSettleReward) SetRewardTokenMintAccount(rewardTokenMint ag_solanago.PublicKey) *FundManagerSettleReward {
+func (inst *FundManagerSettleRewardInstruction) SetRewardTokenMintAccount(rewardTokenMint ag_solanago.PublicKey) *FundManagerSettleRewardInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(rewardTokenMint)
 	return inst
 }
 
 // GetRewardTokenMintAccount gets the "reward_token_mint" account (optional).
-func (inst *FundManagerSettleReward) GetRewardTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerSettleRewardInstruction) GetRewardTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetRewardTokenProgramAccount sets the "reward_token_program" account.
-func (inst *FundManagerSettleReward) SetRewardTokenProgramAccount(rewardTokenProgram ag_solanago.PublicKey) *FundManagerSettleReward {
+func (inst *FundManagerSettleRewardInstruction) SetRewardTokenProgramAccount(rewardTokenProgram ag_solanago.PublicKey) *FundManagerSettleRewardInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(rewardTokenProgram)
 	return inst
 }
 
 // GetRewardTokenProgramAccount gets the "reward_token_program" account (optional).
-func (inst *FundManagerSettleReward) GetRewardTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerSettleRewardInstruction) GetRewardTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *FundManagerSettleReward) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerSettleReward {
+func (inst *FundManagerSettleRewardInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerSettleRewardInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *FundManagerSettleReward) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerSettleRewardInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -179,12 +179,12 @@ func (inst *FundManagerSettleReward) findFindEventAuthorityAddress(knownBumpSeed
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *FundManagerSettleReward) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerSettleRewardInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *FundManagerSettleReward) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerSettleRewardInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -193,12 +193,12 @@ func (inst *FundManagerSettleReward) MustFindEventAuthorityAddressWithBumpSeed(b
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *FundManagerSettleReward) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerSettleRewardInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *FundManagerSettleReward) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *FundManagerSettleRewardInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -207,22 +207,22 @@ func (inst *FundManagerSettleReward) MustFindEventAuthorityAddress() (pda ag_sol
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *FundManagerSettleReward) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerSettleRewardInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *FundManagerSettleReward) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerSettleReward {
+func (inst *FundManagerSettleRewardInstruction) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerSettleRewardInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *FundManagerSettleReward) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerSettleRewardInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
-func (inst FundManagerSettleReward) Build() *Instruction {
+func (inst FundManagerSettleRewardInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_FundManagerSettleReward,
@@ -232,14 +232,14 @@ func (inst FundManagerSettleReward) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst FundManagerSettleReward) ValidateAndBuild() (*Instruction, error) {
+func (inst FundManagerSettleRewardInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *FundManagerSettleReward) Validate() error {
+func (inst *FundManagerSettleRewardInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.RewardPoolId == nil {
@@ -279,7 +279,7 @@ func (inst *FundManagerSettleReward) Validate() error {
 	return nil
 }
 
-func (inst *FundManagerSettleReward) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *FundManagerSettleRewardInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -308,7 +308,7 @@ func (inst *FundManagerSettleReward) EncodeToTree(parent ag_treeout.Branches) {
 		})
 }
 
-func (obj FundManagerSettleReward) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj FundManagerSettleRewardInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `RewardPoolId` param:
 	err = encoder.Encode(obj.RewardPoolId)
 	if err != nil {
@@ -326,7 +326,7 @@ func (obj FundManagerSettleReward) MarshalWithEncoder(encoder *ag_binary.Encoder
 	}
 	return nil
 }
-func (obj *FundManagerSettleReward) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *FundManagerSettleRewardInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `RewardPoolId`:
 	err = decoder.Decode(&obj.RewardPoolId)
 	if err != nil {
@@ -358,7 +358,7 @@ func NewFundManagerSettleRewardInstruction(
 	rewardTokenMint ag_solanago.PublicKey,
 	rewardTokenProgram ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *FundManagerSettleReward {
+	program ag_solanago.PublicKey) *FundManagerSettleRewardInstruction {
 	return NewFundManagerSettleRewardInstructionBuilder().
 		SetRewardPoolId(reward_pool_id).
 		SetRewardId(reward_id).

--- a/generated/restaking/fundmanagersettlereward_test.go
+++ b/generated/restaking/fundmanagersettlereward_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_FundManagerSettleReward(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("FundManagerSettleReward"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(FundManagerSettleReward)
+				params := new(FundManagerSettleRewardInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(FundManagerSettleReward)
+				got := new(FundManagerSettleRewardInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/fundmanagerupdatefundstrategy.go
+++ b/generated/restaking/fundmanagerupdatefundstrategy.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FundManagerUpdateFundStrategy is the `fund_manager_update_fund_strategy` instruction.
-type FundManagerUpdateFundStrategy struct {
+type FundManagerUpdateFundStrategyInstruction struct {
 	DepositEnabled                  *bool
 	DonationEnabled                 *bool
 	WithdrawalEnabled               *bool
@@ -31,9 +31,9 @@ type FundManagerUpdateFundStrategy struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewFundManagerUpdateFundStrategyInstructionBuilder creates a new `FundManagerUpdateFundStrategy` instruction builder.
-func NewFundManagerUpdateFundStrategyInstructionBuilder() *FundManagerUpdateFundStrategy {
-	nd := &FundManagerUpdateFundStrategy{
+// NewFundManagerUpdateFundStrategyInstructionBuilder creates a new `FundManagerUpdateFundStrategyInstruction` instruction builder.
+func NewFundManagerUpdateFundStrategyInstructionBuilder() *FundManagerUpdateFundStrategyInstruction {
+	nd := &FundManagerUpdateFundStrategyInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 5),
 	}
 	nd.AccountMetaSlice[0] = ag_solanago.Meta(Addresses["5UpLTLA7Wjqp7qdfjuTtPcUw3aVtbqFA5Mgm34mxPNg2"]).SIGNER()
@@ -41,70 +41,70 @@ func NewFundManagerUpdateFundStrategyInstructionBuilder() *FundManagerUpdateFund
 }
 
 // SetDepositEnabled sets the "deposit_enabled" parameter.
-func (inst *FundManagerUpdateFundStrategy) SetDepositEnabled(deposit_enabled bool) *FundManagerUpdateFundStrategy {
+func (inst *FundManagerUpdateFundStrategyInstruction) SetDepositEnabled(deposit_enabled bool) *FundManagerUpdateFundStrategyInstruction {
 	inst.DepositEnabled = &deposit_enabled
 	return inst
 }
 
 // SetDonationEnabled sets the "donation_enabled" parameter.
-func (inst *FundManagerUpdateFundStrategy) SetDonationEnabled(donation_enabled bool) *FundManagerUpdateFundStrategy {
+func (inst *FundManagerUpdateFundStrategyInstruction) SetDonationEnabled(donation_enabled bool) *FundManagerUpdateFundStrategyInstruction {
 	inst.DonationEnabled = &donation_enabled
 	return inst
 }
 
 // SetWithdrawalEnabled sets the "withdrawal_enabled" parameter.
-func (inst *FundManagerUpdateFundStrategy) SetWithdrawalEnabled(withdrawal_enabled bool) *FundManagerUpdateFundStrategy {
+func (inst *FundManagerUpdateFundStrategyInstruction) SetWithdrawalEnabled(withdrawal_enabled bool) *FundManagerUpdateFundStrategyInstruction {
 	inst.WithdrawalEnabled = &withdrawal_enabled
 	return inst
 }
 
 // SetTransferEnabled sets the "transfer_enabled" parameter.
-func (inst *FundManagerUpdateFundStrategy) SetTransferEnabled(transfer_enabled bool) *FundManagerUpdateFundStrategy {
+func (inst *FundManagerUpdateFundStrategyInstruction) SetTransferEnabled(transfer_enabled bool) *FundManagerUpdateFundStrategyInstruction {
 	inst.TransferEnabled = &transfer_enabled
 	return inst
 }
 
 // SetWithdrawalFeeRateBps sets the "withdrawal_fee_rate_bps" parameter.
-func (inst *FundManagerUpdateFundStrategy) SetWithdrawalFeeRateBps(withdrawal_fee_rate_bps uint16) *FundManagerUpdateFundStrategy {
+func (inst *FundManagerUpdateFundStrategyInstruction) SetWithdrawalFeeRateBps(withdrawal_fee_rate_bps uint16) *FundManagerUpdateFundStrategyInstruction {
 	inst.WithdrawalFeeRateBps = &withdrawal_fee_rate_bps
 	return inst
 }
 
 // SetWithdrawalBatchThresholdSeconds sets the "withdrawal_batch_threshold_seconds" parameter.
-func (inst *FundManagerUpdateFundStrategy) SetWithdrawalBatchThresholdSeconds(withdrawal_batch_threshold_seconds int64) *FundManagerUpdateFundStrategy {
+func (inst *FundManagerUpdateFundStrategyInstruction) SetWithdrawalBatchThresholdSeconds(withdrawal_batch_threshold_seconds int64) *FundManagerUpdateFundStrategyInstruction {
 	inst.WithdrawalBatchThresholdSeconds = &withdrawal_batch_threshold_seconds
 	return inst
 }
 
 // SetFundManagerAccount sets the "fund_manager" account.
-func (inst *FundManagerUpdateFundStrategy) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerUpdateFundStrategy {
+func (inst *FundManagerUpdateFundStrategyInstruction) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerUpdateFundStrategyInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(fundManager).SIGNER()
 	return inst
 }
 
 // GetFundManagerAccount gets the "fund_manager" account.
-func (inst *FundManagerUpdateFundStrategy) GetFundManagerAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateFundStrategyInstruction) GetFundManagerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *FundManagerUpdateFundStrategy) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerUpdateFundStrategy {
+func (inst *FundManagerUpdateFundStrategyInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerUpdateFundStrategyInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *FundManagerUpdateFundStrategy) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateFundStrategyInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *FundManagerUpdateFundStrategy) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerUpdateFundStrategy {
+func (inst *FundManagerUpdateFundStrategyInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerUpdateFundStrategyInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *FundManagerUpdateFundStrategy) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateFundStrategyInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -121,12 +121,12 @@ func (inst *FundManagerUpdateFundStrategy) findFindFundAccountAddress(receiptTok
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerUpdateFundStrategy) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerUpdateFundStrategyInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerUpdateFundStrategy) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateFundStrategyInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -135,12 +135,12 @@ func (inst *FundManagerUpdateFundStrategy) MustFindFundAccountAddressWithBumpSee
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *FundManagerUpdateFundStrategy) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateFundStrategyInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerUpdateFundStrategy) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateFundStrategyInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -149,17 +149,17 @@ func (inst *FundManagerUpdateFundStrategy) MustFindFundAccountAddress(receiptTok
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *FundManagerUpdateFundStrategy) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateFundStrategyInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *FundManagerUpdateFundStrategy) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerUpdateFundStrategy {
+func (inst *FundManagerUpdateFundStrategyInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerUpdateFundStrategyInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *FundManagerUpdateFundStrategy) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateFundStrategyInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -174,12 +174,12 @@ func (inst *FundManagerUpdateFundStrategy) findFindEventAuthorityAddress(knownBu
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *FundManagerUpdateFundStrategy) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerUpdateFundStrategyInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *FundManagerUpdateFundStrategy) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateFundStrategyInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -188,12 +188,12 @@ func (inst *FundManagerUpdateFundStrategy) MustFindEventAuthorityAddressWithBump
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *FundManagerUpdateFundStrategy) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateFundStrategyInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *FundManagerUpdateFundStrategy) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateFundStrategyInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -202,22 +202,22 @@ func (inst *FundManagerUpdateFundStrategy) MustFindEventAuthorityAddress() (pda 
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *FundManagerUpdateFundStrategy) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateFundStrategyInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *FundManagerUpdateFundStrategy) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerUpdateFundStrategy {
+func (inst *FundManagerUpdateFundStrategyInstruction) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerUpdateFundStrategyInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *FundManagerUpdateFundStrategy) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateFundStrategyInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
-func (inst FundManagerUpdateFundStrategy) Build() *Instruction {
+func (inst FundManagerUpdateFundStrategyInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_FundManagerUpdateFundStrategy,
@@ -227,14 +227,14 @@ func (inst FundManagerUpdateFundStrategy) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst FundManagerUpdateFundStrategy) ValidateAndBuild() (*Instruction, error) {
+func (inst FundManagerUpdateFundStrategyInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *FundManagerUpdateFundStrategy) Validate() error {
+func (inst *FundManagerUpdateFundStrategyInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.DepositEnabled == nil {
@@ -278,7 +278,7 @@ func (inst *FundManagerUpdateFundStrategy) Validate() error {
 	return nil
 }
 
-func (inst *FundManagerUpdateFundStrategy) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *FundManagerUpdateFundStrategyInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -308,7 +308,7 @@ func (inst *FundManagerUpdateFundStrategy) EncodeToTree(parent ag_treeout.Branch
 		})
 }
 
-func (obj FundManagerUpdateFundStrategy) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj FundManagerUpdateFundStrategyInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `DepositEnabled` param:
 	err = encoder.Encode(obj.DepositEnabled)
 	if err != nil {
@@ -341,7 +341,7 @@ func (obj FundManagerUpdateFundStrategy) MarshalWithEncoder(encoder *ag_binary.E
 	}
 	return nil
 }
-func (obj *FundManagerUpdateFundStrategy) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *FundManagerUpdateFundStrategyInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `DepositEnabled`:
 	err = decoder.Decode(&obj.DepositEnabled)
 	if err != nil {
@@ -389,7 +389,7 @@ func NewFundManagerUpdateFundStrategyInstruction(
 	receiptTokenMint ag_solanago.PublicKey,
 	fundAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *FundManagerUpdateFundStrategy {
+	program ag_solanago.PublicKey) *FundManagerUpdateFundStrategyInstruction {
 	return NewFundManagerUpdateFundStrategyInstructionBuilder().
 		SetDepositEnabled(deposit_enabled).
 		SetDonationEnabled(donation_enabled).

--- a/generated/restaking/fundmanagerupdatefundstrategy_test.go
+++ b/generated/restaking/fundmanagerupdatefundstrategy_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_FundManagerUpdateFundStrategy(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("FundManagerUpdateFundStrategy"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(FundManagerUpdateFundStrategy)
+				params := new(FundManagerUpdateFundStrategyInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(FundManagerUpdateFundStrategy)
+				got := new(FundManagerUpdateFundStrategyInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/fundmanagerupdaterestakingvaultdelegationstrategy.go
+++ b/generated/restaking/fundmanagerupdaterestakingvaultdelegationstrategy.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FundManagerUpdateRestakingVaultDelegationStrategy is the `fund_manager_update_restaking_vault_delegation_strategy` instruction.
-type FundManagerUpdateRestakingVaultDelegationStrategy struct {
+type FundManagerUpdateRestakingVaultDelegationStrategyInstruction struct {
 	Vault                         *ag_solanago.PublicKey
 	Operator                      *ag_solanago.PublicKey
 	TokenAllocationWeight         *uint64
@@ -30,9 +30,9 @@ type FundManagerUpdateRestakingVaultDelegationStrategy struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewFundManagerUpdateRestakingVaultDelegationStrategyInstructionBuilder creates a new `FundManagerUpdateRestakingVaultDelegationStrategy` instruction builder.
-func NewFundManagerUpdateRestakingVaultDelegationStrategyInstructionBuilder() *FundManagerUpdateRestakingVaultDelegationStrategy {
-	nd := &FundManagerUpdateRestakingVaultDelegationStrategy{
+// NewFundManagerUpdateRestakingVaultDelegationStrategyInstructionBuilder creates a new `FundManagerUpdateRestakingVaultDelegationStrategyInstruction` instruction builder.
+func NewFundManagerUpdateRestakingVaultDelegationStrategyInstructionBuilder() *FundManagerUpdateRestakingVaultDelegationStrategyInstruction {
+	nd := &FundManagerUpdateRestakingVaultDelegationStrategyInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 5),
 	}
 	nd.AccountMetaSlice[0] = ag_solanago.Meta(Addresses["5UpLTLA7Wjqp7qdfjuTtPcUw3aVtbqFA5Mgm34mxPNg2"]).SIGNER()
@@ -40,64 +40,64 @@ func NewFundManagerUpdateRestakingVaultDelegationStrategyInstructionBuilder() *F
 }
 
 // SetVault sets the "vault" parameter.
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) SetVault(vault ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultDelegationStrategy {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) SetVault(vault ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultDelegationStrategyInstruction {
 	inst.Vault = &vault
 	return inst
 }
 
 // SetOperator sets the "operator" parameter.
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) SetOperator(operator ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultDelegationStrategy {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) SetOperator(operator ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultDelegationStrategyInstruction {
 	inst.Operator = &operator
 	return inst
 }
 
 // SetTokenAllocationWeight sets the "token_allocation_weight" parameter.
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) SetTokenAllocationWeight(token_allocation_weight uint64) *FundManagerUpdateRestakingVaultDelegationStrategy {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) SetTokenAllocationWeight(token_allocation_weight uint64) *FundManagerUpdateRestakingVaultDelegationStrategyInstruction {
 	inst.TokenAllocationWeight = &token_allocation_weight
 	return inst
 }
 
 // SetTokenAllocationCapacityAmount sets the "token_allocation_capacity_amount" parameter.
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) SetTokenAllocationCapacityAmount(token_allocation_capacity_amount uint64) *FundManagerUpdateRestakingVaultDelegationStrategy {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) SetTokenAllocationCapacityAmount(token_allocation_capacity_amount uint64) *FundManagerUpdateRestakingVaultDelegationStrategyInstruction {
 	inst.TokenAllocationCapacityAmount = &token_allocation_capacity_amount
 	return inst
 }
 
 // SetTokenRedelegatingAmount sets the "token_redelegating_amount" parameter.
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) SetTokenRedelegatingAmount(token_redelegating_amount uint64) *FundManagerUpdateRestakingVaultDelegationStrategy {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) SetTokenRedelegatingAmount(token_redelegating_amount uint64) *FundManagerUpdateRestakingVaultDelegationStrategyInstruction {
 	inst.TokenRedelegatingAmount = &token_redelegating_amount
 	return inst
 }
 
 // SetFundManagerAccount sets the "fund_manager" account.
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultDelegationStrategy {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultDelegationStrategyInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(fundManager).SIGNER()
 	return inst
 }
 
 // GetFundManagerAccount gets the "fund_manager" account.
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) GetFundManagerAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) GetFundManagerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultDelegationStrategy {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultDelegationStrategyInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultDelegationStrategy {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultDelegationStrategyInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -114,12 +114,12 @@ func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) findFindFundAccou
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -128,12 +128,12 @@ func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) MustFindFundAccou
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -142,17 +142,17 @@ func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) MustFindFundAccou
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultDelegationStrategy {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultDelegationStrategyInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -167,12 +167,12 @@ func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) findFindEventAuth
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -181,12 +181,12 @@ func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) MustFindEventAuth
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -195,22 +195,22 @@ func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) MustFindEventAuth
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultDelegationStrategy {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultDelegationStrategyInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
-func (inst FundManagerUpdateRestakingVaultDelegationStrategy) Build() *Instruction {
+func (inst FundManagerUpdateRestakingVaultDelegationStrategyInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_FundManagerUpdateRestakingVaultDelegationStrategy,
@@ -220,14 +220,14 @@ func (inst FundManagerUpdateRestakingVaultDelegationStrategy) Build() *Instructi
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst FundManagerUpdateRestakingVaultDelegationStrategy) ValidateAndBuild() (*Instruction, error) {
+func (inst FundManagerUpdateRestakingVaultDelegationStrategyInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) Validate() error {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.Vault == nil {
@@ -265,7 +265,7 @@ func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) Validate() error 
 	return nil
 }
 
-func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -294,7 +294,7 @@ func (inst *FundManagerUpdateRestakingVaultDelegationStrategy) EncodeToTree(pare
 		})
 }
 
-func (obj FundManagerUpdateRestakingVaultDelegationStrategy) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj FundManagerUpdateRestakingVaultDelegationStrategyInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `Vault` param:
 	err = encoder.Encode(obj.Vault)
 	if err != nil {
@@ -335,7 +335,7 @@ func (obj FundManagerUpdateRestakingVaultDelegationStrategy) MarshalWithEncoder(
 	}
 	return nil
 }
-func (obj *FundManagerUpdateRestakingVaultDelegationStrategy) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *FundManagerUpdateRestakingVaultDelegationStrategyInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `Vault`:
 	err = decoder.Decode(&obj.Vault)
 	if err != nil {
@@ -385,7 +385,7 @@ func NewFundManagerUpdateRestakingVaultDelegationStrategyInstruction(
 	receiptTokenMint ag_solanago.PublicKey,
 	fundAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultDelegationStrategy {
+	program ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultDelegationStrategyInstruction {
 	return NewFundManagerUpdateRestakingVaultDelegationStrategyInstructionBuilder().
 		SetVault(vault).
 		SetOperator(operator).

--- a/generated/restaking/fundmanagerupdaterestakingvaultdelegationstrategy_test.go
+++ b/generated/restaking/fundmanagerupdaterestakingvaultdelegationstrategy_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_FundManagerUpdateRestakingVaultDelegationStrategy(t *testi
 	for i := 0; i < 1; i++ {
 		t.Run("FundManagerUpdateRestakingVaultDelegationStrategy"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(FundManagerUpdateRestakingVaultDelegationStrategy)
+				params := new(FundManagerUpdateRestakingVaultDelegationStrategyInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(FundManagerUpdateRestakingVaultDelegationStrategy)
+				got := new(FundManagerUpdateRestakingVaultDelegationStrategyInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/fundmanagerupdaterestakingvaultstrategy.go
+++ b/generated/restaking/fundmanagerupdaterestakingvaultstrategy.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FundManagerUpdateRestakingVaultStrategy is the `fund_manager_update_restaking_vault_strategy` instruction.
-type FundManagerUpdateRestakingVaultStrategy struct {
+type FundManagerUpdateRestakingVaultStrategyInstruction struct {
 	Vault                       *ag_solanago.PublicKey
 	SolAllocationWeight         *uint64
 	SolAllocationCapacityAmount *uint64
@@ -28,9 +28,9 @@ type FundManagerUpdateRestakingVaultStrategy struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewFundManagerUpdateRestakingVaultStrategyInstructionBuilder creates a new `FundManagerUpdateRestakingVaultStrategy` instruction builder.
-func NewFundManagerUpdateRestakingVaultStrategyInstructionBuilder() *FundManagerUpdateRestakingVaultStrategy {
-	nd := &FundManagerUpdateRestakingVaultStrategy{
+// NewFundManagerUpdateRestakingVaultStrategyInstructionBuilder creates a new `FundManagerUpdateRestakingVaultStrategyInstruction` instruction builder.
+func NewFundManagerUpdateRestakingVaultStrategyInstructionBuilder() *FundManagerUpdateRestakingVaultStrategyInstruction {
+	nd := &FundManagerUpdateRestakingVaultStrategyInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 5),
 	}
 	nd.AccountMetaSlice[0] = ag_solanago.Meta(Addresses["5UpLTLA7Wjqp7qdfjuTtPcUw3aVtbqFA5Mgm34mxPNg2"]).SIGNER()
@@ -38,52 +38,52 @@ func NewFundManagerUpdateRestakingVaultStrategyInstructionBuilder() *FundManager
 }
 
 // SetVault sets the "vault" parameter.
-func (inst *FundManagerUpdateRestakingVaultStrategy) SetVault(vault ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultStrategy {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) SetVault(vault ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultStrategyInstruction {
 	inst.Vault = &vault
 	return inst
 }
 
 // SetSolAllocationWeight sets the "sol_allocation_weight" parameter.
-func (inst *FundManagerUpdateRestakingVaultStrategy) SetSolAllocationWeight(sol_allocation_weight uint64) *FundManagerUpdateRestakingVaultStrategy {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) SetSolAllocationWeight(sol_allocation_weight uint64) *FundManagerUpdateRestakingVaultStrategyInstruction {
 	inst.SolAllocationWeight = &sol_allocation_weight
 	return inst
 }
 
 // SetSolAllocationCapacityAmount sets the "sol_allocation_capacity_amount" parameter.
-func (inst *FundManagerUpdateRestakingVaultStrategy) SetSolAllocationCapacityAmount(sol_allocation_capacity_amount uint64) *FundManagerUpdateRestakingVaultStrategy {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) SetSolAllocationCapacityAmount(sol_allocation_capacity_amount uint64) *FundManagerUpdateRestakingVaultStrategyInstruction {
 	inst.SolAllocationCapacityAmount = &sol_allocation_capacity_amount
 	return inst
 }
 
 // SetFundManagerAccount sets the "fund_manager" account.
-func (inst *FundManagerUpdateRestakingVaultStrategy) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultStrategy {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultStrategyInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(fundManager).SIGNER()
 	return inst
 }
 
 // GetFundManagerAccount gets the "fund_manager" account.
-func (inst *FundManagerUpdateRestakingVaultStrategy) GetFundManagerAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) GetFundManagerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *FundManagerUpdateRestakingVaultStrategy) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultStrategy {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultStrategyInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *FundManagerUpdateRestakingVaultStrategy) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *FundManagerUpdateRestakingVaultStrategy) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultStrategy {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultStrategyInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *FundManagerUpdateRestakingVaultStrategy) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -100,12 +100,12 @@ func (inst *FundManagerUpdateRestakingVaultStrategy) findFindFundAccountAddress(
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerUpdateRestakingVaultStrategy) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerUpdateRestakingVaultStrategy) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -114,12 +114,12 @@ func (inst *FundManagerUpdateRestakingVaultStrategy) MustFindFundAccountAddressW
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *FundManagerUpdateRestakingVaultStrategy) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerUpdateRestakingVaultStrategy) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -128,17 +128,17 @@ func (inst *FundManagerUpdateRestakingVaultStrategy) MustFindFundAccountAddress(
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *FundManagerUpdateRestakingVaultStrategy) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *FundManagerUpdateRestakingVaultStrategy) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultStrategy {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultStrategyInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *FundManagerUpdateRestakingVaultStrategy) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -153,12 +153,12 @@ func (inst *FundManagerUpdateRestakingVaultStrategy) findFindEventAuthorityAddre
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *FundManagerUpdateRestakingVaultStrategy) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *FundManagerUpdateRestakingVaultStrategy) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -167,12 +167,12 @@ func (inst *FundManagerUpdateRestakingVaultStrategy) MustFindEventAuthorityAddre
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *FundManagerUpdateRestakingVaultStrategy) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *FundManagerUpdateRestakingVaultStrategy) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -181,22 +181,22 @@ func (inst *FundManagerUpdateRestakingVaultStrategy) MustFindEventAuthorityAddre
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *FundManagerUpdateRestakingVaultStrategy) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *FundManagerUpdateRestakingVaultStrategy) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultStrategy {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultStrategyInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *FundManagerUpdateRestakingVaultStrategy) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
-func (inst FundManagerUpdateRestakingVaultStrategy) Build() *Instruction {
+func (inst FundManagerUpdateRestakingVaultStrategyInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_FundManagerUpdateRestakingVaultStrategy,
@@ -206,14 +206,14 @@ func (inst FundManagerUpdateRestakingVaultStrategy) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst FundManagerUpdateRestakingVaultStrategy) ValidateAndBuild() (*Instruction, error) {
+func (inst FundManagerUpdateRestakingVaultStrategyInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *FundManagerUpdateRestakingVaultStrategy) Validate() error {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.Vault == nil {
@@ -248,7 +248,7 @@ func (inst *FundManagerUpdateRestakingVaultStrategy) Validate() error {
 	return nil
 }
 
-func (inst *FundManagerUpdateRestakingVaultStrategy) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *FundManagerUpdateRestakingVaultStrategyInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -275,7 +275,7 @@ func (inst *FundManagerUpdateRestakingVaultStrategy) EncodeToTree(parent ag_tree
 		})
 }
 
-func (obj FundManagerUpdateRestakingVaultStrategy) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj FundManagerUpdateRestakingVaultStrategyInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `Vault` param:
 	err = encoder.Encode(obj.Vault)
 	if err != nil {
@@ -293,7 +293,7 @@ func (obj FundManagerUpdateRestakingVaultStrategy) MarshalWithEncoder(encoder *a
 	}
 	return nil
 }
-func (obj *FundManagerUpdateRestakingVaultStrategy) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *FundManagerUpdateRestakingVaultStrategyInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `Vault`:
 	err = decoder.Decode(&obj.Vault)
 	if err != nil {
@@ -323,7 +323,7 @@ func NewFundManagerUpdateRestakingVaultStrategyInstruction(
 	receiptTokenMint ag_solanago.PublicKey,
 	fundAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultStrategy {
+	program ag_solanago.PublicKey) *FundManagerUpdateRestakingVaultStrategyInstruction {
 	return NewFundManagerUpdateRestakingVaultStrategyInstructionBuilder().
 		SetVault(vault).
 		SetSolAllocationWeight(sol_allocation_weight).

--- a/generated/restaking/fundmanagerupdaterestakingvaultstrategy_test.go
+++ b/generated/restaking/fundmanagerupdaterestakingvaultstrategy_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_FundManagerUpdateRestakingVaultStrategy(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("FundManagerUpdateRestakingVaultStrategy"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(FundManagerUpdateRestakingVaultStrategy)
+				params := new(FundManagerUpdateRestakingVaultStrategyInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(FundManagerUpdateRestakingVaultStrategy)
+				got := new(FundManagerUpdateRestakingVaultStrategyInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/fundmanagerupdatesolstrategy.go
+++ b/generated/restaking/fundmanagerupdatesolstrategy.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FundManagerUpdateSolStrategy is the `fund_manager_update_sol_strategy` instruction.
-type FundManagerUpdateSolStrategy struct {
+type FundManagerUpdateSolStrategyInstruction struct {
 	SolDepositable                      *bool
 	SolAccumulatedDepositCapacityAmount *uint64
 	SolAccumulatedDepositAmount         *uint64 `bin:"optional"`
@@ -31,9 +31,9 @@ type FundManagerUpdateSolStrategy struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewFundManagerUpdateSolStrategyInstructionBuilder creates a new `FundManagerUpdateSolStrategy` instruction builder.
-func NewFundManagerUpdateSolStrategyInstructionBuilder() *FundManagerUpdateSolStrategy {
-	nd := &FundManagerUpdateSolStrategy{
+// NewFundManagerUpdateSolStrategyInstructionBuilder creates a new `FundManagerUpdateSolStrategyInstruction` instruction builder.
+func NewFundManagerUpdateSolStrategyInstructionBuilder() *FundManagerUpdateSolStrategyInstruction {
+	nd := &FundManagerUpdateSolStrategyInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 5),
 	}
 	nd.AccountMetaSlice[0] = ag_solanago.Meta(Addresses["5UpLTLA7Wjqp7qdfjuTtPcUw3aVtbqFA5Mgm34mxPNg2"]).SIGNER()
@@ -41,70 +41,70 @@ func NewFundManagerUpdateSolStrategyInstructionBuilder() *FundManagerUpdateSolSt
 }
 
 // SetSolDepositable sets the "sol_depositable" parameter.
-func (inst *FundManagerUpdateSolStrategy) SetSolDepositable(sol_depositable bool) *FundManagerUpdateSolStrategy {
+func (inst *FundManagerUpdateSolStrategyInstruction) SetSolDepositable(sol_depositable bool) *FundManagerUpdateSolStrategyInstruction {
 	inst.SolDepositable = &sol_depositable
 	return inst
 }
 
 // SetSolAccumulatedDepositCapacityAmount sets the "sol_accumulated_deposit_capacity_amount" parameter.
-func (inst *FundManagerUpdateSolStrategy) SetSolAccumulatedDepositCapacityAmount(sol_accumulated_deposit_capacity_amount uint64) *FundManagerUpdateSolStrategy {
+func (inst *FundManagerUpdateSolStrategyInstruction) SetSolAccumulatedDepositCapacityAmount(sol_accumulated_deposit_capacity_amount uint64) *FundManagerUpdateSolStrategyInstruction {
 	inst.SolAccumulatedDepositCapacityAmount = &sol_accumulated_deposit_capacity_amount
 	return inst
 }
 
 // SetSolAccumulatedDepositAmount sets the "sol_accumulated_deposit_amount" parameter.
-func (inst *FundManagerUpdateSolStrategy) SetSolAccumulatedDepositAmount(sol_accumulated_deposit_amount uint64) *FundManagerUpdateSolStrategy {
+func (inst *FundManagerUpdateSolStrategyInstruction) SetSolAccumulatedDepositAmount(sol_accumulated_deposit_amount uint64) *FundManagerUpdateSolStrategyInstruction {
 	inst.SolAccumulatedDepositAmount = &sol_accumulated_deposit_amount
 	return inst
 }
 
 // SetSolWithdrawable sets the "sol_withdrawable" parameter.
-func (inst *FundManagerUpdateSolStrategy) SetSolWithdrawable(sol_withdrawable bool) *FundManagerUpdateSolStrategy {
+func (inst *FundManagerUpdateSolStrategyInstruction) SetSolWithdrawable(sol_withdrawable bool) *FundManagerUpdateSolStrategyInstruction {
 	inst.SolWithdrawable = &sol_withdrawable
 	return inst
 }
 
 // SetSolWithdrawalNormalReserveRateBps sets the "sol_withdrawal_normal_reserve_rate_bps" parameter.
-func (inst *FundManagerUpdateSolStrategy) SetSolWithdrawalNormalReserveRateBps(sol_withdrawal_normal_reserve_rate_bps uint16) *FundManagerUpdateSolStrategy {
+func (inst *FundManagerUpdateSolStrategyInstruction) SetSolWithdrawalNormalReserveRateBps(sol_withdrawal_normal_reserve_rate_bps uint16) *FundManagerUpdateSolStrategyInstruction {
 	inst.SolWithdrawalNormalReserveRateBps = &sol_withdrawal_normal_reserve_rate_bps
 	return inst
 }
 
 // SetSolWithdrawalNormalReserveMaxAmount sets the "sol_withdrawal_normal_reserve_max_amount" parameter.
-func (inst *FundManagerUpdateSolStrategy) SetSolWithdrawalNormalReserveMaxAmount(sol_withdrawal_normal_reserve_max_amount uint64) *FundManagerUpdateSolStrategy {
+func (inst *FundManagerUpdateSolStrategyInstruction) SetSolWithdrawalNormalReserveMaxAmount(sol_withdrawal_normal_reserve_max_amount uint64) *FundManagerUpdateSolStrategyInstruction {
 	inst.SolWithdrawalNormalReserveMaxAmount = &sol_withdrawal_normal_reserve_max_amount
 	return inst
 }
 
 // SetFundManagerAccount sets the "fund_manager" account.
-func (inst *FundManagerUpdateSolStrategy) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerUpdateSolStrategy {
+func (inst *FundManagerUpdateSolStrategyInstruction) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerUpdateSolStrategyInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(fundManager).SIGNER()
 	return inst
 }
 
 // GetFundManagerAccount gets the "fund_manager" account.
-func (inst *FundManagerUpdateSolStrategy) GetFundManagerAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateSolStrategyInstruction) GetFundManagerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *FundManagerUpdateSolStrategy) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerUpdateSolStrategy {
+func (inst *FundManagerUpdateSolStrategyInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerUpdateSolStrategyInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *FundManagerUpdateSolStrategy) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateSolStrategyInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *FundManagerUpdateSolStrategy) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerUpdateSolStrategy {
+func (inst *FundManagerUpdateSolStrategyInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerUpdateSolStrategyInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *FundManagerUpdateSolStrategy) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateSolStrategyInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -121,12 +121,12 @@ func (inst *FundManagerUpdateSolStrategy) findFindFundAccountAddress(receiptToke
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerUpdateSolStrategy) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerUpdateSolStrategyInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerUpdateSolStrategy) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateSolStrategyInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -135,12 +135,12 @@ func (inst *FundManagerUpdateSolStrategy) MustFindFundAccountAddressWithBumpSeed
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *FundManagerUpdateSolStrategy) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateSolStrategyInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerUpdateSolStrategy) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateSolStrategyInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -149,17 +149,17 @@ func (inst *FundManagerUpdateSolStrategy) MustFindFundAccountAddress(receiptToke
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *FundManagerUpdateSolStrategy) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateSolStrategyInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *FundManagerUpdateSolStrategy) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerUpdateSolStrategy {
+func (inst *FundManagerUpdateSolStrategyInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerUpdateSolStrategyInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *FundManagerUpdateSolStrategy) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateSolStrategyInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -174,12 +174,12 @@ func (inst *FundManagerUpdateSolStrategy) findFindEventAuthorityAddress(knownBum
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *FundManagerUpdateSolStrategy) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerUpdateSolStrategyInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *FundManagerUpdateSolStrategy) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateSolStrategyInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -188,12 +188,12 @@ func (inst *FundManagerUpdateSolStrategy) MustFindEventAuthorityAddressWithBumpS
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *FundManagerUpdateSolStrategy) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateSolStrategyInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *FundManagerUpdateSolStrategy) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateSolStrategyInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -202,22 +202,22 @@ func (inst *FundManagerUpdateSolStrategy) MustFindEventAuthorityAddress() (pda a
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *FundManagerUpdateSolStrategy) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateSolStrategyInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *FundManagerUpdateSolStrategy) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerUpdateSolStrategy {
+func (inst *FundManagerUpdateSolStrategyInstruction) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerUpdateSolStrategyInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *FundManagerUpdateSolStrategy) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateSolStrategyInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
-func (inst FundManagerUpdateSolStrategy) Build() *Instruction {
+func (inst FundManagerUpdateSolStrategyInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_FundManagerUpdateSolStrategy,
@@ -227,14 +227,14 @@ func (inst FundManagerUpdateSolStrategy) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst FundManagerUpdateSolStrategy) ValidateAndBuild() (*Instruction, error) {
+func (inst FundManagerUpdateSolStrategyInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *FundManagerUpdateSolStrategy) Validate() error {
+func (inst *FundManagerUpdateSolStrategyInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.SolDepositable == nil {
@@ -275,7 +275,7 @@ func (inst *FundManagerUpdateSolStrategy) Validate() error {
 	return nil
 }
 
-func (inst *FundManagerUpdateSolStrategy) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *FundManagerUpdateSolStrategyInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -305,7 +305,7 @@ func (inst *FundManagerUpdateSolStrategy) EncodeToTree(parent ag_treeout.Branche
 		})
 }
 
-func (obj FundManagerUpdateSolStrategy) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj FundManagerUpdateSolStrategyInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `SolDepositable` param:
 	err = encoder.Encode(obj.SolDepositable)
 	if err != nil {
@@ -351,7 +351,7 @@ func (obj FundManagerUpdateSolStrategy) MarshalWithEncoder(encoder *ag_binary.En
 	}
 	return nil
 }
-func (obj *FundManagerUpdateSolStrategy) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *FundManagerUpdateSolStrategyInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `SolDepositable`:
 	err = decoder.Decode(&obj.SolDepositable)
 	if err != nil {
@@ -407,7 +407,7 @@ func NewFundManagerUpdateSolStrategyInstruction(
 	receiptTokenMint ag_solanago.PublicKey,
 	fundAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *FundManagerUpdateSolStrategy {
+	program ag_solanago.PublicKey) *FundManagerUpdateSolStrategyInstruction {
 	return NewFundManagerUpdateSolStrategyInstructionBuilder().
 		SetSolDepositable(sol_depositable).
 		SetSolAccumulatedDepositCapacityAmount(sol_accumulated_deposit_capacity_amount).

--- a/generated/restaking/fundmanagerupdatesolstrategy_test.go
+++ b/generated/restaking/fundmanagerupdatesolstrategy_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_FundManagerUpdateSolStrategy(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("FundManagerUpdateSolStrategy"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(FundManagerUpdateSolStrategy)
+				params := new(FundManagerUpdateSolStrategyInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(FundManagerUpdateSolStrategy)
+				got := new(FundManagerUpdateSolStrategyInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/fundmanagerupdatesupportedtokenstrategy.go
+++ b/generated/restaking/fundmanagerupdatesupportedtokenstrategy.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FundManagerUpdateSupportedTokenStrategy is the `fund_manager_update_supported_token_strategy` instruction.
-type FundManagerUpdateSupportedTokenStrategy struct {
+type FundManagerUpdateSupportedTokenStrategyInstruction struct {
 	TokenMint                             *ag_solanago.PublicKey
 	TokenDepositable                      *bool
 	TokenAccumulatedDepositCapacityAmount *uint64
@@ -35,9 +35,9 @@ type FundManagerUpdateSupportedTokenStrategy struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewFundManagerUpdateSupportedTokenStrategyInstructionBuilder creates a new `FundManagerUpdateSupportedTokenStrategy` instruction builder.
-func NewFundManagerUpdateSupportedTokenStrategyInstructionBuilder() *FundManagerUpdateSupportedTokenStrategy {
-	nd := &FundManagerUpdateSupportedTokenStrategy{
+// NewFundManagerUpdateSupportedTokenStrategyInstructionBuilder creates a new `FundManagerUpdateSupportedTokenStrategyInstruction` instruction builder.
+func NewFundManagerUpdateSupportedTokenStrategyInstructionBuilder() *FundManagerUpdateSupportedTokenStrategyInstruction {
+	nd := &FundManagerUpdateSupportedTokenStrategyInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 5),
 	}
 	nd.AccountMetaSlice[0] = ag_solanago.Meta(Addresses["5UpLTLA7Wjqp7qdfjuTtPcUw3aVtbqFA5Mgm34mxPNg2"]).SIGNER()
@@ -45,94 +45,94 @@ func NewFundManagerUpdateSupportedTokenStrategyInstructionBuilder() *FundManager
 }
 
 // SetTokenMint sets the "token_mint" parameter.
-func (inst *FundManagerUpdateSupportedTokenStrategy) SetTokenMint(token_mint ag_solanago.PublicKey) *FundManagerUpdateSupportedTokenStrategy {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) SetTokenMint(token_mint ag_solanago.PublicKey) *FundManagerUpdateSupportedTokenStrategyInstruction {
 	inst.TokenMint = &token_mint
 	return inst
 }
 
 // SetTokenDepositable sets the "token_depositable" parameter.
-func (inst *FundManagerUpdateSupportedTokenStrategy) SetTokenDepositable(token_depositable bool) *FundManagerUpdateSupportedTokenStrategy {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) SetTokenDepositable(token_depositable bool) *FundManagerUpdateSupportedTokenStrategyInstruction {
 	inst.TokenDepositable = &token_depositable
 	return inst
 }
 
 // SetTokenAccumulatedDepositCapacityAmount sets the "token_accumulated_deposit_capacity_amount" parameter.
-func (inst *FundManagerUpdateSupportedTokenStrategy) SetTokenAccumulatedDepositCapacityAmount(token_accumulated_deposit_capacity_amount uint64) *FundManagerUpdateSupportedTokenStrategy {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) SetTokenAccumulatedDepositCapacityAmount(token_accumulated_deposit_capacity_amount uint64) *FundManagerUpdateSupportedTokenStrategyInstruction {
 	inst.TokenAccumulatedDepositCapacityAmount = &token_accumulated_deposit_capacity_amount
 	return inst
 }
 
 // SetTokenAccumulatedDepositAmount sets the "token_accumulated_deposit_amount" parameter.
-func (inst *FundManagerUpdateSupportedTokenStrategy) SetTokenAccumulatedDepositAmount(token_accumulated_deposit_amount uint64) *FundManagerUpdateSupportedTokenStrategy {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) SetTokenAccumulatedDepositAmount(token_accumulated_deposit_amount uint64) *FundManagerUpdateSupportedTokenStrategyInstruction {
 	inst.TokenAccumulatedDepositAmount = &token_accumulated_deposit_amount
 	return inst
 }
 
 // SetTokenWithdrawable sets the "token_withdrawable" parameter.
-func (inst *FundManagerUpdateSupportedTokenStrategy) SetTokenWithdrawable(token_withdrawable bool) *FundManagerUpdateSupportedTokenStrategy {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) SetTokenWithdrawable(token_withdrawable bool) *FundManagerUpdateSupportedTokenStrategyInstruction {
 	inst.TokenWithdrawable = &token_withdrawable
 	return inst
 }
 
 // SetTokenWithdrawalNormalReserveRateBps sets the "token_withdrawal_normal_reserve_rate_bps" parameter.
-func (inst *FundManagerUpdateSupportedTokenStrategy) SetTokenWithdrawalNormalReserveRateBps(token_withdrawal_normal_reserve_rate_bps uint16) *FundManagerUpdateSupportedTokenStrategy {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) SetTokenWithdrawalNormalReserveRateBps(token_withdrawal_normal_reserve_rate_bps uint16) *FundManagerUpdateSupportedTokenStrategyInstruction {
 	inst.TokenWithdrawalNormalReserveRateBps = &token_withdrawal_normal_reserve_rate_bps
 	return inst
 }
 
 // SetTokenWithdrawalNormalReserveMaxAmount sets the "token_withdrawal_normal_reserve_max_amount" parameter.
-func (inst *FundManagerUpdateSupportedTokenStrategy) SetTokenWithdrawalNormalReserveMaxAmount(token_withdrawal_normal_reserve_max_amount uint64) *FundManagerUpdateSupportedTokenStrategy {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) SetTokenWithdrawalNormalReserveMaxAmount(token_withdrawal_normal_reserve_max_amount uint64) *FundManagerUpdateSupportedTokenStrategyInstruction {
 	inst.TokenWithdrawalNormalReserveMaxAmount = &token_withdrawal_normal_reserve_max_amount
 	return inst
 }
 
 // SetTokenRebalancingAmount sets the "token_rebalancing_amount" parameter.
-func (inst *FundManagerUpdateSupportedTokenStrategy) SetTokenRebalancingAmount(token_rebalancing_amount uint64) *FundManagerUpdateSupportedTokenStrategy {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) SetTokenRebalancingAmount(token_rebalancing_amount uint64) *FundManagerUpdateSupportedTokenStrategyInstruction {
 	inst.TokenRebalancingAmount = &token_rebalancing_amount
 	return inst
 }
 
 // SetSolAllocationWeight sets the "sol_allocation_weight" parameter.
-func (inst *FundManagerUpdateSupportedTokenStrategy) SetSolAllocationWeight(sol_allocation_weight uint64) *FundManagerUpdateSupportedTokenStrategy {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) SetSolAllocationWeight(sol_allocation_weight uint64) *FundManagerUpdateSupportedTokenStrategyInstruction {
 	inst.SolAllocationWeight = &sol_allocation_weight
 	return inst
 }
 
 // SetSolAllocationCapacityAmount sets the "sol_allocation_capacity_amount" parameter.
-func (inst *FundManagerUpdateSupportedTokenStrategy) SetSolAllocationCapacityAmount(sol_allocation_capacity_amount uint64) *FundManagerUpdateSupportedTokenStrategy {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) SetSolAllocationCapacityAmount(sol_allocation_capacity_amount uint64) *FundManagerUpdateSupportedTokenStrategyInstruction {
 	inst.SolAllocationCapacityAmount = &sol_allocation_capacity_amount
 	return inst
 }
 
 // SetFundManagerAccount sets the "fund_manager" account.
-func (inst *FundManagerUpdateSupportedTokenStrategy) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerUpdateSupportedTokenStrategy {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) SetFundManagerAccount(fundManager ag_solanago.PublicKey) *FundManagerUpdateSupportedTokenStrategyInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(fundManager).SIGNER()
 	return inst
 }
 
 // GetFundManagerAccount gets the "fund_manager" account.
-func (inst *FundManagerUpdateSupportedTokenStrategy) GetFundManagerAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) GetFundManagerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *FundManagerUpdateSupportedTokenStrategy) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerUpdateSupportedTokenStrategy {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *FundManagerUpdateSupportedTokenStrategyInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *FundManagerUpdateSupportedTokenStrategy) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *FundManagerUpdateSupportedTokenStrategy) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerUpdateSupportedTokenStrategy {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *FundManagerUpdateSupportedTokenStrategyInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *FundManagerUpdateSupportedTokenStrategy) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -149,12 +149,12 @@ func (inst *FundManagerUpdateSupportedTokenStrategy) findFindFundAccountAddress(
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *FundManagerUpdateSupportedTokenStrategy) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *FundManagerUpdateSupportedTokenStrategy) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -163,12 +163,12 @@ func (inst *FundManagerUpdateSupportedTokenStrategy) MustFindFundAccountAddressW
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *FundManagerUpdateSupportedTokenStrategy) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *FundManagerUpdateSupportedTokenStrategy) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -177,17 +177,17 @@ func (inst *FundManagerUpdateSupportedTokenStrategy) MustFindFundAccountAddress(
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *FundManagerUpdateSupportedTokenStrategy) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *FundManagerUpdateSupportedTokenStrategy) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerUpdateSupportedTokenStrategy {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *FundManagerUpdateSupportedTokenStrategyInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *FundManagerUpdateSupportedTokenStrategy) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -202,12 +202,12 @@ func (inst *FundManagerUpdateSupportedTokenStrategy) findFindEventAuthorityAddre
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *FundManagerUpdateSupportedTokenStrategy) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *FundManagerUpdateSupportedTokenStrategy) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -216,12 +216,12 @@ func (inst *FundManagerUpdateSupportedTokenStrategy) MustFindEventAuthorityAddre
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *FundManagerUpdateSupportedTokenStrategy) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *FundManagerUpdateSupportedTokenStrategy) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -230,22 +230,22 @@ func (inst *FundManagerUpdateSupportedTokenStrategy) MustFindEventAuthorityAddre
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *FundManagerUpdateSupportedTokenStrategy) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *FundManagerUpdateSupportedTokenStrategy) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerUpdateSupportedTokenStrategy {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) SetProgramAccount(program ag_solanago.PublicKey) *FundManagerUpdateSupportedTokenStrategyInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *FundManagerUpdateSupportedTokenStrategy) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
-func (inst FundManagerUpdateSupportedTokenStrategy) Build() *Instruction {
+func (inst FundManagerUpdateSupportedTokenStrategyInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_FundManagerUpdateSupportedTokenStrategy,
@@ -255,14 +255,14 @@ func (inst FundManagerUpdateSupportedTokenStrategy) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst FundManagerUpdateSupportedTokenStrategy) ValidateAndBuild() (*Instruction, error) {
+func (inst FundManagerUpdateSupportedTokenStrategyInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *FundManagerUpdateSupportedTokenStrategy) Validate() error {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.TokenMint == nil {
@@ -312,7 +312,7 @@ func (inst *FundManagerUpdateSupportedTokenStrategy) Validate() error {
 	return nil
 }
 
-func (inst *FundManagerUpdateSupportedTokenStrategy) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *FundManagerUpdateSupportedTokenStrategyInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -346,7 +346,7 @@ func (inst *FundManagerUpdateSupportedTokenStrategy) EncodeToTree(parent ag_tree
 		})
 }
 
-func (obj FundManagerUpdateSupportedTokenStrategy) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj FundManagerUpdateSupportedTokenStrategyInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `TokenMint` param:
 	err = encoder.Encode(obj.TokenMint)
 	if err != nil {
@@ -425,7 +425,7 @@ func (obj FundManagerUpdateSupportedTokenStrategy) MarshalWithEncoder(encoder *a
 	}
 	return nil
 }
-func (obj *FundManagerUpdateSupportedTokenStrategy) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *FundManagerUpdateSupportedTokenStrategyInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `TokenMint`:
 	err = decoder.Decode(&obj.TokenMint)
 	if err != nil {
@@ -513,7 +513,7 @@ func NewFundManagerUpdateSupportedTokenStrategyInstruction(
 	receiptTokenMint ag_solanago.PublicKey,
 	fundAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *FundManagerUpdateSupportedTokenStrategy {
+	program ag_solanago.PublicKey) *FundManagerUpdateSupportedTokenStrategyInstruction {
 	return NewFundManagerUpdateSupportedTokenStrategyInstructionBuilder().
 		SetTokenMint(token_mint).
 		SetTokenDepositable(token_depositable).

--- a/generated/restaking/fundmanagerupdatesupportedtokenstrategy_test.go
+++ b/generated/restaking/fundmanagerupdatesupportedtokenstrategy_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_FundManagerUpdateSupportedTokenStrategy(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("FundManagerUpdateSupportedTokenStrategy"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(FundManagerUpdateSupportedTokenStrategy)
+				params := new(FundManagerUpdateSupportedTokenStrategyInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(FundManagerUpdateSupportedTokenStrategy)
+				got := new(FundManagerUpdateSupportedTokenStrategyInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/instructions.go
+++ b/generated/restaking/instructions.go
@@ -273,169 +273,169 @@ var InstructionImplDef = ag_binary.NewVariantDefinition(
 	ag_binary.AnchorTypeIDEncoding,
 	[]ag_binary.VariantType{
 		{
-			Name: "admin_initialize_extra_account_meta_list", Type: (*AdminInitializeExtraAccountMetaList)(nil),
+			Name: "admin_initialize_extra_account_meta_list", Type: (*AdminInitializeExtraAccountMetaListInstruction)(nil),
 		},
 		{
-			Name: "admin_initialize_fund_account", Type: (*AdminInitializeFundAccount)(nil),
+			Name: "admin_initialize_fund_account", Type: (*AdminInitializeFundAccountInstruction)(nil),
 		},
 		{
-			Name: "admin_initialize_fund_wrap_account_reward_account", Type: (*AdminInitializeFundWrapAccountRewardAccount)(nil),
+			Name: "admin_initialize_fund_wrap_account_reward_account", Type: (*AdminInitializeFundWrapAccountRewardAccountInstruction)(nil),
 		},
 		{
-			Name: "admin_initialize_normalized_token_pool_account", Type: (*AdminInitializeNormalizedTokenPoolAccount)(nil),
+			Name: "admin_initialize_normalized_token_pool_account", Type: (*AdminInitializeNormalizedTokenPoolAccountInstruction)(nil),
 		},
 		{
-			Name: "admin_initialize_reward_account", Type: (*AdminInitializeRewardAccount)(nil),
+			Name: "admin_initialize_reward_account", Type: (*AdminInitializeRewardAccountInstruction)(nil),
 		},
 		{
-			Name: "admin_set_address_lookup_table_account", Type: (*AdminSetAddressLookupTableAccount)(nil),
+			Name: "admin_set_address_lookup_table_account", Type: (*AdminSetAddressLookupTableAccountInstruction)(nil),
 		},
 		{
-			Name: "admin_update_extra_account_meta_list_if_needed", Type: (*AdminUpdateExtraAccountMetaListIfNeeded)(nil),
+			Name: "admin_update_extra_account_meta_list_if_needed", Type: (*AdminUpdateExtraAccountMetaListIfNeededInstruction)(nil),
 		},
 		{
-			Name: "admin_update_fund_account_if_needed", Type: (*AdminUpdateFundAccountIfNeeded)(nil),
+			Name: "admin_update_fund_account_if_needed", Type: (*AdminUpdateFundAccountIfNeededInstruction)(nil),
 		},
 		{
-			Name: "admin_update_fund_wrap_account_reward_account_if_needed", Type: (*AdminUpdateFundWrapAccountRewardAccountIfNeeded)(nil),
+			Name: "admin_update_fund_wrap_account_reward_account_if_needed", Type: (*AdminUpdateFundWrapAccountRewardAccountIfNeededInstruction)(nil),
 		},
 		{
-			Name: "admin_update_normalized_token_pool_account_if_needed", Type: (*AdminUpdateNormalizedTokenPoolAccountIfNeeded)(nil),
+			Name: "admin_update_normalized_token_pool_account_if_needed", Type: (*AdminUpdateNormalizedTokenPoolAccountIfNeededInstruction)(nil),
 		},
 		{
-			Name: "admin_update_reward_account_if_needed", Type: (*AdminUpdateRewardAccountIfNeeded)(nil),
+			Name: "admin_update_reward_account_if_needed", Type: (*AdminUpdateRewardAccountIfNeededInstruction)(nil),
 		},
 		{
-			Name: "fund_manager_add_normalized_token_pool_supported_token", Type: (*FundManagerAddNormalizedTokenPoolSupportedToken)(nil),
+			Name: "fund_manager_add_normalized_token_pool_supported_token", Type: (*FundManagerAddNormalizedTokenPoolSupportedTokenInstruction)(nil),
 		},
 		{
-			Name: "fund_manager_add_restaking_vault_compounding_reward_token", Type: (*FundManagerAddRestakingVaultCompoundingRewardToken)(nil),
+			Name: "fund_manager_add_restaking_vault_compounding_reward_token", Type: (*FundManagerAddRestakingVaultCompoundingRewardTokenInstruction)(nil),
 		},
 		{
-			Name: "fund_manager_add_reward", Type: (*FundManagerAddReward)(nil),
+			Name: "fund_manager_add_reward", Type: (*FundManagerAddRewardInstruction)(nil),
 		},
 		{
-			Name: "fund_manager_add_reward_pool", Type: (*FundManagerAddRewardPool)(nil),
+			Name: "fund_manager_add_reward_pool", Type: (*FundManagerAddRewardPoolInstruction)(nil),
 		},
 		{
-			Name: "fund_manager_add_reward_pool_holder", Type: (*FundManagerAddRewardPoolHolder)(nil),
+			Name: "fund_manager_add_reward_pool_holder", Type: (*FundManagerAddRewardPoolHolderInstruction)(nil),
 		},
 		{
-			Name: "fund_manager_add_supported_token", Type: (*FundManagerAddSupportedToken)(nil),
+			Name: "fund_manager_add_supported_token", Type: (*FundManagerAddSupportedTokenInstruction)(nil),
 		},
 		{
-			Name: "fund_manager_add_token_swap_strategy", Type: (*FundManagerAddTokenSwapStrategy)(nil),
+			Name: "fund_manager_add_token_swap_strategy", Type: (*FundManagerAddTokenSwapStrategyInstruction)(nil),
 		},
 		{
-			Name: "fund_manager_close_reward_pool", Type: (*FundManagerCloseRewardPool)(nil),
+			Name: "fund_manager_close_reward_pool", Type: (*FundManagerCloseRewardPoolInstruction)(nil),
 		},
 		{
-			Name: "fund_manager_initialize_fund_jito_restaking_vault", Type: (*FundManagerInitializeFundJitoRestakingVault)(nil),
+			Name: "fund_manager_initialize_fund_jito_restaking_vault", Type: (*FundManagerInitializeFundJitoRestakingVaultInstruction)(nil),
 		},
 		{
-			Name: "fund_manager_initialize_fund_jito_restaking_vault_delegation", Type: (*FundManagerInitializeFundJitoRestakingVaultDelegation)(nil),
+			Name: "fund_manager_initialize_fund_jito_restaking_vault_delegation", Type: (*FundManagerInitializeFundJitoRestakingVaultDelegationInstruction)(nil),
 		},
 		{
-			Name: "fund_manager_initialize_fund_normalized_token", Type: (*FundManagerInitializeFundNormalizedToken)(nil),
+			Name: "fund_manager_initialize_fund_normalized_token", Type: (*FundManagerInitializeFundNormalizedTokenInstruction)(nil),
 		},
 		{
-			Name: "fund_manager_initialize_fund_wrapped_token", Type: (*FundManagerInitializeFundWrappedToken)(nil),
+			Name: "fund_manager_initialize_fund_wrapped_token", Type: (*FundManagerInitializeFundWrappedTokenInstruction)(nil),
 		},
 		{
-			Name: "fund_manager_settle_reward", Type: (*FundManagerSettleReward)(nil),
+			Name: "fund_manager_settle_reward", Type: (*FundManagerSettleRewardInstruction)(nil),
 		},
 		{
-			Name: "fund_manager_update_fund_strategy", Type: (*FundManagerUpdateFundStrategy)(nil),
+			Name: "fund_manager_update_fund_strategy", Type: (*FundManagerUpdateFundStrategyInstruction)(nil),
 		},
 		{
-			Name: "fund_manager_update_restaking_vault_delegation_strategy", Type: (*FundManagerUpdateRestakingVaultDelegationStrategy)(nil),
+			Name: "fund_manager_update_restaking_vault_delegation_strategy", Type: (*FundManagerUpdateRestakingVaultDelegationStrategyInstruction)(nil),
 		},
 		{
-			Name: "fund_manager_update_restaking_vault_strategy", Type: (*FundManagerUpdateRestakingVaultStrategy)(nil),
+			Name: "fund_manager_update_restaking_vault_strategy", Type: (*FundManagerUpdateRestakingVaultStrategyInstruction)(nil),
 		},
 		{
-			Name: "fund_manager_update_sol_strategy", Type: (*FundManagerUpdateSolStrategy)(nil),
+			Name: "fund_manager_update_sol_strategy", Type: (*FundManagerUpdateSolStrategyInstruction)(nil),
 		},
 		{
-			Name: "fund_manager_update_supported_token_strategy", Type: (*FundManagerUpdateSupportedTokenStrategy)(nil),
+			Name: "fund_manager_update_supported_token_strategy", Type: (*FundManagerUpdateSupportedTokenStrategyInstruction)(nil),
 		},
 		{
-			Name: "operator_donate_sol_to_fund", Type: (*OperatorDonateSolToFund)(nil),
+			Name: "operator_donate_sol_to_fund", Type: (*OperatorDonateSolToFundInstruction)(nil),
 		},
 		{
-			Name: "operator_donate_supported_token_to_fund", Type: (*OperatorDonateSupportedTokenToFund)(nil),
+			Name: "operator_donate_supported_token_to_fund", Type: (*OperatorDonateSupportedTokenToFundInstruction)(nil),
 		},
 		{
-			Name: "operator_log_message", Type: (*OperatorLogMessage)(nil),
+			Name: "operator_log_message", Type: (*OperatorLogMessageInstruction)(nil),
 		},
 		{
-			Name: "operator_run_fund_command", Type: (*OperatorRunFundCommand)(nil),
+			Name: "operator_run_fund_command", Type: (*OperatorRunFundCommandInstruction)(nil),
 		},
 		{
-			Name: "operator_update_fund_prices", Type: (*OperatorUpdateFundPrices)(nil),
+			Name: "operator_update_fund_prices", Type: (*OperatorUpdateFundPricesInstruction)(nil),
 		},
 		{
-			Name: "operator_update_normalized_token_pool_prices", Type: (*OperatorUpdateNormalizedTokenPoolPrices)(nil),
+			Name: "operator_update_normalized_token_pool_prices", Type: (*OperatorUpdateNormalizedTokenPoolPricesInstruction)(nil),
 		},
 		{
-			Name: "operator_update_reward_pools", Type: (*OperatorUpdateRewardPools)(nil),
+			Name: "operator_update_reward_pools", Type: (*OperatorUpdateRewardPoolsInstruction)(nil),
 		},
 		{
-			Name: "slasher_initialize_normalized_token_withdrawal_account", Type: (*SlasherInitializeNormalizedTokenWithdrawalAccount)(nil),
+			Name: "slasher_initialize_normalized_token_withdrawal_account", Type: (*SlasherInitializeNormalizedTokenWithdrawalAccountInstruction)(nil),
 		},
 		{
-			Name: "slasher_withdraw_normalized_token", Type: (*SlasherWithdrawNormalizedToken)(nil),
+			Name: "slasher_withdraw_normalized_token", Type: (*SlasherWithdrawNormalizedTokenInstruction)(nil),
 		},
 		{
-			Name: "user_cancel_withdrawal_request", Type: (*UserCancelWithdrawalRequest)(nil),
+			Name: "user_cancel_withdrawal_request", Type: (*UserCancelWithdrawalRequestInstruction)(nil),
 		},
 		{
-			Name: "user_claim_rewards", Type: (*UserClaimRewards)(nil),
+			Name: "user_claim_rewards", Type: (*UserClaimRewardsInstruction)(nil),
 		},
 		{
-			Name: "user_create_fund_account_idempotent", Type: (*UserCreateFundAccountIdempotent)(nil),
+			Name: "user_create_fund_account_idempotent", Type: (*UserCreateFundAccountIdempotentInstruction)(nil),
 		},
 		{
-			Name: "user_create_reward_account_idempotent", Type: (*UserCreateRewardAccountIdempotent)(nil),
+			Name: "user_create_reward_account_idempotent", Type: (*UserCreateRewardAccountIdempotentInstruction)(nil),
 		},
 		{
-			Name: "user_deposit_sol", Type: (*UserDepositSol)(nil),
+			Name: "user_deposit_sol", Type: (*UserDepositSolInstruction)(nil),
 		},
 		{
-			Name: "user_deposit_supported_token", Type: (*UserDepositSupportedToken)(nil),
+			Name: "user_deposit_supported_token", Type: (*UserDepositSupportedTokenInstruction)(nil),
 		},
 		{
-			Name: "user_initialize_fund_account", Type: (*UserInitializeFundAccount)(nil),
+			Name: "user_initialize_fund_account", Type: (*UserInitializeFundAccountInstruction)(nil),
 		},
 		{
-			Name: "user_initialize_reward_account", Type: (*UserInitializeRewardAccount)(nil),
+			Name: "user_initialize_reward_account", Type: (*UserInitializeRewardAccountInstruction)(nil),
 		},
 		{
-			Name: "user_request_withdrawal", Type: (*UserRequestWithdrawal)(nil),
+			Name: "user_request_withdrawal", Type: (*UserRequestWithdrawalInstruction)(nil),
 		},
 		{
-			Name: "user_unwrap_receipt_token", Type: (*UserUnwrapReceiptToken)(nil),
+			Name: "user_unwrap_receipt_token", Type: (*UserUnwrapReceiptTokenInstruction)(nil),
 		},
 		{
-			Name: "user_update_fund_account_if_needed", Type: (*UserUpdateFundAccountIfNeeded)(nil),
+			Name: "user_update_fund_account_if_needed", Type: (*UserUpdateFundAccountIfNeededInstruction)(nil),
 		},
 		{
-			Name: "user_update_reward_account_if_needed", Type: (*UserUpdateRewardAccountIfNeeded)(nil),
+			Name: "user_update_reward_account_if_needed", Type: (*UserUpdateRewardAccountIfNeededInstruction)(nil),
 		},
 		{
-			Name: "user_update_reward_pools", Type: (*UserUpdateRewardPools)(nil),
+			Name: "user_update_reward_pools", Type: (*UserUpdateRewardPoolsInstruction)(nil),
 		},
 		{
-			Name: "user_withdraw_sol", Type: (*UserWithdrawSol)(nil),
+			Name: "user_withdraw_sol", Type: (*UserWithdrawSolInstruction)(nil),
 		},
 		{
-			Name: "user_withdraw_supported_token", Type: (*UserWithdrawSupportedToken)(nil),
+			Name: "user_withdraw_supported_token", Type: (*UserWithdrawSupportedTokenInstruction)(nil),
 		},
 		{
-			Name: "user_wrap_receipt_token", Type: (*UserWrapReceiptToken)(nil),
+			Name: "user_wrap_receipt_token", Type: (*UserWrapReceiptTokenInstruction)(nil),
 		},
 		{
-			Name: "user_wrap_receipt_token_if_needed", Type: (*UserWrapReceiptTokenIfNeeded)(nil),
+			Name: "user_wrap_receipt_token_if_needed", Type: (*UserWrapReceiptTokenIfNeededInstruction)(nil),
 		},
 	},
 )

--- a/generated/restaking/operatordonatesoltofund.go
+++ b/generated/restaking/operatordonatesoltofund.go
@@ -11,7 +11,7 @@ import (
 )
 
 // OperatorDonateSolToFund is the `operator_donate_sol_to_fund` instruction.
-type OperatorDonateSolToFund struct {
+type OperatorDonateSolToFundInstruction struct {
 	Amount           *uint64
 	OffsetReceivable *bool
 
@@ -33,9 +33,9 @@ type OperatorDonateSolToFund struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewOperatorDonateSolToFundInstructionBuilder creates a new `OperatorDonateSolToFund` instruction builder.
-func NewOperatorDonateSolToFundInstructionBuilder() *OperatorDonateSolToFund {
-	nd := &OperatorDonateSolToFund{
+// NewOperatorDonateSolToFundInstructionBuilder creates a new `OperatorDonateSolToFundInstruction` instruction builder.
+func NewOperatorDonateSolToFundInstructionBuilder() *OperatorDonateSolToFundInstruction {
+	nd := &OperatorDonateSolToFundInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 8),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["11111111111111111111111111111111"])
@@ -44,68 +44,68 @@ func NewOperatorDonateSolToFundInstructionBuilder() *OperatorDonateSolToFund {
 }
 
 // SetAmount sets the "amount" parameter.
-func (inst *OperatorDonateSolToFund) SetAmount(amount uint64) *OperatorDonateSolToFund {
+func (inst *OperatorDonateSolToFundInstruction) SetAmount(amount uint64) *OperatorDonateSolToFundInstruction {
 	inst.Amount = &amount
 	return inst
 }
 
 // SetOffsetReceivable sets the "offset_receivable" parameter.
-func (inst *OperatorDonateSolToFund) SetOffsetReceivable(offset_receivable bool) *OperatorDonateSolToFund {
+func (inst *OperatorDonateSolToFundInstruction) SetOffsetReceivable(offset_receivable bool) *OperatorDonateSolToFundInstruction {
 	inst.OffsetReceivable = &offset_receivable
 	return inst
 }
 
 // SetOperatorAccount sets the "operator" account.
-func (inst *OperatorDonateSolToFund) SetOperatorAccount(operator ag_solanago.PublicKey) *OperatorDonateSolToFund {
+func (inst *OperatorDonateSolToFundInstruction) SetOperatorAccount(operator ag_solanago.PublicKey) *OperatorDonateSolToFundInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(operator).WRITE().SIGNER()
 	return inst
 }
 
 // GetOperatorAccount gets the "operator" account.
-func (inst *OperatorDonateSolToFund) GetOperatorAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorDonateSolToFundInstruction) GetOperatorAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *OperatorDonateSolToFund) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *OperatorDonateSolToFund {
+func (inst *OperatorDonateSolToFundInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *OperatorDonateSolToFundInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *OperatorDonateSolToFund) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorDonateSolToFundInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *OperatorDonateSolToFund) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *OperatorDonateSolToFund {
+func (inst *OperatorDonateSolToFundInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *OperatorDonateSolToFundInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *OperatorDonateSolToFund) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorDonateSolToFundInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetReceiptTokenProgramAccount sets the "receipt_token_program" account.
-func (inst *OperatorDonateSolToFund) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *OperatorDonateSolToFund {
+func (inst *OperatorDonateSolToFundInstruction) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *OperatorDonateSolToFundInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenProgram)
 	return inst
 }
 
 // GetReceiptTokenProgramAccount gets the "receipt_token_program" account.
-func (inst *OperatorDonateSolToFund) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorDonateSolToFundInstruction) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *OperatorDonateSolToFund) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *OperatorDonateSolToFund {
+func (inst *OperatorDonateSolToFundInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *OperatorDonateSolToFundInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *OperatorDonateSolToFund) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorDonateSolToFundInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -122,12 +122,12 @@ func (inst *OperatorDonateSolToFund) findFindFundAccountAddress(receiptTokenMint
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *OperatorDonateSolToFund) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *OperatorDonateSolToFundInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *OperatorDonateSolToFund) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *OperatorDonateSolToFundInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -136,12 +136,12 @@ func (inst *OperatorDonateSolToFund) MustFindFundAccountAddressWithBumpSeed(rece
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *OperatorDonateSolToFund) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorDonateSolToFundInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *OperatorDonateSolToFund) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *OperatorDonateSolToFundInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -150,17 +150,17 @@ func (inst *OperatorDonateSolToFund) MustFindFundAccountAddress(receiptTokenMint
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *OperatorDonateSolToFund) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorDonateSolToFundInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetFundReserveAccountAccount sets the "fund_reserve_account" account.
-func (inst *OperatorDonateSolToFund) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *OperatorDonateSolToFund {
+func (inst *OperatorDonateSolToFundInstruction) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *OperatorDonateSolToFundInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(fundReserveAccount).WRITE()
 	return inst
 }
 
-func (inst *OperatorDonateSolToFund) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorDonateSolToFundInstruction) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_reserve
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x72), byte(0x65), byte(0x73), byte(0x65), byte(0x72), byte(0x76), byte(0x65)})
@@ -177,12 +177,12 @@ func (inst *OperatorDonateSolToFund) findFindFundReserveAccountAddress(receiptTo
 }
 
 // FindFundReserveAccountAddressWithBumpSeed calculates FundReserveAccount account address with given seeds and a known bump seed.
-func (inst *OperatorDonateSolToFund) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *OperatorDonateSolToFundInstruction) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *OperatorDonateSolToFund) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *OperatorDonateSolToFundInstruction) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -191,12 +191,12 @@ func (inst *OperatorDonateSolToFund) MustFindFundReserveAccountAddressWithBumpSe
 }
 
 // FindFundReserveAccountAddress finds FundReserveAccount account address with given seeds.
-func (inst *OperatorDonateSolToFund) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorDonateSolToFundInstruction) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *OperatorDonateSolToFund) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *OperatorDonateSolToFundInstruction) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -205,17 +205,17 @@ func (inst *OperatorDonateSolToFund) MustFindFundReserveAccountAddress(receiptTo
 }
 
 // GetFundReserveAccountAccount gets the "fund_reserve_account" account.
-func (inst *OperatorDonateSolToFund) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorDonateSolToFundInstruction) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *OperatorDonateSolToFund) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *OperatorDonateSolToFund {
+func (inst *OperatorDonateSolToFundInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *OperatorDonateSolToFundInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *OperatorDonateSolToFund) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorDonateSolToFundInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -230,12 +230,12 @@ func (inst *OperatorDonateSolToFund) findFindEventAuthorityAddress(knownBumpSeed
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *OperatorDonateSolToFund) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *OperatorDonateSolToFundInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *OperatorDonateSolToFund) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *OperatorDonateSolToFundInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -244,12 +244,12 @@ func (inst *OperatorDonateSolToFund) MustFindEventAuthorityAddressWithBumpSeed(b
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *OperatorDonateSolToFund) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorDonateSolToFundInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *OperatorDonateSolToFund) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *OperatorDonateSolToFundInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -258,22 +258,22 @@ func (inst *OperatorDonateSolToFund) MustFindEventAuthorityAddress() (pda ag_sol
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *OperatorDonateSolToFund) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorDonateSolToFundInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *OperatorDonateSolToFund) SetProgramAccount(program ag_solanago.PublicKey) *OperatorDonateSolToFund {
+func (inst *OperatorDonateSolToFundInstruction) SetProgramAccount(program ag_solanago.PublicKey) *OperatorDonateSolToFundInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *OperatorDonateSolToFund) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorDonateSolToFundInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
-func (inst OperatorDonateSolToFund) Build() *Instruction {
+func (inst OperatorDonateSolToFundInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_OperatorDonateSolToFund,
@@ -283,14 +283,14 @@ func (inst OperatorDonateSolToFund) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst OperatorDonateSolToFund) ValidateAndBuild() (*Instruction, error) {
+func (inst OperatorDonateSolToFundInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *OperatorDonateSolToFund) Validate() error {
+func (inst *OperatorDonateSolToFundInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.Amount == nil {
@@ -331,7 +331,7 @@ func (inst *OperatorDonateSolToFund) Validate() error {
 	return nil
 }
 
-func (inst *OperatorDonateSolToFund) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *OperatorDonateSolToFundInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -360,7 +360,7 @@ func (inst *OperatorDonateSolToFund) EncodeToTree(parent ag_treeout.Branches) {
 		})
 }
 
-func (obj OperatorDonateSolToFund) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj OperatorDonateSolToFundInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `Amount` param:
 	err = encoder.Encode(obj.Amount)
 	if err != nil {
@@ -373,7 +373,7 @@ func (obj OperatorDonateSolToFund) MarshalWithEncoder(encoder *ag_binary.Encoder
 	}
 	return nil
 }
-func (obj *OperatorDonateSolToFund) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *OperatorDonateSolToFundInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `Amount`:
 	err = decoder.Decode(&obj.Amount)
 	if err != nil {
@@ -400,7 +400,7 @@ func NewOperatorDonateSolToFundInstruction(
 	fundAccount ag_solanago.PublicKey,
 	fundReserveAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *OperatorDonateSolToFund {
+	program ag_solanago.PublicKey) *OperatorDonateSolToFundInstruction {
 	return NewOperatorDonateSolToFundInstructionBuilder().
 		SetAmount(amount).
 		SetOffsetReceivable(offset_receivable).

--- a/generated/restaking/operatordonatesoltofund_test.go
+++ b/generated/restaking/operatordonatesoltofund_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_OperatorDonateSolToFund(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("OperatorDonateSolToFund"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(OperatorDonateSolToFund)
+				params := new(OperatorDonateSolToFundInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(OperatorDonateSolToFund)
+				got := new(OperatorDonateSolToFundInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/operatordonatesupportedtokentofund.go
+++ b/generated/restaking/operatordonatesupportedtokentofund.go
@@ -11,7 +11,7 @@ import (
 )
 
 // OperatorDonateSupportedTokenToFund is the `operator_donate_supported_token_to_fund` instruction.
-type OperatorDonateSupportedTokenToFund struct {
+type OperatorDonateSupportedTokenToFundInstruction struct {
 	Amount           *uint64
 	OffsetReceivable *bool
 
@@ -39,9 +39,9 @@ type OperatorDonateSupportedTokenToFund struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewOperatorDonateSupportedTokenToFundInstructionBuilder creates a new `OperatorDonateSupportedTokenToFund` instruction builder.
-func NewOperatorDonateSupportedTokenToFundInstructionBuilder() *OperatorDonateSupportedTokenToFund {
-	nd := &OperatorDonateSupportedTokenToFund{
+// NewOperatorDonateSupportedTokenToFundInstructionBuilder creates a new `OperatorDonateSupportedTokenToFundInstruction` instruction builder.
+func NewOperatorDonateSupportedTokenToFundInstructionBuilder() *OperatorDonateSupportedTokenToFundInstruction {
+	nd := &OperatorDonateSupportedTokenToFundInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 11),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"])
@@ -49,79 +49,79 @@ func NewOperatorDonateSupportedTokenToFundInstructionBuilder() *OperatorDonateSu
 }
 
 // SetAmount sets the "amount" parameter.
-func (inst *OperatorDonateSupportedTokenToFund) SetAmount(amount uint64) *OperatorDonateSupportedTokenToFund {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) SetAmount(amount uint64) *OperatorDonateSupportedTokenToFundInstruction {
 	inst.Amount = &amount
 	return inst
 }
 
 // SetOffsetReceivable sets the "offset_receivable" parameter.
-func (inst *OperatorDonateSupportedTokenToFund) SetOffsetReceivable(offset_receivable bool) *OperatorDonateSupportedTokenToFund {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) SetOffsetReceivable(offset_receivable bool) *OperatorDonateSupportedTokenToFundInstruction {
 	inst.OffsetReceivable = &offset_receivable
 	return inst
 }
 
 // SetOperatorAccount sets the "operator" account.
-func (inst *OperatorDonateSupportedTokenToFund) SetOperatorAccount(operator ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFund {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) SetOperatorAccount(operator ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFundInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(operator).WRITE().SIGNER()
 	return inst
 }
 
 // GetOperatorAccount gets the "operator" account.
-func (inst *OperatorDonateSupportedTokenToFund) GetOperatorAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) GetOperatorAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetReceiptTokenProgramAccount sets the "receipt_token_program" account.
-func (inst *OperatorDonateSupportedTokenToFund) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFund {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFundInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(receiptTokenProgram)
 	return inst
 }
 
 // GetReceiptTokenProgramAccount gets the "receipt_token_program" account.
-func (inst *OperatorDonateSupportedTokenToFund) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetSupportedTokenProgramAccount sets the "supported_token_program" account.
-func (inst *OperatorDonateSupportedTokenToFund) SetSupportedTokenProgramAccount(supportedTokenProgram ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFund {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) SetSupportedTokenProgramAccount(supportedTokenProgram ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFundInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(supportedTokenProgram)
 	return inst
 }
 
 // GetSupportedTokenProgramAccount gets the "supported_token_program" account.
-func (inst *OperatorDonateSupportedTokenToFund) GetSupportedTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) GetSupportedTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *OperatorDonateSupportedTokenToFund) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFund {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFundInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *OperatorDonateSupportedTokenToFund) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetSupportedTokenMintAccount sets the "supported_token_mint" account.
-func (inst *OperatorDonateSupportedTokenToFund) SetSupportedTokenMintAccount(supportedTokenMint ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFund {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) SetSupportedTokenMintAccount(supportedTokenMint ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFundInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(supportedTokenMint)
 	return inst
 }
 
 // GetSupportedTokenMintAccount gets the "supported_token_mint" account.
-func (inst *OperatorDonateSupportedTokenToFund) GetSupportedTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) GetSupportedTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetFundSupportedTokenReserveAccountAccount sets the "fund_supported_token_reserve_account" account.
-func (inst *OperatorDonateSupportedTokenToFund) SetFundSupportedTokenReserveAccountAccount(fundSupportedTokenReserveAccount ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFund {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) SetFundSupportedTokenReserveAccountAccount(fundSupportedTokenReserveAccount ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFundInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(fundSupportedTokenReserveAccount).WRITE()
 	return inst
 }
 
-func (inst *OperatorDonateSupportedTokenToFund) findFindFundSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) findFindFundSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: fundReserveAccount
 	seeds = append(seeds, fundReserveAccount.Bytes())
@@ -142,12 +142,12 @@ func (inst *OperatorDonateSupportedTokenToFund) findFindFundSupportedTokenReserv
 }
 
 // FindFundSupportedTokenReserveAccountAddressWithBumpSeed calculates FundSupportedTokenReserveAccount account address with given seeds and a known bump seed.
-func (inst *OperatorDonateSupportedTokenToFund) FindFundSupportedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) FindFundSupportedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundSupportedTokenReserveAccountAddress(fundReserveAccount, supportedTokenProgram, supportedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *OperatorDonateSupportedTokenToFund) MustFindFundSupportedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) MustFindFundSupportedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundSupportedTokenReserveAccountAddress(fundReserveAccount, supportedTokenProgram, supportedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -156,12 +156,12 @@ func (inst *OperatorDonateSupportedTokenToFund) MustFindFundSupportedTokenReserv
 }
 
 // FindFundSupportedTokenReserveAccountAddress finds FundSupportedTokenReserveAccount account address with given seeds.
-func (inst *OperatorDonateSupportedTokenToFund) FindFundSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) FindFundSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundSupportedTokenReserveAccountAddress(fundReserveAccount, supportedTokenProgram, supportedTokenMint, 0)
 	return
 }
 
-func (inst *OperatorDonateSupportedTokenToFund) MustFindFundSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) MustFindFundSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundSupportedTokenReserveAccountAddress(fundReserveAccount, supportedTokenProgram, supportedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -170,28 +170,28 @@ func (inst *OperatorDonateSupportedTokenToFund) MustFindFundSupportedTokenReserv
 }
 
 // GetFundSupportedTokenReserveAccountAccount gets the "fund_supported_token_reserve_account" account.
-func (inst *OperatorDonateSupportedTokenToFund) GetFundSupportedTokenReserveAccountAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) GetFundSupportedTokenReserveAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetOperatorSupportedTokenAccountAccount sets the "operator_supported_token_account" account.
-func (inst *OperatorDonateSupportedTokenToFund) SetOperatorSupportedTokenAccountAccount(operatorSupportedTokenAccount ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFund {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) SetOperatorSupportedTokenAccountAccount(operatorSupportedTokenAccount ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFundInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(operatorSupportedTokenAccount).WRITE()
 	return inst
 }
 
 // GetOperatorSupportedTokenAccountAccount gets the "operator_supported_token_account" account.
-func (inst *OperatorDonateSupportedTokenToFund) GetOperatorSupportedTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) GetOperatorSupportedTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *OperatorDonateSupportedTokenToFund) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFund {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFundInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *OperatorDonateSupportedTokenToFund) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -208,12 +208,12 @@ func (inst *OperatorDonateSupportedTokenToFund) findFindFundAccountAddress(recei
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *OperatorDonateSupportedTokenToFund) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *OperatorDonateSupportedTokenToFund) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -222,12 +222,12 @@ func (inst *OperatorDonateSupportedTokenToFund) MustFindFundAccountAddressWithBu
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *OperatorDonateSupportedTokenToFund) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *OperatorDonateSupportedTokenToFund) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -236,17 +236,17 @@ func (inst *OperatorDonateSupportedTokenToFund) MustFindFundAccountAddress(recei
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *OperatorDonateSupportedTokenToFund) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetFundReserveAccountAccount sets the "fund_reserve_account" account.
-func (inst *OperatorDonateSupportedTokenToFund) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFund {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFundInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(fundReserveAccount)
 	return inst
 }
 
-func (inst *OperatorDonateSupportedTokenToFund) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_reserve
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x72), byte(0x65), byte(0x73), byte(0x65), byte(0x72), byte(0x76), byte(0x65)})
@@ -263,12 +263,12 @@ func (inst *OperatorDonateSupportedTokenToFund) findFindFundReserveAccountAddres
 }
 
 // FindFundReserveAccountAddressWithBumpSeed calculates FundReserveAccount account address with given seeds and a known bump seed.
-func (inst *OperatorDonateSupportedTokenToFund) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *OperatorDonateSupportedTokenToFund) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -277,12 +277,12 @@ func (inst *OperatorDonateSupportedTokenToFund) MustFindFundReserveAccountAddres
 }
 
 // FindFundReserveAccountAddress finds FundReserveAccount account address with given seeds.
-func (inst *OperatorDonateSupportedTokenToFund) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *OperatorDonateSupportedTokenToFund) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -291,17 +291,17 @@ func (inst *OperatorDonateSupportedTokenToFund) MustFindFundReserveAccountAddres
 }
 
 // GetFundReserveAccountAccount gets the "fund_reserve_account" account.
-func (inst *OperatorDonateSupportedTokenToFund) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *OperatorDonateSupportedTokenToFund) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFund {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFundInstruction {
 	inst.AccountMetaSlice[9] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *OperatorDonateSupportedTokenToFund) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -316,12 +316,12 @@ func (inst *OperatorDonateSupportedTokenToFund) findFindEventAuthorityAddress(kn
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *OperatorDonateSupportedTokenToFund) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *OperatorDonateSupportedTokenToFund) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -330,12 +330,12 @@ func (inst *OperatorDonateSupportedTokenToFund) MustFindEventAuthorityAddressWit
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *OperatorDonateSupportedTokenToFund) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *OperatorDonateSupportedTokenToFund) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -344,22 +344,22 @@ func (inst *OperatorDonateSupportedTokenToFund) MustFindEventAuthorityAddress() 
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *OperatorDonateSupportedTokenToFund) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(9)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *OperatorDonateSupportedTokenToFund) SetProgramAccount(program ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFund {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) SetProgramAccount(program ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFundInstruction {
 	inst.AccountMetaSlice[10] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *OperatorDonateSupportedTokenToFund) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(10)
 }
 
-func (inst OperatorDonateSupportedTokenToFund) Build() *Instruction {
+func (inst OperatorDonateSupportedTokenToFundInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_OperatorDonateSupportedTokenToFund,
@@ -369,14 +369,14 @@ func (inst OperatorDonateSupportedTokenToFund) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst OperatorDonateSupportedTokenToFund) ValidateAndBuild() (*Instruction, error) {
+func (inst OperatorDonateSupportedTokenToFundInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *OperatorDonateSupportedTokenToFund) Validate() error {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.Amount == nil {
@@ -426,7 +426,7 @@ func (inst *OperatorDonateSupportedTokenToFund) Validate() error {
 	return nil
 }
 
-func (inst *OperatorDonateSupportedTokenToFund) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *OperatorDonateSupportedTokenToFundInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -458,7 +458,7 @@ func (inst *OperatorDonateSupportedTokenToFund) EncodeToTree(parent ag_treeout.B
 		})
 }
 
-func (obj OperatorDonateSupportedTokenToFund) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj OperatorDonateSupportedTokenToFundInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `Amount` param:
 	err = encoder.Encode(obj.Amount)
 	if err != nil {
@@ -471,7 +471,7 @@ func (obj OperatorDonateSupportedTokenToFund) MarshalWithEncoder(encoder *ag_bin
 	}
 	return nil
 }
-func (obj *OperatorDonateSupportedTokenToFund) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *OperatorDonateSupportedTokenToFundInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `Amount`:
 	err = decoder.Decode(&obj.Amount)
 	if err != nil {
@@ -501,7 +501,7 @@ func NewOperatorDonateSupportedTokenToFundInstruction(
 	fundAccount ag_solanago.PublicKey,
 	fundReserveAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFund {
+	program ag_solanago.PublicKey) *OperatorDonateSupportedTokenToFundInstruction {
 	return NewOperatorDonateSupportedTokenToFundInstructionBuilder().
 		SetAmount(amount).
 		SetOffsetReceivable(offset_receivable).

--- a/generated/restaking/operatordonatesupportedtokentofund_test.go
+++ b/generated/restaking/operatordonatesupportedtokentofund_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_OperatorDonateSupportedTokenToFund(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("OperatorDonateSupportedTokenToFund"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(OperatorDonateSupportedTokenToFund)
+				params := new(OperatorDonateSupportedTokenToFundInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(OperatorDonateSupportedTokenToFund)
+				got := new(OperatorDonateSupportedTokenToFundInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/operatorlogmessage.go
+++ b/generated/restaking/operatorlogmessage.go
@@ -11,7 +11,7 @@ import (
 )
 
 // OperatorLogMessage is the `operator_log_message` instruction.
-type OperatorLogMessage struct {
+type OperatorLogMessageInstruction struct {
 	Message *string
 
 	// [0] = [] event_authority
@@ -20,27 +20,27 @@ type OperatorLogMessage struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewOperatorLogMessageInstructionBuilder creates a new `OperatorLogMessage` instruction builder.
-func NewOperatorLogMessageInstructionBuilder() *OperatorLogMessage {
-	nd := &OperatorLogMessage{
+// NewOperatorLogMessageInstructionBuilder creates a new `OperatorLogMessageInstruction` instruction builder.
+func NewOperatorLogMessageInstructionBuilder() *OperatorLogMessageInstruction {
+	nd := &OperatorLogMessageInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 2),
 	}
 	return nd
 }
 
 // SetMessage sets the "message" parameter.
-func (inst *OperatorLogMessage) SetMessage(message string) *OperatorLogMessage {
+func (inst *OperatorLogMessageInstruction) SetMessage(message string) *OperatorLogMessageInstruction {
 	inst.Message = &message
 	return inst
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *OperatorLogMessage) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *OperatorLogMessage {
+func (inst *OperatorLogMessageInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *OperatorLogMessageInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *OperatorLogMessage) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorLogMessageInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -55,12 +55,12 @@ func (inst *OperatorLogMessage) findFindEventAuthorityAddress(knownBumpSeed uint
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *OperatorLogMessage) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *OperatorLogMessageInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *OperatorLogMessage) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *OperatorLogMessageInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -69,12 +69,12 @@ func (inst *OperatorLogMessage) MustFindEventAuthorityAddressWithBumpSeed(bumpSe
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *OperatorLogMessage) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorLogMessageInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *OperatorLogMessage) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *OperatorLogMessageInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -83,22 +83,22 @@ func (inst *OperatorLogMessage) MustFindEventAuthorityAddress() (pda ag_solanago
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *OperatorLogMessage) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorLogMessageInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *OperatorLogMessage) SetProgramAccount(program ag_solanago.PublicKey) *OperatorLogMessage {
+func (inst *OperatorLogMessageInstruction) SetProgramAccount(program ag_solanago.PublicKey) *OperatorLogMessageInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *OperatorLogMessage) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorLogMessageInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
-func (inst OperatorLogMessage) Build() *Instruction {
+func (inst OperatorLogMessageInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_OperatorLogMessage,
@@ -108,14 +108,14 @@ func (inst OperatorLogMessage) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst OperatorLogMessage) ValidateAndBuild() (*Instruction, error) {
+func (inst OperatorLogMessageInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *OperatorLogMessage) Validate() error {
+func (inst *OperatorLogMessageInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.Message == nil {
@@ -135,7 +135,7 @@ func (inst *OperatorLogMessage) Validate() error {
 	return nil
 }
 
-func (inst *OperatorLogMessage) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *OperatorLogMessageInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -157,7 +157,7 @@ func (inst *OperatorLogMessage) EncodeToTree(parent ag_treeout.Branches) {
 		})
 }
 
-func (obj OperatorLogMessage) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj OperatorLogMessageInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `Message` param:
 	err = encoder.Encode(obj.Message)
 	if err != nil {
@@ -165,7 +165,7 @@ func (obj OperatorLogMessage) MarshalWithEncoder(encoder *ag_binary.Encoder) (er
 	}
 	return nil
 }
-func (obj *OperatorLogMessage) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *OperatorLogMessageInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `Message`:
 	err = decoder.Decode(&obj.Message)
 	if err != nil {
@@ -180,7 +180,7 @@ func NewOperatorLogMessageInstruction(
 	message string,
 	// Accounts:
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *OperatorLogMessage {
+	program ag_solanago.PublicKey) *OperatorLogMessageInstruction {
 	return NewOperatorLogMessageInstructionBuilder().
 		SetMessage(message).
 		SetEventAuthorityAccount(eventAuthority).

--- a/generated/restaking/operatorlogmessage_test.go
+++ b/generated/restaking/operatorlogmessage_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_OperatorLogMessage(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("OperatorLogMessage"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(OperatorLogMessage)
+				params := new(OperatorLogMessageInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(OperatorLogMessage)
+				got := new(OperatorLogMessageInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/operatorrunfundcommand.go
+++ b/generated/restaking/operatorrunfundcommand.go
@@ -11,7 +11,7 @@ import (
 )
 
 // OperatorRunFundCommand is the `operator_run_fund_command` instruction.
-type OperatorRunFundCommand struct {
+type OperatorRunFundCommandInstruction struct {
 	ForceResetCommand *OperationCommandEntry `bin:"optional"`
 
 	// [0] = [WRITE, SIGNER] operator
@@ -28,9 +28,9 @@ type OperatorRunFundCommand struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewOperatorRunFundCommandInstructionBuilder creates a new `OperatorRunFundCommand` instruction builder.
-func NewOperatorRunFundCommandInstructionBuilder() *OperatorRunFundCommand {
-	nd := &OperatorRunFundCommand{
+// NewOperatorRunFundCommandInstructionBuilder creates a new `OperatorRunFundCommandInstruction` instruction builder.
+func NewOperatorRunFundCommandInstructionBuilder() *OperatorRunFundCommandInstruction {
+	nd := &OperatorRunFundCommandInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 6),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["11111111111111111111111111111111"])
@@ -38,51 +38,51 @@ func NewOperatorRunFundCommandInstructionBuilder() *OperatorRunFundCommand {
 }
 
 // SetForceResetCommand sets the "force_reset_command" parameter.
-func (inst *OperatorRunFundCommand) SetForceResetCommand(force_reset_command OperationCommandEntry) *OperatorRunFundCommand {
+func (inst *OperatorRunFundCommandInstruction) SetForceResetCommand(force_reset_command OperationCommandEntry) *OperatorRunFundCommandInstruction {
 	inst.ForceResetCommand = &force_reset_command
 	return inst
 }
 
 // SetOperatorAccount sets the "operator" account.
-func (inst *OperatorRunFundCommand) SetOperatorAccount(operator ag_solanago.PublicKey) *OperatorRunFundCommand {
+func (inst *OperatorRunFundCommandInstruction) SetOperatorAccount(operator ag_solanago.PublicKey) *OperatorRunFundCommandInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(operator).WRITE().SIGNER()
 	return inst
 }
 
 // GetOperatorAccount gets the "operator" account.
-func (inst *OperatorRunFundCommand) GetOperatorAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorRunFundCommandInstruction) GetOperatorAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *OperatorRunFundCommand) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *OperatorRunFundCommand {
+func (inst *OperatorRunFundCommandInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *OperatorRunFundCommandInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *OperatorRunFundCommand) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorRunFundCommandInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *OperatorRunFundCommand) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *OperatorRunFundCommand {
+func (inst *OperatorRunFundCommandInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *OperatorRunFundCommandInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenMint).WRITE()
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *OperatorRunFundCommand) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorRunFundCommandInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *OperatorRunFundCommand) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *OperatorRunFundCommand {
+func (inst *OperatorRunFundCommandInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *OperatorRunFundCommandInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *OperatorRunFundCommand) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorRunFundCommandInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -99,12 +99,12 @@ func (inst *OperatorRunFundCommand) findFindFundAccountAddress(receiptTokenMint 
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *OperatorRunFundCommand) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *OperatorRunFundCommandInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *OperatorRunFundCommand) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *OperatorRunFundCommandInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -113,12 +113,12 @@ func (inst *OperatorRunFundCommand) MustFindFundAccountAddressWithBumpSeed(recei
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *OperatorRunFundCommand) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorRunFundCommandInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *OperatorRunFundCommand) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *OperatorRunFundCommandInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -127,17 +127,17 @@ func (inst *OperatorRunFundCommand) MustFindFundAccountAddress(receiptTokenMint 
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *OperatorRunFundCommand) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorRunFundCommandInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *OperatorRunFundCommand) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *OperatorRunFundCommand {
+func (inst *OperatorRunFundCommandInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *OperatorRunFundCommandInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *OperatorRunFundCommand) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorRunFundCommandInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -152,12 +152,12 @@ func (inst *OperatorRunFundCommand) findFindEventAuthorityAddress(knownBumpSeed 
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *OperatorRunFundCommand) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *OperatorRunFundCommandInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *OperatorRunFundCommand) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *OperatorRunFundCommandInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -166,12 +166,12 @@ func (inst *OperatorRunFundCommand) MustFindEventAuthorityAddressWithBumpSeed(bu
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *OperatorRunFundCommand) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorRunFundCommandInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *OperatorRunFundCommand) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *OperatorRunFundCommandInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -180,22 +180,22 @@ func (inst *OperatorRunFundCommand) MustFindEventAuthorityAddress() (pda ag_sola
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *OperatorRunFundCommand) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorRunFundCommandInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *OperatorRunFundCommand) SetProgramAccount(program ag_solanago.PublicKey) *OperatorRunFundCommand {
+func (inst *OperatorRunFundCommandInstruction) SetProgramAccount(program ag_solanago.PublicKey) *OperatorRunFundCommandInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *OperatorRunFundCommand) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorRunFundCommandInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
-func (inst OperatorRunFundCommand) Build() *Instruction {
+func (inst OperatorRunFundCommandInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_OperatorRunFundCommand,
@@ -205,14 +205,14 @@ func (inst OperatorRunFundCommand) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst OperatorRunFundCommand) ValidateAndBuild() (*Instruction, error) {
+func (inst OperatorRunFundCommandInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *OperatorRunFundCommand) Validate() error {
+func (inst *OperatorRunFundCommandInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 	}
@@ -241,7 +241,7 @@ func (inst *OperatorRunFundCommand) Validate() error {
 	return nil
 }
 
-func (inst *OperatorRunFundCommand) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *OperatorRunFundCommandInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -267,7 +267,7 @@ func (inst *OperatorRunFundCommand) EncodeToTree(parent ag_treeout.Branches) {
 		})
 }
 
-func (obj OperatorRunFundCommand) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj OperatorRunFundCommandInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `ForceResetCommand` param (optional):
 	{
 		if obj.ForceResetCommand == nil {
@@ -288,7 +288,7 @@ func (obj OperatorRunFundCommand) MarshalWithEncoder(encoder *ag_binary.Encoder)
 	}
 	return nil
 }
-func (obj *OperatorRunFundCommand) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *OperatorRunFundCommandInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `ForceResetCommand` (optional):
 	{
 		ok, err := decoder.ReadBool()
@@ -315,7 +315,7 @@ func NewOperatorRunFundCommandInstruction(
 	receiptTokenMint ag_solanago.PublicKey,
 	fundAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *OperatorRunFundCommand {
+	program ag_solanago.PublicKey) *OperatorRunFundCommandInstruction {
 	return NewOperatorRunFundCommandInstructionBuilder().
 		SetForceResetCommand(force_reset_command).
 		SetOperatorAccount(operator).

--- a/generated/restaking/operatorrunfundcommand_test.go
+++ b/generated/restaking/operatorrunfundcommand_test.go
@@ -15,14 +15,14 @@ func TestEncodeDecode_OperatorRunFundCommand(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("OperatorRunFundCommand"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(OperatorRunFundCommand)
+				params := new(OperatorRunFundCommandInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				params.ForceResetCommand = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(OperatorRunFundCommand)
+				got := new(OperatorRunFundCommandInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/operatorupdatefundprices.go
+++ b/generated/restaking/operatorupdatefundprices.go
@@ -11,7 +11,7 @@ import (
 )
 
 // OperatorUpdateFundPrices is the `operator_update_fund_prices` instruction.
-type OperatorUpdateFundPrices struct {
+type OperatorUpdateFundPricesInstruction struct {
 
 	// [0] = [WRITE, SIGNER] operator
 	//
@@ -27,9 +27,9 @@ type OperatorUpdateFundPrices struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewOperatorUpdateFundPricesInstructionBuilder creates a new `OperatorUpdateFundPrices` instruction builder.
-func NewOperatorUpdateFundPricesInstructionBuilder() *OperatorUpdateFundPrices {
-	nd := &OperatorUpdateFundPrices{
+// NewOperatorUpdateFundPricesInstructionBuilder creates a new `OperatorUpdateFundPricesInstruction` instruction builder.
+func NewOperatorUpdateFundPricesInstructionBuilder() *OperatorUpdateFundPricesInstruction {
+	nd := &OperatorUpdateFundPricesInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 6),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["11111111111111111111111111111111"])
@@ -37,45 +37,45 @@ func NewOperatorUpdateFundPricesInstructionBuilder() *OperatorUpdateFundPrices {
 }
 
 // SetOperatorAccount sets the "operator" account.
-func (inst *OperatorUpdateFundPrices) SetOperatorAccount(operator ag_solanago.PublicKey) *OperatorUpdateFundPrices {
+func (inst *OperatorUpdateFundPricesInstruction) SetOperatorAccount(operator ag_solanago.PublicKey) *OperatorUpdateFundPricesInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(operator).WRITE().SIGNER()
 	return inst
 }
 
 // GetOperatorAccount gets the "operator" account.
-func (inst *OperatorUpdateFundPrices) GetOperatorAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorUpdateFundPricesInstruction) GetOperatorAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *OperatorUpdateFundPrices) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *OperatorUpdateFundPrices {
+func (inst *OperatorUpdateFundPricesInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *OperatorUpdateFundPricesInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *OperatorUpdateFundPrices) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorUpdateFundPricesInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *OperatorUpdateFundPrices) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *OperatorUpdateFundPrices {
+func (inst *OperatorUpdateFundPricesInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *OperatorUpdateFundPricesInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenMint).WRITE()
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *OperatorUpdateFundPrices) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorUpdateFundPricesInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *OperatorUpdateFundPrices) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *OperatorUpdateFundPrices {
+func (inst *OperatorUpdateFundPricesInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *OperatorUpdateFundPricesInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *OperatorUpdateFundPrices) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorUpdateFundPricesInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -92,12 +92,12 @@ func (inst *OperatorUpdateFundPrices) findFindFundAccountAddress(receiptTokenMin
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *OperatorUpdateFundPrices) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *OperatorUpdateFundPricesInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *OperatorUpdateFundPrices) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *OperatorUpdateFundPricesInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -106,12 +106,12 @@ func (inst *OperatorUpdateFundPrices) MustFindFundAccountAddressWithBumpSeed(rec
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *OperatorUpdateFundPrices) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorUpdateFundPricesInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *OperatorUpdateFundPrices) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *OperatorUpdateFundPricesInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -120,17 +120,17 @@ func (inst *OperatorUpdateFundPrices) MustFindFundAccountAddress(receiptTokenMin
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *OperatorUpdateFundPrices) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorUpdateFundPricesInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *OperatorUpdateFundPrices) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *OperatorUpdateFundPrices {
+func (inst *OperatorUpdateFundPricesInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *OperatorUpdateFundPricesInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *OperatorUpdateFundPrices) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorUpdateFundPricesInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -145,12 +145,12 @@ func (inst *OperatorUpdateFundPrices) findFindEventAuthorityAddress(knownBumpSee
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *OperatorUpdateFundPrices) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *OperatorUpdateFundPricesInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *OperatorUpdateFundPrices) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *OperatorUpdateFundPricesInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -159,12 +159,12 @@ func (inst *OperatorUpdateFundPrices) MustFindEventAuthorityAddressWithBumpSeed(
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *OperatorUpdateFundPrices) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorUpdateFundPricesInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *OperatorUpdateFundPrices) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *OperatorUpdateFundPricesInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -173,22 +173,22 @@ func (inst *OperatorUpdateFundPrices) MustFindEventAuthorityAddress() (pda ag_so
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *OperatorUpdateFundPrices) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorUpdateFundPricesInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *OperatorUpdateFundPrices) SetProgramAccount(program ag_solanago.PublicKey) *OperatorUpdateFundPrices {
+func (inst *OperatorUpdateFundPricesInstruction) SetProgramAccount(program ag_solanago.PublicKey) *OperatorUpdateFundPricesInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *OperatorUpdateFundPrices) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorUpdateFundPricesInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
-func (inst OperatorUpdateFundPrices) Build() *Instruction {
+func (inst OperatorUpdateFundPricesInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_OperatorUpdateFundPrices,
@@ -198,14 +198,14 @@ func (inst OperatorUpdateFundPrices) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst OperatorUpdateFundPrices) ValidateAndBuild() (*Instruction, error) {
+func (inst OperatorUpdateFundPricesInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *OperatorUpdateFundPrices) Validate() error {
+func (inst *OperatorUpdateFundPricesInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -230,7 +230,7 @@ func (inst *OperatorUpdateFundPrices) Validate() error {
 	return nil
 }
 
-func (inst *OperatorUpdateFundPrices) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *OperatorUpdateFundPricesInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -254,10 +254,10 @@ func (inst *OperatorUpdateFundPrices) EncodeToTree(parent ag_treeout.Branches) {
 		})
 }
 
-func (obj OperatorUpdateFundPrices) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj OperatorUpdateFundPricesInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *OperatorUpdateFundPrices) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *OperatorUpdateFundPricesInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -269,7 +269,7 @@ func NewOperatorUpdateFundPricesInstruction(
 	receiptTokenMint ag_solanago.PublicKey,
 	fundAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *OperatorUpdateFundPrices {
+	program ag_solanago.PublicKey) *OperatorUpdateFundPricesInstruction {
 	return NewOperatorUpdateFundPricesInstructionBuilder().
 		SetOperatorAccount(operator).
 		SetSystemProgramAccount(systemProgram).

--- a/generated/restaking/operatorupdatefundprices_test.go
+++ b/generated/restaking/operatorupdatefundprices_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_OperatorUpdateFundPrices(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("OperatorUpdateFundPrices"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(OperatorUpdateFundPrices)
+				params := new(OperatorUpdateFundPricesInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(OperatorUpdateFundPrices)
+				got := new(OperatorUpdateFundPricesInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/operatorupdatenormalizedtokenpoolprices.go
+++ b/generated/restaking/operatorupdatenormalizedtokenpoolprices.go
@@ -11,7 +11,7 @@ import (
 )
 
 // OperatorUpdateNormalizedTokenPoolPrices is the `operator_update_normalized_token_pool_prices` instruction.
-type OperatorUpdateNormalizedTokenPoolPrices struct {
+type OperatorUpdateNormalizedTokenPoolPricesInstruction struct {
 
 	// [0] = [SIGNER] operator
 	//
@@ -27,9 +27,9 @@ type OperatorUpdateNormalizedTokenPoolPrices struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewOperatorUpdateNormalizedTokenPoolPricesInstructionBuilder creates a new `OperatorUpdateNormalizedTokenPoolPrices` instruction builder.
-func NewOperatorUpdateNormalizedTokenPoolPricesInstructionBuilder() *OperatorUpdateNormalizedTokenPoolPrices {
-	nd := &OperatorUpdateNormalizedTokenPoolPrices{
+// NewOperatorUpdateNormalizedTokenPoolPricesInstructionBuilder creates a new `OperatorUpdateNormalizedTokenPoolPricesInstruction` instruction builder.
+func NewOperatorUpdateNormalizedTokenPoolPricesInstructionBuilder() *OperatorUpdateNormalizedTokenPoolPricesInstruction {
+	nd := &OperatorUpdateNormalizedTokenPoolPricesInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 6),
 	}
 	nd.AccountMetaSlice[3] = ag_solanago.Meta(Addresses["TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"])
@@ -37,34 +37,34 @@ func NewOperatorUpdateNormalizedTokenPoolPricesInstructionBuilder() *OperatorUpd
 }
 
 // SetOperatorAccount sets the "operator" account.
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) SetOperatorAccount(operator ag_solanago.PublicKey) *OperatorUpdateNormalizedTokenPoolPrices {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) SetOperatorAccount(operator ag_solanago.PublicKey) *OperatorUpdateNormalizedTokenPoolPricesInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(operator).SIGNER()
 	return inst
 }
 
 // GetOperatorAccount gets the "operator" account.
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) GetOperatorAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) GetOperatorAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetNormalizedTokenMintAccount sets the "normalized_token_mint" account.
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) SetNormalizedTokenMintAccount(normalizedTokenMint ag_solanago.PublicKey) *OperatorUpdateNormalizedTokenPoolPrices {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) SetNormalizedTokenMintAccount(normalizedTokenMint ag_solanago.PublicKey) *OperatorUpdateNormalizedTokenPoolPricesInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(normalizedTokenMint)
 	return inst
 }
 
 // GetNormalizedTokenMintAccount gets the "normalized_token_mint" account.
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) GetNormalizedTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) GetNormalizedTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetNormalizedTokenPoolAccountAccount sets the "normalized_token_pool_account" account.
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) SetNormalizedTokenPoolAccountAccount(normalizedTokenPoolAccount ag_solanago.PublicKey) *OperatorUpdateNormalizedTokenPoolPrices {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) SetNormalizedTokenPoolAccountAccount(normalizedTokenPoolAccount ag_solanago.PublicKey) *OperatorUpdateNormalizedTokenPoolPricesInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(normalizedTokenPoolAccount).WRITE()
 	return inst
 }
 
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: nt_pool
 	seeds = append(seeds, []byte{byte(0x6e), byte(0x74), byte(0x5f), byte(0x70), byte(0x6f), byte(0x6f), byte(0x6c)})
@@ -81,12 +81,12 @@ func (inst *OperatorUpdateNormalizedTokenPoolPrices) findFindNormalizedTokenPool
 }
 
 // FindNormalizedTokenPoolAccountAddressWithBumpSeed calculates NormalizedTokenPoolAccount account address with given seeds and a known bump seed.
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) FindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) FindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) MustFindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) MustFindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -95,12 +95,12 @@ func (inst *OperatorUpdateNormalizedTokenPoolPrices) MustFindNormalizedTokenPool
 }
 
 // FindNormalizedTokenPoolAccountAddress finds NormalizedTokenPoolAccount account address with given seeds.
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) FindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) FindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, 0)
 	return
 }
 
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) MustFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) MustFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -109,28 +109,28 @@ func (inst *OperatorUpdateNormalizedTokenPoolPrices) MustFindNormalizedTokenPool
 }
 
 // GetNormalizedTokenPoolAccountAccount gets the "normalized_token_pool_account" account.
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) GetNormalizedTokenPoolAccountAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) GetNormalizedTokenPoolAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetNormalizedTokenProgramAccount sets the "normalized_token_program" account.
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) SetNormalizedTokenProgramAccount(normalizedTokenProgram ag_solanago.PublicKey) *OperatorUpdateNormalizedTokenPoolPrices {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) SetNormalizedTokenProgramAccount(normalizedTokenProgram ag_solanago.PublicKey) *OperatorUpdateNormalizedTokenPoolPricesInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(normalizedTokenProgram)
 	return inst
 }
 
 // GetNormalizedTokenProgramAccount gets the "normalized_token_program" account.
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) GetNormalizedTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) GetNormalizedTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *OperatorUpdateNormalizedTokenPoolPrices {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *OperatorUpdateNormalizedTokenPoolPricesInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -145,12 +145,12 @@ func (inst *OperatorUpdateNormalizedTokenPoolPrices) findFindEventAuthorityAddre
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -159,12 +159,12 @@ func (inst *OperatorUpdateNormalizedTokenPoolPrices) MustFindEventAuthorityAddre
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -173,22 +173,22 @@ func (inst *OperatorUpdateNormalizedTokenPoolPrices) MustFindEventAuthorityAddre
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) SetProgramAccount(program ag_solanago.PublicKey) *OperatorUpdateNormalizedTokenPoolPrices {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) SetProgramAccount(program ag_solanago.PublicKey) *OperatorUpdateNormalizedTokenPoolPricesInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
-func (inst OperatorUpdateNormalizedTokenPoolPrices) Build() *Instruction {
+func (inst OperatorUpdateNormalizedTokenPoolPricesInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_OperatorUpdateNormalizedTokenPoolPrices,
@@ -198,14 +198,14 @@ func (inst OperatorUpdateNormalizedTokenPoolPrices) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst OperatorUpdateNormalizedTokenPoolPrices) ValidateAndBuild() (*Instruction, error) {
+func (inst OperatorUpdateNormalizedTokenPoolPricesInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) Validate() error {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -230,7 +230,7 @@ func (inst *OperatorUpdateNormalizedTokenPoolPrices) Validate() error {
 	return nil
 }
 
-func (inst *OperatorUpdateNormalizedTokenPoolPrices) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *OperatorUpdateNormalizedTokenPoolPricesInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -254,10 +254,10 @@ func (inst *OperatorUpdateNormalizedTokenPoolPrices) EncodeToTree(parent ag_tree
 		})
 }
 
-func (obj OperatorUpdateNormalizedTokenPoolPrices) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj OperatorUpdateNormalizedTokenPoolPricesInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *OperatorUpdateNormalizedTokenPoolPrices) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *OperatorUpdateNormalizedTokenPoolPricesInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -269,7 +269,7 @@ func NewOperatorUpdateNormalizedTokenPoolPricesInstruction(
 	normalizedTokenPoolAccount ag_solanago.PublicKey,
 	normalizedTokenProgram ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *OperatorUpdateNormalizedTokenPoolPrices {
+	program ag_solanago.PublicKey) *OperatorUpdateNormalizedTokenPoolPricesInstruction {
 	return NewOperatorUpdateNormalizedTokenPoolPricesInstructionBuilder().
 		SetOperatorAccount(operator).
 		SetNormalizedTokenMintAccount(normalizedTokenMint).

--- a/generated/restaking/operatorupdatenormalizedtokenpoolprices_test.go
+++ b/generated/restaking/operatorupdatenormalizedtokenpoolprices_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_OperatorUpdateNormalizedTokenPoolPrices(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("OperatorUpdateNormalizedTokenPoolPrices"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(OperatorUpdateNormalizedTokenPoolPrices)
+				params := new(OperatorUpdateNormalizedTokenPoolPricesInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(OperatorUpdateNormalizedTokenPoolPrices)
+				got := new(OperatorUpdateNormalizedTokenPoolPricesInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/operatorupdaterewardpools.go
+++ b/generated/restaking/operatorupdaterewardpools.go
@@ -11,7 +11,7 @@ import (
 )
 
 // OperatorUpdateRewardPools is the `operator_update_reward_pools` instruction.
-type OperatorUpdateRewardPools struct {
+type OperatorUpdateRewardPoolsInstruction struct {
 
 	// [0] = [WRITE, SIGNER] operator
 	//
@@ -27,9 +27,9 @@ type OperatorUpdateRewardPools struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewOperatorUpdateRewardPoolsInstructionBuilder creates a new `OperatorUpdateRewardPools` instruction builder.
-func NewOperatorUpdateRewardPoolsInstructionBuilder() *OperatorUpdateRewardPools {
-	nd := &OperatorUpdateRewardPools{
+// NewOperatorUpdateRewardPoolsInstructionBuilder creates a new `OperatorUpdateRewardPoolsInstruction` instruction builder.
+func NewOperatorUpdateRewardPoolsInstructionBuilder() *OperatorUpdateRewardPoolsInstruction {
+	nd := &OperatorUpdateRewardPoolsInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 6),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["11111111111111111111111111111111"])
@@ -37,45 +37,45 @@ func NewOperatorUpdateRewardPoolsInstructionBuilder() *OperatorUpdateRewardPools
 }
 
 // SetOperatorAccount sets the "operator" account.
-func (inst *OperatorUpdateRewardPools) SetOperatorAccount(operator ag_solanago.PublicKey) *OperatorUpdateRewardPools {
+func (inst *OperatorUpdateRewardPoolsInstruction) SetOperatorAccount(operator ag_solanago.PublicKey) *OperatorUpdateRewardPoolsInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(operator).WRITE().SIGNER()
 	return inst
 }
 
 // GetOperatorAccount gets the "operator" account.
-func (inst *OperatorUpdateRewardPools) GetOperatorAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorUpdateRewardPoolsInstruction) GetOperatorAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *OperatorUpdateRewardPools) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *OperatorUpdateRewardPools {
+func (inst *OperatorUpdateRewardPoolsInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *OperatorUpdateRewardPoolsInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *OperatorUpdateRewardPools) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorUpdateRewardPoolsInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *OperatorUpdateRewardPools) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *OperatorUpdateRewardPools {
+func (inst *OperatorUpdateRewardPoolsInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *OperatorUpdateRewardPoolsInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *OperatorUpdateRewardPools) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorUpdateRewardPoolsInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *OperatorUpdateRewardPools) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *OperatorUpdateRewardPools {
+func (inst *OperatorUpdateRewardPoolsInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *OperatorUpdateRewardPoolsInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *OperatorUpdateRewardPools) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorUpdateRewardPoolsInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -92,12 +92,12 @@ func (inst *OperatorUpdateRewardPools) findFindRewardAccountAddress(receiptToken
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *OperatorUpdateRewardPools) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *OperatorUpdateRewardPoolsInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *OperatorUpdateRewardPools) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *OperatorUpdateRewardPoolsInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -106,12 +106,12 @@ func (inst *OperatorUpdateRewardPools) MustFindRewardAccountAddressWithBumpSeed(
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *OperatorUpdateRewardPools) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorUpdateRewardPoolsInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *OperatorUpdateRewardPools) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *OperatorUpdateRewardPoolsInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -120,17 +120,17 @@ func (inst *OperatorUpdateRewardPools) MustFindRewardAccountAddress(receiptToken
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *OperatorUpdateRewardPools) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorUpdateRewardPoolsInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *OperatorUpdateRewardPools) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *OperatorUpdateRewardPools {
+func (inst *OperatorUpdateRewardPoolsInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *OperatorUpdateRewardPoolsInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *OperatorUpdateRewardPools) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorUpdateRewardPoolsInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -145,12 +145,12 @@ func (inst *OperatorUpdateRewardPools) findFindEventAuthorityAddress(knownBumpSe
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *OperatorUpdateRewardPools) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *OperatorUpdateRewardPoolsInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *OperatorUpdateRewardPools) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *OperatorUpdateRewardPoolsInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -159,12 +159,12 @@ func (inst *OperatorUpdateRewardPools) MustFindEventAuthorityAddressWithBumpSeed
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *OperatorUpdateRewardPools) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *OperatorUpdateRewardPoolsInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *OperatorUpdateRewardPools) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *OperatorUpdateRewardPoolsInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -173,22 +173,22 @@ func (inst *OperatorUpdateRewardPools) MustFindEventAuthorityAddress() (pda ag_s
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *OperatorUpdateRewardPools) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorUpdateRewardPoolsInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *OperatorUpdateRewardPools) SetProgramAccount(program ag_solanago.PublicKey) *OperatorUpdateRewardPools {
+func (inst *OperatorUpdateRewardPoolsInstruction) SetProgramAccount(program ag_solanago.PublicKey) *OperatorUpdateRewardPoolsInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *OperatorUpdateRewardPools) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *OperatorUpdateRewardPoolsInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
-func (inst OperatorUpdateRewardPools) Build() *Instruction {
+func (inst OperatorUpdateRewardPoolsInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_OperatorUpdateRewardPools,
@@ -198,14 +198,14 @@ func (inst OperatorUpdateRewardPools) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst OperatorUpdateRewardPools) ValidateAndBuild() (*Instruction, error) {
+func (inst OperatorUpdateRewardPoolsInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *OperatorUpdateRewardPools) Validate() error {
+func (inst *OperatorUpdateRewardPoolsInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -230,7 +230,7 @@ func (inst *OperatorUpdateRewardPools) Validate() error {
 	return nil
 }
 
-func (inst *OperatorUpdateRewardPools) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *OperatorUpdateRewardPoolsInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -254,10 +254,10 @@ func (inst *OperatorUpdateRewardPools) EncodeToTree(parent ag_treeout.Branches) 
 		})
 }
 
-func (obj OperatorUpdateRewardPools) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj OperatorUpdateRewardPoolsInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *OperatorUpdateRewardPools) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *OperatorUpdateRewardPoolsInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -269,7 +269,7 @@ func NewOperatorUpdateRewardPoolsInstruction(
 	receiptTokenMint ag_solanago.PublicKey,
 	rewardAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *OperatorUpdateRewardPools {
+	program ag_solanago.PublicKey) *OperatorUpdateRewardPoolsInstruction {
 	return NewOperatorUpdateRewardPoolsInstructionBuilder().
 		SetOperatorAccount(operator).
 		SetSystemProgramAccount(systemProgram).

--- a/generated/restaking/operatorupdaterewardpools_test.go
+++ b/generated/restaking/operatorupdaterewardpools_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_OperatorUpdateRewardPools(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("OperatorUpdateRewardPools"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(OperatorUpdateRewardPools)
+				params := new(OperatorUpdateRewardPoolsInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(OperatorUpdateRewardPools)
+				got := new(OperatorUpdateRewardPoolsInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/slasherinitializenormalizedtokenwithdrawalaccount.go
+++ b/generated/restaking/slasherinitializenormalizedtokenwithdrawalaccount.go
@@ -11,7 +11,7 @@ import (
 )
 
 // SlasherInitializeNormalizedTokenWithdrawalAccount is the `slasher_initialize_normalized_token_withdrawal_account` instruction.
-type SlasherInitializeNormalizedTokenWithdrawalAccount struct {
+type SlasherInitializeNormalizedTokenWithdrawalAccountInstruction struct {
 
 	// [0] = [WRITE, SIGNER] payer
 	//
@@ -35,9 +35,9 @@ type SlasherInitializeNormalizedTokenWithdrawalAccount struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewSlasherInitializeNormalizedTokenWithdrawalAccountInstructionBuilder creates a new `SlasherInitializeNormalizedTokenWithdrawalAccount` instruction builder.
-func NewSlasherInitializeNormalizedTokenWithdrawalAccountInstructionBuilder() *SlasherInitializeNormalizedTokenWithdrawalAccount {
-	nd := &SlasherInitializeNormalizedTokenWithdrawalAccount{
+// NewSlasherInitializeNormalizedTokenWithdrawalAccountInstructionBuilder creates a new `SlasherInitializeNormalizedTokenWithdrawalAccountInstruction` instruction builder.
+func NewSlasherInitializeNormalizedTokenWithdrawalAccountInstructionBuilder() *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction {
+	nd := &SlasherInitializeNormalizedTokenWithdrawalAccountInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 10),
 	}
 	nd.AccountMetaSlice[4] = ag_solanago.Meta(Addresses["TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"])
@@ -46,45 +46,45 @@ func NewSlasherInitializeNormalizedTokenWithdrawalAccountInstructionBuilder() *S
 }
 
 // SetPayerAccount sets the "payer" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) SetPayerAccount(payer ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccount {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) SetPayerAccount(payer ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(payer).WRITE().SIGNER()
 	return inst
 }
 
 // GetPayerAccount gets the "payer" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) GetPayerAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) GetPayerAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSlasherAccount sets the "slasher" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) SetSlasherAccount(slasher ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccount {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) SetSlasherAccount(slasher ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(slasher).SIGNER()
 	return inst
 }
 
 // GetSlasherAccount gets the "slasher" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) GetSlasherAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) GetSlasherAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetNormalizedTokenMintAccount sets the "normalized_token_mint" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) SetNormalizedTokenMintAccount(normalizedTokenMint ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccount {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) SetNormalizedTokenMintAccount(normalizedTokenMint ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(normalizedTokenMint).WRITE()
 	return inst
 }
 
 // GetNormalizedTokenMintAccount gets the "normalized_token_mint" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) GetNormalizedTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) GetNormalizedTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetNormalizedTokenPoolAccountAccount sets the "normalized_token_pool_account" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) SetNormalizedTokenPoolAccountAccount(normalizedTokenPoolAccount ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccount {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) SetNormalizedTokenPoolAccountAccount(normalizedTokenPoolAccount ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(normalizedTokenPoolAccount).WRITE()
 	return inst
 }
 
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: nt_pool
 	seeds = append(seeds, []byte{byte(0x6e), byte(0x74), byte(0x5f), byte(0x70), byte(0x6f), byte(0x6f), byte(0x6c)})
@@ -101,12 +101,12 @@ func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) findFindNormalize
 }
 
 // FindNormalizedTokenPoolAccountAddressWithBumpSeed calculates NormalizedTokenPoolAccount account address with given seeds and a known bump seed.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) FindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) FindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) MustFindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) MustFindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -115,12 +115,12 @@ func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) MustFindNormalize
 }
 
 // FindNormalizedTokenPoolAccountAddress finds NormalizedTokenPoolAccount account address with given seeds.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) FindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) FindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, 0)
 	return
 }
 
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) MustFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) MustFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -129,28 +129,28 @@ func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) MustFindNormalize
 }
 
 // GetNormalizedTokenPoolAccountAccount gets the "normalized_token_pool_account" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) GetNormalizedTokenPoolAccountAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) GetNormalizedTokenPoolAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetNormalizedTokenProgramAccount sets the "normalized_token_program" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) SetNormalizedTokenProgramAccount(normalizedTokenProgram ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccount {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) SetNormalizedTokenProgramAccount(normalizedTokenProgram ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(normalizedTokenProgram)
 	return inst
 }
 
 // GetNormalizedTokenProgramAccount gets the "normalized_token_program" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) GetNormalizedTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) GetNormalizedTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetSlasherNormalizedTokenWithdrawalTicketAccountAccount sets the "slasher_normalized_token_withdrawal_ticket_account" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) SetSlasherNormalizedTokenWithdrawalTicketAccountAccount(slasherNormalizedTokenWithdrawalTicketAccount ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccount {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) SetSlasherNormalizedTokenWithdrawalTicketAccountAccount(slasherNormalizedTokenWithdrawalTicketAccount ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(slasherNormalizedTokenWithdrawalTicketAccount).WRITE()
 	return inst
 }
 
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) findFindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) findFindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: nt_withdrawal
 	seeds = append(seeds, []byte{byte(0x6e), byte(0x74), byte(0x5f), byte(0x77), byte(0x69), byte(0x74), byte(0x68), byte(0x64), byte(0x72), byte(0x61), byte(0x77), byte(0x61), byte(0x6c)})
@@ -169,12 +169,12 @@ func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) findFindSlasherNo
 }
 
 // FindSlasherNormalizedTokenWithdrawalTicketAccountAddressWithBumpSeed calculates SlasherNormalizedTokenWithdrawalTicketAccount account address with given seeds and a known bump seed.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) FindSlasherNormalizedTokenWithdrawalTicketAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) FindSlasherNormalizedTokenWithdrawalTicketAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint, slasher, bumpSeed)
 	return
 }
 
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) MustFindSlasherNormalizedTokenWithdrawalTicketAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) MustFindSlasherNormalizedTokenWithdrawalTicketAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint, slasher, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -183,12 +183,12 @@ func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) MustFindSlasherNo
 }
 
 // FindSlasherNormalizedTokenWithdrawalTicketAccountAddress finds SlasherNormalizedTokenWithdrawalTicketAccount account address with given seeds.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) FindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) FindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint, slasher, 0)
 	return
 }
 
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) MustFindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) MustFindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint, slasher, 0)
 	if err != nil {
 		panic(err)
@@ -197,39 +197,39 @@ func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) MustFindSlasherNo
 }
 
 // GetSlasherNormalizedTokenWithdrawalTicketAccountAccount gets the "slasher_normalized_token_withdrawal_ticket_account" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) GetSlasherNormalizedTokenWithdrawalTicketAccountAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) GetSlasherNormalizedTokenWithdrawalTicketAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetSlasherNormalizedTokenAccountAccount sets the "slasher_normalized_token_account" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) SetSlasherNormalizedTokenAccountAccount(slasherNormalizedTokenAccount ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccount {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) SetSlasherNormalizedTokenAccountAccount(slasherNormalizedTokenAccount ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(slasherNormalizedTokenAccount).WRITE()
 	return inst
 }
 
 // GetSlasherNormalizedTokenAccountAccount gets the "slasher_normalized_token_account" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) GetSlasherNormalizedTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) GetSlasherNormalizedTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccount {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccount {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -244,12 +244,12 @@ func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) findFindEventAuth
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -258,12 +258,12 @@ func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) MustFindEventAuth
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -272,22 +272,22 @@ func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) MustFindEventAuth
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) SetProgramAccount(program ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccount {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) SetProgramAccount(program ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction {
 	inst.AccountMetaSlice[9] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(9)
 }
 
-func (inst SlasherInitializeNormalizedTokenWithdrawalAccount) Build() *Instruction {
+func (inst SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_SlasherInitializeNormalizedTokenWithdrawalAccount,
@@ -297,14 +297,14 @@ func (inst SlasherInitializeNormalizedTokenWithdrawalAccount) Build() *Instructi
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst SlasherInitializeNormalizedTokenWithdrawalAccount) ValidateAndBuild() (*Instruction, error) {
+func (inst SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) Validate() error {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -341,7 +341,7 @@ func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) Validate() error 
 	return nil
 }
 
-func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -369,10 +369,10 @@ func (inst *SlasherInitializeNormalizedTokenWithdrawalAccount) EncodeToTree(pare
 		})
 }
 
-func (obj SlasherInitializeNormalizedTokenWithdrawalAccount) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *SlasherInitializeNormalizedTokenWithdrawalAccount) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -388,7 +388,7 @@ func NewSlasherInitializeNormalizedTokenWithdrawalAccountInstruction(
 	slasherNormalizedTokenAccount ag_solanago.PublicKey,
 	systemProgram ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccount {
+	program ag_solanago.PublicKey) *SlasherInitializeNormalizedTokenWithdrawalAccountInstruction {
 	return NewSlasherInitializeNormalizedTokenWithdrawalAccountInstructionBuilder().
 		SetPayerAccount(payer).
 		SetSlasherAccount(slasher).

--- a/generated/restaking/slasherinitializenormalizedtokenwithdrawalaccount_test.go
+++ b/generated/restaking/slasherinitializenormalizedtokenwithdrawalaccount_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_SlasherInitializeNormalizedTokenWithdrawalAccount(t *testi
 	for i := 0; i < 1; i++ {
 		t.Run("SlasherInitializeNormalizedTokenWithdrawalAccount"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(SlasherInitializeNormalizedTokenWithdrawalAccount)
+				params := new(SlasherInitializeNormalizedTokenWithdrawalAccountInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(SlasherInitializeNormalizedTokenWithdrawalAccount)
+				got := new(SlasherInitializeNormalizedTokenWithdrawalAccountInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/slasherwithdrawnormalizedtoken.go
+++ b/generated/restaking/slasherwithdrawnormalizedtoken.go
@@ -11,7 +11,7 @@ import (
 )
 
 // SlasherWithdrawNormalizedToken is the `slasher_withdraw_normalized_token` instruction.
-type SlasherWithdrawNormalizedToken struct {
+type SlasherWithdrawNormalizedTokenInstruction struct {
 
 	// [0] = [WRITE, SIGNER] slasher
 	//
@@ -39,9 +39,9 @@ type SlasherWithdrawNormalizedToken struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewSlasherWithdrawNormalizedTokenInstructionBuilder creates a new `SlasherWithdrawNormalizedToken` instruction builder.
-func NewSlasherWithdrawNormalizedTokenInstructionBuilder() *SlasherWithdrawNormalizedToken {
-	nd := &SlasherWithdrawNormalizedToken{
+// NewSlasherWithdrawNormalizedTokenInstructionBuilder creates a new `SlasherWithdrawNormalizedTokenInstruction` instruction builder.
+func NewSlasherWithdrawNormalizedTokenInstructionBuilder() *SlasherWithdrawNormalizedTokenInstruction {
+	nd := &SlasherWithdrawNormalizedTokenInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 12),
 	}
 	nd.AccountMetaSlice[3] = ag_solanago.Meta(Addresses["TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"])
@@ -49,34 +49,34 @@ func NewSlasherWithdrawNormalizedTokenInstructionBuilder() *SlasherWithdrawNorma
 }
 
 // SetSlasherAccount sets the "slasher" account.
-func (inst *SlasherWithdrawNormalizedToken) SetSlasherAccount(slasher ag_solanago.PublicKey) *SlasherWithdrawNormalizedToken {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) SetSlasherAccount(slasher ag_solanago.PublicKey) *SlasherWithdrawNormalizedTokenInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(slasher).WRITE().SIGNER()
 	return inst
 }
 
 // GetSlasherAccount gets the "slasher" account.
-func (inst *SlasherWithdrawNormalizedToken) GetSlasherAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) GetSlasherAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetNormalizedTokenMintAccount sets the "normalized_token_mint" account.
-func (inst *SlasherWithdrawNormalizedToken) SetNormalizedTokenMintAccount(normalizedTokenMint ag_solanago.PublicKey) *SlasherWithdrawNormalizedToken {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) SetNormalizedTokenMintAccount(normalizedTokenMint ag_solanago.PublicKey) *SlasherWithdrawNormalizedTokenInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(normalizedTokenMint)
 	return inst
 }
 
 // GetNormalizedTokenMintAccount gets the "normalized_token_mint" account.
-func (inst *SlasherWithdrawNormalizedToken) GetNormalizedTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) GetNormalizedTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetNormalizedTokenPoolAccountAccount sets the "normalized_token_pool_account" account.
-func (inst *SlasherWithdrawNormalizedToken) SetNormalizedTokenPoolAccountAccount(normalizedTokenPoolAccount ag_solanago.PublicKey) *SlasherWithdrawNormalizedToken {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) SetNormalizedTokenPoolAccountAccount(normalizedTokenPoolAccount ag_solanago.PublicKey) *SlasherWithdrawNormalizedTokenInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(normalizedTokenPoolAccount).WRITE()
 	return inst
 }
 
-func (inst *SlasherWithdrawNormalizedToken) findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: nt_pool
 	seeds = append(seeds, []byte{byte(0x6e), byte(0x74), byte(0x5f), byte(0x70), byte(0x6f), byte(0x6f), byte(0x6c)})
@@ -93,12 +93,12 @@ func (inst *SlasherWithdrawNormalizedToken) findFindNormalizedTokenPoolAccountAd
 }
 
 // FindNormalizedTokenPoolAccountAddressWithBumpSeed calculates NormalizedTokenPoolAccount account address with given seeds and a known bump seed.
-func (inst *SlasherWithdrawNormalizedToken) FindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) FindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *SlasherWithdrawNormalizedToken) MustFindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) MustFindNormalizedTokenPoolAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -107,12 +107,12 @@ func (inst *SlasherWithdrawNormalizedToken) MustFindNormalizedTokenPoolAccountAd
 }
 
 // FindNormalizedTokenPoolAccountAddress finds NormalizedTokenPoolAccount account address with given seeds.
-func (inst *SlasherWithdrawNormalizedToken) FindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) FindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, 0)
 	return
 }
 
-func (inst *SlasherWithdrawNormalizedToken) MustFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) MustFindNormalizedTokenPoolAccountAddress(normalizedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindNormalizedTokenPoolAccountAddress(normalizedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -121,28 +121,28 @@ func (inst *SlasherWithdrawNormalizedToken) MustFindNormalizedTokenPoolAccountAd
 }
 
 // GetNormalizedTokenPoolAccountAccount gets the "normalized_token_pool_account" account.
-func (inst *SlasherWithdrawNormalizedToken) GetNormalizedTokenPoolAccountAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) GetNormalizedTokenPoolAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetNormalizedTokenProgramAccount sets the "normalized_token_program" account.
-func (inst *SlasherWithdrawNormalizedToken) SetNormalizedTokenProgramAccount(normalizedTokenProgram ag_solanago.PublicKey) *SlasherWithdrawNormalizedToken {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) SetNormalizedTokenProgramAccount(normalizedTokenProgram ag_solanago.PublicKey) *SlasherWithdrawNormalizedTokenInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(normalizedTokenProgram)
 	return inst
 }
 
 // GetNormalizedTokenProgramAccount gets the "normalized_token_program" account.
-func (inst *SlasherWithdrawNormalizedToken) GetNormalizedTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) GetNormalizedTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetSlasherNormalizedTokenWithdrawalTicketAccountAccount sets the "slasher_normalized_token_withdrawal_ticket_account" account.
-func (inst *SlasherWithdrawNormalizedToken) SetSlasherNormalizedTokenWithdrawalTicketAccountAccount(slasherNormalizedTokenWithdrawalTicketAccount ag_solanago.PublicKey) *SlasherWithdrawNormalizedToken {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) SetSlasherNormalizedTokenWithdrawalTicketAccountAccount(slasherNormalizedTokenWithdrawalTicketAccount ag_solanago.PublicKey) *SlasherWithdrawNormalizedTokenInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(slasherNormalizedTokenWithdrawalTicketAccount).WRITE()
 	return inst
 }
 
-func (inst *SlasherWithdrawNormalizedToken) findFindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) findFindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: nt_withdrawal
 	seeds = append(seeds, []byte{byte(0x6e), byte(0x74), byte(0x5f), byte(0x77), byte(0x69), byte(0x74), byte(0x68), byte(0x64), byte(0x72), byte(0x61), byte(0x77), byte(0x61), byte(0x6c)})
@@ -161,12 +161,12 @@ func (inst *SlasherWithdrawNormalizedToken) findFindSlasherNormalizedTokenWithdr
 }
 
 // FindSlasherNormalizedTokenWithdrawalTicketAccountAddressWithBumpSeed calculates SlasherNormalizedTokenWithdrawalTicketAccount account address with given seeds and a known bump seed.
-func (inst *SlasherWithdrawNormalizedToken) FindSlasherNormalizedTokenWithdrawalTicketAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) FindSlasherNormalizedTokenWithdrawalTicketAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint, slasher, bumpSeed)
 	return
 }
 
-func (inst *SlasherWithdrawNormalizedToken) MustFindSlasherNormalizedTokenWithdrawalTicketAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) MustFindSlasherNormalizedTokenWithdrawalTicketAccountAddressWithBumpSeed(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint, slasher, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -175,12 +175,12 @@ func (inst *SlasherWithdrawNormalizedToken) MustFindSlasherNormalizedTokenWithdr
 }
 
 // FindSlasherNormalizedTokenWithdrawalTicketAccountAddress finds SlasherNormalizedTokenWithdrawalTicketAccount account address with given seeds.
-func (inst *SlasherWithdrawNormalizedToken) FindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) FindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint, slasher, 0)
 	return
 }
 
-func (inst *SlasherWithdrawNormalizedToken) MustFindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) MustFindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint ag_solanago.PublicKey, slasher ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindSlasherNormalizedTokenWithdrawalTicketAccountAddress(normalizedTokenMint, slasher, 0)
 	if err != nil {
 		panic(err)
@@ -189,39 +189,39 @@ func (inst *SlasherWithdrawNormalizedToken) MustFindSlasherNormalizedTokenWithdr
 }
 
 // GetSlasherNormalizedTokenWithdrawalTicketAccountAccount gets the "slasher_normalized_token_withdrawal_ticket_account" account.
-func (inst *SlasherWithdrawNormalizedToken) GetSlasherNormalizedTokenWithdrawalTicketAccountAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) GetSlasherNormalizedTokenWithdrawalTicketAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetSupportedTokenMintAccount sets the "supported_token_mint" account.
-func (inst *SlasherWithdrawNormalizedToken) SetSupportedTokenMintAccount(supportedTokenMint ag_solanago.PublicKey) *SlasherWithdrawNormalizedToken {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) SetSupportedTokenMintAccount(supportedTokenMint ag_solanago.PublicKey) *SlasherWithdrawNormalizedTokenInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(supportedTokenMint)
 	return inst
 }
 
 // GetSupportedTokenMintAccount gets the "supported_token_mint" account.
-func (inst *SlasherWithdrawNormalizedToken) GetSupportedTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) GetSupportedTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetSupportedTokenProgramAccount sets the "supported_token_program" account.
-func (inst *SlasherWithdrawNormalizedToken) SetSupportedTokenProgramAccount(supportedTokenProgram ag_solanago.PublicKey) *SlasherWithdrawNormalizedToken {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) SetSupportedTokenProgramAccount(supportedTokenProgram ag_solanago.PublicKey) *SlasherWithdrawNormalizedTokenInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(supportedTokenProgram)
 	return inst
 }
 
 // GetSupportedTokenProgramAccount gets the "supported_token_program" account.
-func (inst *SlasherWithdrawNormalizedToken) GetSupportedTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) GetSupportedTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetNormalizedTokenPoolSupportedTokenReserveAccountAccount sets the "normalized_token_pool_supported_token_reserve_account" account.
-func (inst *SlasherWithdrawNormalizedToken) SetNormalizedTokenPoolSupportedTokenReserveAccountAccount(normalizedTokenPoolSupportedTokenReserveAccount ag_solanago.PublicKey) *SlasherWithdrawNormalizedToken {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) SetNormalizedTokenPoolSupportedTokenReserveAccountAccount(normalizedTokenPoolSupportedTokenReserveAccount ag_solanago.PublicKey) *SlasherWithdrawNormalizedTokenInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(normalizedTokenPoolSupportedTokenReserveAccount).WRITE()
 	return inst
 }
 
-func (inst *SlasherWithdrawNormalizedToken) findFindNormalizedTokenPoolSupportedTokenReserveAccountAddress(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) findFindNormalizedTokenPoolSupportedTokenReserveAccountAddress(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: normalizedTokenPoolAccount
 	seeds = append(seeds, normalizedTokenPoolAccount.Bytes())
@@ -242,12 +242,12 @@ func (inst *SlasherWithdrawNormalizedToken) findFindNormalizedTokenPoolSupported
 }
 
 // FindNormalizedTokenPoolSupportedTokenReserveAccountAddressWithBumpSeed calculates NormalizedTokenPoolSupportedTokenReserveAccount account address with given seeds and a known bump seed.
-func (inst *SlasherWithdrawNormalizedToken) FindNormalizedTokenPoolSupportedTokenReserveAccountAddressWithBumpSeed(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) FindNormalizedTokenPoolSupportedTokenReserveAccountAddressWithBumpSeed(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindNormalizedTokenPoolSupportedTokenReserveAccountAddress(normalizedTokenPoolAccount, supportedTokenProgram, supportedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *SlasherWithdrawNormalizedToken) MustFindNormalizedTokenPoolSupportedTokenReserveAccountAddressWithBumpSeed(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) MustFindNormalizedTokenPoolSupportedTokenReserveAccountAddressWithBumpSeed(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindNormalizedTokenPoolSupportedTokenReserveAccountAddress(normalizedTokenPoolAccount, supportedTokenProgram, supportedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -256,12 +256,12 @@ func (inst *SlasherWithdrawNormalizedToken) MustFindNormalizedTokenPoolSupported
 }
 
 // FindNormalizedTokenPoolSupportedTokenReserveAccountAddress finds NormalizedTokenPoolSupportedTokenReserveAccount account address with given seeds.
-func (inst *SlasherWithdrawNormalizedToken) FindNormalizedTokenPoolSupportedTokenReserveAccountAddress(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) FindNormalizedTokenPoolSupportedTokenReserveAccountAddress(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindNormalizedTokenPoolSupportedTokenReserveAccountAddress(normalizedTokenPoolAccount, supportedTokenProgram, supportedTokenMint, 0)
 	return
 }
 
-func (inst *SlasherWithdrawNormalizedToken) MustFindNormalizedTokenPoolSupportedTokenReserveAccountAddress(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) MustFindNormalizedTokenPoolSupportedTokenReserveAccountAddress(normalizedTokenPoolAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindNormalizedTokenPoolSupportedTokenReserveAccountAddress(normalizedTokenPoolAccount, supportedTokenProgram, supportedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -270,39 +270,39 @@ func (inst *SlasherWithdrawNormalizedToken) MustFindNormalizedTokenPoolSupported
 }
 
 // GetNormalizedTokenPoolSupportedTokenReserveAccountAccount gets the "normalized_token_pool_supported_token_reserve_account" account.
-func (inst *SlasherWithdrawNormalizedToken) GetNormalizedTokenPoolSupportedTokenReserveAccountAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) GetNormalizedTokenPoolSupportedTokenReserveAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetDestinationSupportedTokenAccountAccount sets the "destination_supported_token_account" account.
-func (inst *SlasherWithdrawNormalizedToken) SetDestinationSupportedTokenAccountAccount(destinationSupportedTokenAccount ag_solanago.PublicKey) *SlasherWithdrawNormalizedToken {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) SetDestinationSupportedTokenAccountAccount(destinationSupportedTokenAccount ag_solanago.PublicKey) *SlasherWithdrawNormalizedTokenInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(destinationSupportedTokenAccount).WRITE()
 	return inst
 }
 
 // GetDestinationSupportedTokenAccountAccount gets the "destination_supported_token_account" account.
-func (inst *SlasherWithdrawNormalizedToken) GetDestinationSupportedTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) GetDestinationSupportedTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
 // SetDestinationRentLamportsAccountAccount sets the "destination_rent_lamports_account" account.
-func (inst *SlasherWithdrawNormalizedToken) SetDestinationRentLamportsAccountAccount(destinationRentLamportsAccount ag_solanago.PublicKey) *SlasherWithdrawNormalizedToken {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) SetDestinationRentLamportsAccountAccount(destinationRentLamportsAccount ag_solanago.PublicKey) *SlasherWithdrawNormalizedTokenInstruction {
 	inst.AccountMetaSlice[9] = ag_solanago.Meta(destinationRentLamportsAccount).WRITE()
 	return inst
 }
 
 // GetDestinationRentLamportsAccountAccount gets the "destination_rent_lamports_account" account.
-func (inst *SlasherWithdrawNormalizedToken) GetDestinationRentLamportsAccountAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) GetDestinationRentLamportsAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(9)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *SlasherWithdrawNormalizedToken) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *SlasherWithdrawNormalizedToken {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *SlasherWithdrawNormalizedTokenInstruction {
 	inst.AccountMetaSlice[10] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *SlasherWithdrawNormalizedToken) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -317,12 +317,12 @@ func (inst *SlasherWithdrawNormalizedToken) findFindEventAuthorityAddress(knownB
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *SlasherWithdrawNormalizedToken) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *SlasherWithdrawNormalizedToken) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -331,12 +331,12 @@ func (inst *SlasherWithdrawNormalizedToken) MustFindEventAuthorityAddressWithBum
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *SlasherWithdrawNormalizedToken) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *SlasherWithdrawNormalizedToken) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -345,22 +345,22 @@ func (inst *SlasherWithdrawNormalizedToken) MustFindEventAuthorityAddress() (pda
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *SlasherWithdrawNormalizedToken) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(10)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *SlasherWithdrawNormalizedToken) SetProgramAccount(program ag_solanago.PublicKey) *SlasherWithdrawNormalizedToken {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) SetProgramAccount(program ag_solanago.PublicKey) *SlasherWithdrawNormalizedTokenInstruction {
 	inst.AccountMetaSlice[11] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *SlasherWithdrawNormalizedToken) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(11)
 }
 
-func (inst SlasherWithdrawNormalizedToken) Build() *Instruction {
+func (inst SlasherWithdrawNormalizedTokenInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_SlasherWithdrawNormalizedToken,
@@ -370,14 +370,14 @@ func (inst SlasherWithdrawNormalizedToken) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst SlasherWithdrawNormalizedToken) ValidateAndBuild() (*Instruction, error) {
+func (inst SlasherWithdrawNormalizedTokenInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *SlasherWithdrawNormalizedToken) Validate() error {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -420,7 +420,7 @@ func (inst *SlasherWithdrawNormalizedToken) Validate() error {
 	return nil
 }
 
-func (inst *SlasherWithdrawNormalizedToken) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *SlasherWithdrawNormalizedTokenInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -450,10 +450,10 @@ func (inst *SlasherWithdrawNormalizedToken) EncodeToTree(parent ag_treeout.Branc
 		})
 }
 
-func (obj SlasherWithdrawNormalizedToken) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj SlasherWithdrawNormalizedTokenInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *SlasherWithdrawNormalizedToken) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *SlasherWithdrawNormalizedTokenInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -471,7 +471,7 @@ func NewSlasherWithdrawNormalizedTokenInstruction(
 	destinationSupportedTokenAccount ag_solanago.PublicKey,
 	destinationRentLamportsAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *SlasherWithdrawNormalizedToken {
+	program ag_solanago.PublicKey) *SlasherWithdrawNormalizedTokenInstruction {
 	return NewSlasherWithdrawNormalizedTokenInstructionBuilder().
 		SetSlasherAccount(slasher).
 		SetNormalizedTokenMintAccount(normalizedTokenMint).

--- a/generated/restaking/slasherwithdrawnormalizedtoken_test.go
+++ b/generated/restaking/slasherwithdrawnormalizedtoken_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_SlasherWithdrawNormalizedToken(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("SlasherWithdrawNormalizedToken"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(SlasherWithdrawNormalizedToken)
+				params := new(SlasherWithdrawNormalizedTokenInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(SlasherWithdrawNormalizedToken)
+				got := new(SlasherWithdrawNormalizedTokenInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/usercancelwithdrawalrequest.go
+++ b/generated/restaking/usercancelwithdrawalrequest.go
@@ -11,7 +11,7 @@ import (
 )
 
 // UserCancelWithdrawalRequest is the `user_cancel_withdrawal_request` instruction.
-type UserCancelWithdrawalRequest struct {
+type UserCancelWithdrawalRequestInstruction struct {
 	RequestId          *uint64
 	SupportedTokenMint *ag_solanago.PublicKey `bin:"optional"`
 
@@ -45,9 +45,9 @@ type UserCancelWithdrawalRequest struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewUserCancelWithdrawalRequestInstructionBuilder creates a new `UserCancelWithdrawalRequest` instruction builder.
-func NewUserCancelWithdrawalRequestInstructionBuilder() *UserCancelWithdrawalRequest {
-	nd := &UserCancelWithdrawalRequest{
+// NewUserCancelWithdrawalRequestInstructionBuilder creates a new `UserCancelWithdrawalRequestInstruction` instruction builder.
+func NewUserCancelWithdrawalRequestInstructionBuilder() *UserCancelWithdrawalRequestInstruction {
+	nd := &UserCancelWithdrawalRequestInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 14),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["11111111111111111111111111111111"])
@@ -57,68 +57,68 @@ func NewUserCancelWithdrawalRequestInstructionBuilder() *UserCancelWithdrawalReq
 }
 
 // SetRequestId sets the "request_id" parameter.
-func (inst *UserCancelWithdrawalRequest) SetRequestId(request_id uint64) *UserCancelWithdrawalRequest {
+func (inst *UserCancelWithdrawalRequestInstruction) SetRequestId(request_id uint64) *UserCancelWithdrawalRequestInstruction {
 	inst.RequestId = &request_id
 	return inst
 }
 
 // SetSupportedTokenMint sets the "supported_token_mint" parameter.
-func (inst *UserCancelWithdrawalRequest) SetSupportedTokenMint(supported_token_mint ag_solanago.PublicKey) *UserCancelWithdrawalRequest {
+func (inst *UserCancelWithdrawalRequestInstruction) SetSupportedTokenMint(supported_token_mint ag_solanago.PublicKey) *UserCancelWithdrawalRequestInstruction {
 	inst.SupportedTokenMint = &supported_token_mint
 	return inst
 }
 
 // SetUserAccount sets the "user" account.
-func (inst *UserCancelWithdrawalRequest) SetUserAccount(user ag_solanago.PublicKey) *UserCancelWithdrawalRequest {
+func (inst *UserCancelWithdrawalRequestInstruction) SetUserAccount(user ag_solanago.PublicKey) *UserCancelWithdrawalRequestInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(user).WRITE().SIGNER()
 	return inst
 }
 
 // GetUserAccount gets the "user" account.
-func (inst *UserCancelWithdrawalRequest) GetUserAccount() *ag_solanago.AccountMeta {
+func (inst *UserCancelWithdrawalRequestInstruction) GetUserAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *UserCancelWithdrawalRequest) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserCancelWithdrawalRequest {
+func (inst *UserCancelWithdrawalRequestInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserCancelWithdrawalRequestInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *UserCancelWithdrawalRequest) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserCancelWithdrawalRequestInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenProgramAccount sets the "receipt_token_program" account.
-func (inst *UserCancelWithdrawalRequest) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserCancelWithdrawalRequest {
+func (inst *UserCancelWithdrawalRequestInstruction) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserCancelWithdrawalRequestInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenProgram)
 	return inst
 }
 
 // GetReceiptTokenProgramAccount gets the "receipt_token_program" account.
-func (inst *UserCancelWithdrawalRequest) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserCancelWithdrawalRequestInstruction) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *UserCancelWithdrawalRequest) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserCancelWithdrawalRequest {
+func (inst *UserCancelWithdrawalRequestInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserCancelWithdrawalRequestInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenMint).WRITE()
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *UserCancelWithdrawalRequest) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserCancelWithdrawalRequestInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetReceiptTokenLockAccountAccount sets the "receipt_token_lock_account" account.
-func (inst *UserCancelWithdrawalRequest) SetReceiptTokenLockAccountAccount(receiptTokenLockAccount ag_solanago.PublicKey) *UserCancelWithdrawalRequest {
+func (inst *UserCancelWithdrawalRequestInstruction) SetReceiptTokenLockAccountAccount(receiptTokenLockAccount ag_solanago.PublicKey) *UserCancelWithdrawalRequestInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(receiptTokenLockAccount).WRITE()
 	return inst
 }
 
-func (inst *UserCancelWithdrawalRequest) findFindReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) findFindReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: fundAccount
 	seeds = append(seeds, fundAccount.Bytes())
@@ -139,12 +139,12 @@ func (inst *UserCancelWithdrawalRequest) findFindReceiptTokenLockAccountAddress(
 }
 
 // FindReceiptTokenLockAccountAddressWithBumpSeed calculates ReceiptTokenLockAccount account address with given seeds and a known bump seed.
-func (inst *UserCancelWithdrawalRequest) FindReceiptTokenLockAccountAddressWithBumpSeed(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) FindReceiptTokenLockAccountAddressWithBumpSeed(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindReceiptTokenLockAccountAddress(fundAccount, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserCancelWithdrawalRequest) MustFindReceiptTokenLockAccountAddressWithBumpSeed(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserCancelWithdrawalRequestInstruction) MustFindReceiptTokenLockAccountAddressWithBumpSeed(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindReceiptTokenLockAccountAddress(fundAccount, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -153,12 +153,12 @@ func (inst *UserCancelWithdrawalRequest) MustFindReceiptTokenLockAccountAddressW
 }
 
 // FindReceiptTokenLockAccountAddress finds ReceiptTokenLockAccount account address with given seeds.
-func (inst *UserCancelWithdrawalRequest) FindReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) FindReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindReceiptTokenLockAccountAddress(fundAccount, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserCancelWithdrawalRequest) MustFindReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserCancelWithdrawalRequestInstruction) MustFindReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindReceiptTokenLockAccountAddress(fundAccount, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -167,17 +167,17 @@ func (inst *UserCancelWithdrawalRequest) MustFindReceiptTokenLockAccountAddress(
 }
 
 // GetReceiptTokenLockAccountAccount gets the "receipt_token_lock_account" account.
-func (inst *UserCancelWithdrawalRequest) GetReceiptTokenLockAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserCancelWithdrawalRequestInstruction) GetReceiptTokenLockAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetUserReceiptTokenAccountAccount sets the "user_receipt_token_account" account.
-func (inst *UserCancelWithdrawalRequest) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserCancelWithdrawalRequest {
+func (inst *UserCancelWithdrawalRequestInstruction) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserCancelWithdrawalRequestInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(userReceiptTokenAccount).WRITE()
 	return inst
 }
 
-func (inst *UserCancelWithdrawalRequest) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: user
 	seeds = append(seeds, user.Bytes())
@@ -198,12 +198,12 @@ func (inst *UserCancelWithdrawalRequest) findFindUserReceiptTokenAccountAddress(
 }
 
 // FindUserReceiptTokenAccountAddressWithBumpSeed calculates UserReceiptTokenAccount account address with given seeds and a known bump seed.
-func (inst *UserCancelWithdrawalRequest) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserCancelWithdrawalRequest) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserCancelWithdrawalRequestInstruction) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -212,12 +212,12 @@ func (inst *UserCancelWithdrawalRequest) MustFindUserReceiptTokenAccountAddressW
 }
 
 // FindUserReceiptTokenAccountAddress finds UserReceiptTokenAccount account address with given seeds.
-func (inst *UserCancelWithdrawalRequest) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserCancelWithdrawalRequest) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserCancelWithdrawalRequestInstruction) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -226,17 +226,17 @@ func (inst *UserCancelWithdrawalRequest) MustFindUserReceiptTokenAccountAddress(
 }
 
 // GetUserReceiptTokenAccountAccount gets the "user_receipt_token_account" account.
-func (inst *UserCancelWithdrawalRequest) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserCancelWithdrawalRequestInstruction) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *UserCancelWithdrawalRequest) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *UserCancelWithdrawalRequest {
+func (inst *UserCancelWithdrawalRequestInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *UserCancelWithdrawalRequestInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserCancelWithdrawalRequest) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -253,12 +253,12 @@ func (inst *UserCancelWithdrawalRequest) findFindFundAccountAddress(receiptToken
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *UserCancelWithdrawalRequest) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserCancelWithdrawalRequest) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserCancelWithdrawalRequestInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -267,12 +267,12 @@ func (inst *UserCancelWithdrawalRequest) MustFindFundAccountAddressWithBumpSeed(
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *UserCancelWithdrawalRequest) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserCancelWithdrawalRequest) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserCancelWithdrawalRequestInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -281,17 +281,17 @@ func (inst *UserCancelWithdrawalRequest) MustFindFundAccountAddress(receiptToken
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *UserCancelWithdrawalRequest) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserCancelWithdrawalRequestInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetFundReserveAccountAccount sets the "fund_reserve_account" account.
-func (inst *UserCancelWithdrawalRequest) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *UserCancelWithdrawalRequest {
+func (inst *UserCancelWithdrawalRequestInstruction) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *UserCancelWithdrawalRequestInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(fundReserveAccount).WRITE()
 	return inst
 }
 
-func (inst *UserCancelWithdrawalRequest) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_reserve
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x72), byte(0x65), byte(0x73), byte(0x65), byte(0x72), byte(0x76), byte(0x65)})
@@ -308,12 +308,12 @@ func (inst *UserCancelWithdrawalRequest) findFindFundReserveAccountAddress(recei
 }
 
 // FindFundReserveAccountAddressWithBumpSeed calculates FundReserveAccount account address with given seeds and a known bump seed.
-func (inst *UserCancelWithdrawalRequest) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserCancelWithdrawalRequest) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserCancelWithdrawalRequestInstruction) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -322,12 +322,12 @@ func (inst *UserCancelWithdrawalRequest) MustFindFundReserveAccountAddressWithBu
 }
 
 // FindFundReserveAccountAddress finds FundReserveAccount account address with given seeds.
-func (inst *UserCancelWithdrawalRequest) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserCancelWithdrawalRequest) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserCancelWithdrawalRequestInstruction) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -336,17 +336,17 @@ func (inst *UserCancelWithdrawalRequest) MustFindFundReserveAccountAddress(recei
 }
 
 // GetFundReserveAccountAccount gets the "fund_reserve_account" account.
-func (inst *UserCancelWithdrawalRequest) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserCancelWithdrawalRequestInstruction) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetUserFundAccountAccount sets the "user_fund_account" account.
-func (inst *UserCancelWithdrawalRequest) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserCancelWithdrawalRequest {
+func (inst *UserCancelWithdrawalRequestInstruction) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserCancelWithdrawalRequestInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(userFundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserCancelWithdrawalRequest) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_fund
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -365,12 +365,12 @@ func (inst *UserCancelWithdrawalRequest) findFindUserFundAccountAddress(receiptT
 }
 
 // FindUserFundAccountAddressWithBumpSeed calculates UserFundAccount account address with given seeds and a known bump seed.
-func (inst *UserCancelWithdrawalRequest) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserCancelWithdrawalRequest) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserCancelWithdrawalRequestInstruction) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -379,12 +379,12 @@ func (inst *UserCancelWithdrawalRequest) MustFindUserFundAccountAddressWithBumpS
 }
 
 // FindUserFundAccountAddress finds UserFundAccount account address with given seeds.
-func (inst *UserCancelWithdrawalRequest) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserCancelWithdrawalRequest) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserCancelWithdrawalRequestInstruction) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -393,17 +393,17 @@ func (inst *UserCancelWithdrawalRequest) MustFindUserFundAccountAddress(receiptT
 }
 
 // GetUserFundAccountAccount gets the "user_fund_account" account.
-func (inst *UserCancelWithdrawalRequest) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserCancelWithdrawalRequestInstruction) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *UserCancelWithdrawalRequest) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserCancelWithdrawalRequest {
+func (inst *UserCancelWithdrawalRequestInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserCancelWithdrawalRequestInstruction {
 	inst.AccountMetaSlice[9] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserCancelWithdrawalRequest) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -420,12 +420,12 @@ func (inst *UserCancelWithdrawalRequest) findFindRewardAccountAddress(receiptTok
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *UserCancelWithdrawalRequest) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserCancelWithdrawalRequest) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserCancelWithdrawalRequestInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -434,12 +434,12 @@ func (inst *UserCancelWithdrawalRequest) MustFindRewardAccountAddressWithBumpSee
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *UserCancelWithdrawalRequest) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserCancelWithdrawalRequest) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserCancelWithdrawalRequestInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -448,17 +448,17 @@ func (inst *UserCancelWithdrawalRequest) MustFindRewardAccountAddress(receiptTok
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *UserCancelWithdrawalRequest) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserCancelWithdrawalRequestInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(9)
 }
 
 // SetUserRewardAccountAccount sets the "user_reward_account" account.
-func (inst *UserCancelWithdrawalRequest) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserCancelWithdrawalRequest {
+func (inst *UserCancelWithdrawalRequestInstruction) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserCancelWithdrawalRequestInstruction {
 	inst.AccountMetaSlice[10] = ag_solanago.Meta(userRewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserCancelWithdrawalRequest) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -477,12 +477,12 @@ func (inst *UserCancelWithdrawalRequest) findFindUserRewardAccountAddress(receip
 }
 
 // FindUserRewardAccountAddressWithBumpSeed calculates UserRewardAccount account address with given seeds and a known bump seed.
-func (inst *UserCancelWithdrawalRequest) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserCancelWithdrawalRequest) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserCancelWithdrawalRequestInstruction) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -491,12 +491,12 @@ func (inst *UserCancelWithdrawalRequest) MustFindUserRewardAccountAddressWithBum
 }
 
 // FindUserRewardAccountAddress finds UserRewardAccount account address with given seeds.
-func (inst *UserCancelWithdrawalRequest) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserCancelWithdrawalRequest) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserCancelWithdrawalRequestInstruction) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -505,28 +505,28 @@ func (inst *UserCancelWithdrawalRequest) MustFindUserRewardAccountAddress(receip
 }
 
 // GetUserRewardAccountAccount gets the "user_reward_account" account.
-func (inst *UserCancelWithdrawalRequest) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserCancelWithdrawalRequestInstruction) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(10)
 }
 
 // SetInstructionsSysvarAccount sets the "instructions_sysvar" account.
-func (inst *UserCancelWithdrawalRequest) SetInstructionsSysvarAccount(instructionsSysvar ag_solanago.PublicKey) *UserCancelWithdrawalRequest {
+func (inst *UserCancelWithdrawalRequestInstruction) SetInstructionsSysvarAccount(instructionsSysvar ag_solanago.PublicKey) *UserCancelWithdrawalRequestInstruction {
 	inst.AccountMetaSlice[11] = ag_solanago.Meta(instructionsSysvar)
 	return inst
 }
 
 // GetInstructionsSysvarAccount gets the "instructions_sysvar" account.
-func (inst *UserCancelWithdrawalRequest) GetInstructionsSysvarAccount() *ag_solanago.AccountMeta {
+func (inst *UserCancelWithdrawalRequestInstruction) GetInstructionsSysvarAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(11)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *UserCancelWithdrawalRequest) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserCancelWithdrawalRequest {
+func (inst *UserCancelWithdrawalRequestInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserCancelWithdrawalRequestInstruction {
 	inst.AccountMetaSlice[12] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *UserCancelWithdrawalRequest) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -541,12 +541,12 @@ func (inst *UserCancelWithdrawalRequest) findFindEventAuthorityAddress(knownBump
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *UserCancelWithdrawalRequest) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *UserCancelWithdrawalRequest) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserCancelWithdrawalRequestInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -555,12 +555,12 @@ func (inst *UserCancelWithdrawalRequest) MustFindEventAuthorityAddressWithBumpSe
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *UserCancelWithdrawalRequest) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCancelWithdrawalRequestInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *UserCancelWithdrawalRequest) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *UserCancelWithdrawalRequestInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -569,22 +569,22 @@ func (inst *UserCancelWithdrawalRequest) MustFindEventAuthorityAddress() (pda ag
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *UserCancelWithdrawalRequest) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *UserCancelWithdrawalRequestInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(12)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *UserCancelWithdrawalRequest) SetProgramAccount(program ag_solanago.PublicKey) *UserCancelWithdrawalRequest {
+func (inst *UserCancelWithdrawalRequestInstruction) SetProgramAccount(program ag_solanago.PublicKey) *UserCancelWithdrawalRequestInstruction {
 	inst.AccountMetaSlice[13] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *UserCancelWithdrawalRequest) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserCancelWithdrawalRequestInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(13)
 }
 
-func (inst UserCancelWithdrawalRequest) Build() *Instruction {
+func (inst UserCancelWithdrawalRequestInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_UserCancelWithdrawalRequest,
@@ -594,14 +594,14 @@ func (inst UserCancelWithdrawalRequest) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst UserCancelWithdrawalRequest) ValidateAndBuild() (*Instruction, error) {
+func (inst UserCancelWithdrawalRequestInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *UserCancelWithdrawalRequest) Validate() error {
+func (inst *UserCancelWithdrawalRequestInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.RequestId == nil {
@@ -657,7 +657,7 @@ func (inst *UserCancelWithdrawalRequest) Validate() error {
 	return nil
 }
 
-func (inst *UserCancelWithdrawalRequest) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *UserCancelWithdrawalRequestInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -692,7 +692,7 @@ func (inst *UserCancelWithdrawalRequest) EncodeToTree(parent ag_treeout.Branches
 		})
 }
 
-func (obj UserCancelWithdrawalRequest) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj UserCancelWithdrawalRequestInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `RequestId` param:
 	err = encoder.Encode(obj.RequestId)
 	if err != nil {
@@ -718,7 +718,7 @@ func (obj UserCancelWithdrawalRequest) MarshalWithEncoder(encoder *ag_binary.Enc
 	}
 	return nil
 }
-func (obj *UserCancelWithdrawalRequest) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *UserCancelWithdrawalRequestInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `RequestId`:
 	err = decoder.Decode(&obj.RequestId)
 	if err != nil {
@@ -759,7 +759,7 @@ func NewUserCancelWithdrawalRequestInstruction(
 	userRewardAccount ag_solanago.PublicKey,
 	instructionsSysvar ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *UserCancelWithdrawalRequest {
+	program ag_solanago.PublicKey) *UserCancelWithdrawalRequestInstruction {
 	return NewUserCancelWithdrawalRequestInstructionBuilder().
 		SetRequestId(request_id).
 		SetSupportedTokenMint(supported_token_mint).

--- a/generated/restaking/usercancelwithdrawalrequest_test.go
+++ b/generated/restaking/usercancelwithdrawalrequest_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_UserCancelWithdrawalRequest(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("UserCancelWithdrawalRequest"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(UserCancelWithdrawalRequest)
+				params := new(UserCancelWithdrawalRequestInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(UserCancelWithdrawalRequest)
+				got := new(UserCancelWithdrawalRequestInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/userclaimrewards.go
+++ b/generated/restaking/userclaimrewards.go
@@ -11,7 +11,7 @@ import (
 )
 
 // UserClaimRewards is the `user_claim_rewards` instruction.
-type UserClaimRewards struct {
+type UserClaimRewardsInstruction struct {
 	RewardPoolId *uint8
 	RewardId     *uint8
 
@@ -31,9 +31,9 @@ type UserClaimRewards struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewUserClaimRewardsInstructionBuilder creates a new `UserClaimRewards` instruction builder.
-func NewUserClaimRewardsInstructionBuilder() *UserClaimRewards {
-	nd := &UserClaimRewards{
+// NewUserClaimRewardsInstructionBuilder creates a new `UserClaimRewardsInstruction` instruction builder.
+func NewUserClaimRewardsInstructionBuilder() *UserClaimRewardsInstruction {
+	nd := &UserClaimRewardsInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 7),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["11111111111111111111111111111111"])
@@ -41,57 +41,57 @@ func NewUserClaimRewardsInstructionBuilder() *UserClaimRewards {
 }
 
 // SetRewardPoolId sets the "reward_pool_id" parameter.
-func (inst *UserClaimRewards) SetRewardPoolId(reward_pool_id uint8) *UserClaimRewards {
+func (inst *UserClaimRewardsInstruction) SetRewardPoolId(reward_pool_id uint8) *UserClaimRewardsInstruction {
 	inst.RewardPoolId = &reward_pool_id
 	return inst
 }
 
 // SetRewardId sets the "reward_id" parameter.
-func (inst *UserClaimRewards) SetRewardId(reward_id uint8) *UserClaimRewards {
+func (inst *UserClaimRewardsInstruction) SetRewardId(reward_id uint8) *UserClaimRewardsInstruction {
 	inst.RewardId = &reward_id
 	return inst
 }
 
 // SetUserAccount sets the "user" account.
-func (inst *UserClaimRewards) SetUserAccount(user ag_solanago.PublicKey) *UserClaimRewards {
+func (inst *UserClaimRewardsInstruction) SetUserAccount(user ag_solanago.PublicKey) *UserClaimRewardsInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(user).WRITE().SIGNER()
 	return inst
 }
 
 // GetUserAccount gets the "user" account.
-func (inst *UserClaimRewards) GetUserAccount() *ag_solanago.AccountMeta {
+func (inst *UserClaimRewardsInstruction) GetUserAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *UserClaimRewards) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserClaimRewards {
+func (inst *UserClaimRewardsInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserClaimRewardsInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *UserClaimRewards) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserClaimRewardsInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *UserClaimRewards) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserClaimRewards {
+func (inst *UserClaimRewardsInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserClaimRewardsInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *UserClaimRewards) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserClaimRewardsInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *UserClaimRewards) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserClaimRewards {
+func (inst *UserClaimRewardsInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserClaimRewardsInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserClaimRewards) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserClaimRewardsInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -108,12 +108,12 @@ func (inst *UserClaimRewards) findFindRewardAccountAddress(receiptTokenMint ag_s
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *UserClaimRewards) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserClaimRewardsInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserClaimRewards) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserClaimRewardsInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -122,12 +122,12 @@ func (inst *UserClaimRewards) MustFindRewardAccountAddressWithBumpSeed(receiptTo
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *UserClaimRewards) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserClaimRewardsInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserClaimRewards) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserClaimRewardsInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -136,17 +136,17 @@ func (inst *UserClaimRewards) MustFindRewardAccountAddress(receiptTokenMint ag_s
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *UserClaimRewards) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserClaimRewardsInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetUserRewardAccountAccount sets the "user_reward_account" account.
-func (inst *UserClaimRewards) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserClaimRewards {
+func (inst *UserClaimRewardsInstruction) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserClaimRewardsInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(userRewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserClaimRewards) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserClaimRewardsInstruction) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -165,12 +165,12 @@ func (inst *UserClaimRewards) findFindUserRewardAccountAddress(receiptTokenMint 
 }
 
 // FindUserRewardAccountAddressWithBumpSeed calculates UserRewardAccount account address with given seeds and a known bump seed.
-func (inst *UserClaimRewards) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserClaimRewardsInstruction) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserClaimRewards) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserClaimRewardsInstruction) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -179,12 +179,12 @@ func (inst *UserClaimRewards) MustFindUserRewardAccountAddressWithBumpSeed(recei
 }
 
 // FindUserRewardAccountAddress finds UserRewardAccount account address with given seeds.
-func (inst *UserClaimRewards) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserClaimRewardsInstruction) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserClaimRewards) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserClaimRewardsInstruction) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -193,17 +193,17 @@ func (inst *UserClaimRewards) MustFindUserRewardAccountAddress(receiptTokenMint 
 }
 
 // GetUserRewardAccountAccount gets the "user_reward_account" account.
-func (inst *UserClaimRewards) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserClaimRewardsInstruction) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *UserClaimRewards) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserClaimRewards {
+func (inst *UserClaimRewardsInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserClaimRewardsInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *UserClaimRewards) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserClaimRewardsInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -218,12 +218,12 @@ func (inst *UserClaimRewards) findFindEventAuthorityAddress(knownBumpSeed uint8)
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *UserClaimRewards) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserClaimRewardsInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *UserClaimRewards) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserClaimRewardsInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -232,12 +232,12 @@ func (inst *UserClaimRewards) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *UserClaimRewards) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserClaimRewardsInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *UserClaimRewards) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *UserClaimRewardsInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -246,22 +246,22 @@ func (inst *UserClaimRewards) MustFindEventAuthorityAddress() (pda ag_solanago.P
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *UserClaimRewards) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *UserClaimRewardsInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *UserClaimRewards) SetProgramAccount(program ag_solanago.PublicKey) *UserClaimRewards {
+func (inst *UserClaimRewardsInstruction) SetProgramAccount(program ag_solanago.PublicKey) *UserClaimRewardsInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *UserClaimRewards) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserClaimRewardsInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
-func (inst UserClaimRewards) Build() *Instruction {
+func (inst UserClaimRewardsInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_UserClaimRewards,
@@ -271,14 +271,14 @@ func (inst UserClaimRewards) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst UserClaimRewards) ValidateAndBuild() (*Instruction, error) {
+func (inst UserClaimRewardsInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *UserClaimRewards) Validate() error {
+func (inst *UserClaimRewardsInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.RewardPoolId == nil {
@@ -316,7 +316,7 @@ func (inst *UserClaimRewards) Validate() error {
 	return nil
 }
 
-func (inst *UserClaimRewards) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *UserClaimRewardsInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -344,7 +344,7 @@ func (inst *UserClaimRewards) EncodeToTree(parent ag_treeout.Branches) {
 		})
 }
 
-func (obj UserClaimRewards) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj UserClaimRewardsInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `RewardPoolId` param:
 	err = encoder.Encode(obj.RewardPoolId)
 	if err != nil {
@@ -357,7 +357,7 @@ func (obj UserClaimRewards) MarshalWithEncoder(encoder *ag_binary.Encoder) (err 
 	}
 	return nil
 }
-func (obj *UserClaimRewards) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *UserClaimRewardsInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `RewardPoolId`:
 	err = decoder.Decode(&obj.RewardPoolId)
 	if err != nil {
@@ -383,7 +383,7 @@ func NewUserClaimRewardsInstruction(
 	rewardAccount ag_solanago.PublicKey,
 	userRewardAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *UserClaimRewards {
+	program ag_solanago.PublicKey) *UserClaimRewardsInstruction {
 	return NewUserClaimRewardsInstructionBuilder().
 		SetRewardPoolId(reward_pool_id).
 		SetRewardId(reward_id).

--- a/generated/restaking/userclaimrewards_test.go
+++ b/generated/restaking/userclaimrewards_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_UserClaimRewards(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("UserClaimRewards"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(UserClaimRewards)
+				params := new(UserClaimRewardsInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(UserClaimRewards)
+				got := new(UserClaimRewardsInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/usercreatefundaccountidempotent.go
+++ b/generated/restaking/usercreatefundaccountidempotent.go
@@ -11,7 +11,7 @@ import (
 )
 
 // UserCreateFundAccountIdempotent is the `user_create_fund_account_idempotent` instruction.
-type UserCreateFundAccountIdempotent struct {
+type UserCreateFundAccountIdempotentInstruction struct {
 	DesiredAccountSize *uint32 `bin:"optional"`
 
 	// [0] = [WRITE, SIGNER] user
@@ -32,9 +32,9 @@ type UserCreateFundAccountIdempotent struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewUserCreateFundAccountIdempotentInstructionBuilder creates a new `UserCreateFundAccountIdempotent` instruction builder.
-func NewUserCreateFundAccountIdempotentInstructionBuilder() *UserCreateFundAccountIdempotent {
-	nd := &UserCreateFundAccountIdempotent{
+// NewUserCreateFundAccountIdempotentInstructionBuilder creates a new `UserCreateFundAccountIdempotentInstruction` instruction builder.
+func NewUserCreateFundAccountIdempotentInstructionBuilder() *UserCreateFundAccountIdempotentInstruction {
+	nd := &UserCreateFundAccountIdempotentInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 8),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["11111111111111111111111111111111"])
@@ -43,62 +43,62 @@ func NewUserCreateFundAccountIdempotentInstructionBuilder() *UserCreateFundAccou
 }
 
 // SetDesiredAccountSize sets the "desired_account_size" parameter.
-func (inst *UserCreateFundAccountIdempotent) SetDesiredAccountSize(desired_account_size uint32) *UserCreateFundAccountIdempotent {
+func (inst *UserCreateFundAccountIdempotentInstruction) SetDesiredAccountSize(desired_account_size uint32) *UserCreateFundAccountIdempotentInstruction {
 	inst.DesiredAccountSize = &desired_account_size
 	return inst
 }
 
 // SetUserAccount sets the "user" account.
-func (inst *UserCreateFundAccountIdempotent) SetUserAccount(user ag_solanago.PublicKey) *UserCreateFundAccountIdempotent {
+func (inst *UserCreateFundAccountIdempotentInstruction) SetUserAccount(user ag_solanago.PublicKey) *UserCreateFundAccountIdempotentInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(user).WRITE().SIGNER()
 	return inst
 }
 
 // GetUserAccount gets the "user" account.
-func (inst *UserCreateFundAccountIdempotent) GetUserAccount() *ag_solanago.AccountMeta {
+func (inst *UserCreateFundAccountIdempotentInstruction) GetUserAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *UserCreateFundAccountIdempotent) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserCreateFundAccountIdempotent {
+func (inst *UserCreateFundAccountIdempotentInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserCreateFundAccountIdempotentInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *UserCreateFundAccountIdempotent) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserCreateFundAccountIdempotentInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *UserCreateFundAccountIdempotent) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserCreateFundAccountIdempotent {
+func (inst *UserCreateFundAccountIdempotentInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserCreateFundAccountIdempotentInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *UserCreateFundAccountIdempotent) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserCreateFundAccountIdempotentInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetReceiptTokenProgramAccount sets the "receipt_token_program" account.
-func (inst *UserCreateFundAccountIdempotent) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserCreateFundAccountIdempotent {
+func (inst *UserCreateFundAccountIdempotentInstruction) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserCreateFundAccountIdempotentInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenProgram)
 	return inst
 }
 
 // GetReceiptTokenProgramAccount gets the "receipt_token_program" account.
-func (inst *UserCreateFundAccountIdempotent) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserCreateFundAccountIdempotentInstruction) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetUserReceiptTokenAccountAccount sets the "user_receipt_token_account" account.
-func (inst *UserCreateFundAccountIdempotent) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserCreateFundAccountIdempotent {
+func (inst *UserCreateFundAccountIdempotentInstruction) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserCreateFundAccountIdempotentInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(userReceiptTokenAccount)
 	return inst
 }
 
-func (inst *UserCreateFundAccountIdempotent) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCreateFundAccountIdempotentInstruction) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: user
 	seeds = append(seeds, user.Bytes())
@@ -119,12 +119,12 @@ func (inst *UserCreateFundAccountIdempotent) findFindUserReceiptTokenAccountAddr
 }
 
 // FindUserReceiptTokenAccountAddressWithBumpSeed calculates UserReceiptTokenAccount account address with given seeds and a known bump seed.
-func (inst *UserCreateFundAccountIdempotent) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserCreateFundAccountIdempotentInstruction) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserCreateFundAccountIdempotent) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserCreateFundAccountIdempotentInstruction) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -133,12 +133,12 @@ func (inst *UserCreateFundAccountIdempotent) MustFindUserReceiptTokenAccountAddr
 }
 
 // FindUserReceiptTokenAccountAddress finds UserReceiptTokenAccount account address with given seeds.
-func (inst *UserCreateFundAccountIdempotent) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCreateFundAccountIdempotentInstruction) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserCreateFundAccountIdempotent) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserCreateFundAccountIdempotentInstruction) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -147,17 +147,17 @@ func (inst *UserCreateFundAccountIdempotent) MustFindUserReceiptTokenAccountAddr
 }
 
 // GetUserReceiptTokenAccountAccount gets the "user_receipt_token_account" account.
-func (inst *UserCreateFundAccountIdempotent) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserCreateFundAccountIdempotentInstruction) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetUserFundAccountAccount sets the "user_fund_account" account.
-func (inst *UserCreateFundAccountIdempotent) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserCreateFundAccountIdempotent {
+func (inst *UserCreateFundAccountIdempotentInstruction) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserCreateFundAccountIdempotentInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(userFundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserCreateFundAccountIdempotent) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCreateFundAccountIdempotentInstruction) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_fund
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -176,12 +176,12 @@ func (inst *UserCreateFundAccountIdempotent) findFindUserFundAccountAddress(rece
 }
 
 // FindUserFundAccountAddressWithBumpSeed calculates UserFundAccount account address with given seeds and a known bump seed.
-func (inst *UserCreateFundAccountIdempotent) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserCreateFundAccountIdempotentInstruction) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserCreateFundAccountIdempotent) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserCreateFundAccountIdempotentInstruction) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -190,12 +190,12 @@ func (inst *UserCreateFundAccountIdempotent) MustFindUserFundAccountAddressWithB
 }
 
 // FindUserFundAccountAddress finds UserFundAccount account address with given seeds.
-func (inst *UserCreateFundAccountIdempotent) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCreateFundAccountIdempotentInstruction) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserCreateFundAccountIdempotent) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserCreateFundAccountIdempotentInstruction) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -204,17 +204,17 @@ func (inst *UserCreateFundAccountIdempotent) MustFindUserFundAccountAddress(rece
 }
 
 // GetUserFundAccountAccount gets the "user_fund_account" account.
-func (inst *UserCreateFundAccountIdempotent) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserCreateFundAccountIdempotentInstruction) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *UserCreateFundAccountIdempotent) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserCreateFundAccountIdempotent {
+func (inst *UserCreateFundAccountIdempotentInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserCreateFundAccountIdempotentInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *UserCreateFundAccountIdempotent) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCreateFundAccountIdempotentInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -229,12 +229,12 @@ func (inst *UserCreateFundAccountIdempotent) findFindEventAuthorityAddress(known
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *UserCreateFundAccountIdempotent) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserCreateFundAccountIdempotentInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *UserCreateFundAccountIdempotent) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserCreateFundAccountIdempotentInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -243,12 +243,12 @@ func (inst *UserCreateFundAccountIdempotent) MustFindEventAuthorityAddressWithBu
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *UserCreateFundAccountIdempotent) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCreateFundAccountIdempotentInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *UserCreateFundAccountIdempotent) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *UserCreateFundAccountIdempotentInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -257,22 +257,22 @@ func (inst *UserCreateFundAccountIdempotent) MustFindEventAuthorityAddress() (pd
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *UserCreateFundAccountIdempotent) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *UserCreateFundAccountIdempotentInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *UserCreateFundAccountIdempotent) SetProgramAccount(program ag_solanago.PublicKey) *UserCreateFundAccountIdempotent {
+func (inst *UserCreateFundAccountIdempotentInstruction) SetProgramAccount(program ag_solanago.PublicKey) *UserCreateFundAccountIdempotentInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *UserCreateFundAccountIdempotent) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserCreateFundAccountIdempotentInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
-func (inst UserCreateFundAccountIdempotent) Build() *Instruction {
+func (inst UserCreateFundAccountIdempotentInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_UserCreateFundAccountIdempotent,
@@ -282,14 +282,14 @@ func (inst UserCreateFundAccountIdempotent) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst UserCreateFundAccountIdempotent) ValidateAndBuild() (*Instruction, error) {
+func (inst UserCreateFundAccountIdempotentInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *UserCreateFundAccountIdempotent) Validate() error {
+func (inst *UserCreateFundAccountIdempotentInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 	}
@@ -324,7 +324,7 @@ func (inst *UserCreateFundAccountIdempotent) Validate() error {
 	return nil
 }
 
-func (inst *UserCreateFundAccountIdempotent) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *UserCreateFundAccountIdempotentInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -352,7 +352,7 @@ func (inst *UserCreateFundAccountIdempotent) EncodeToTree(parent ag_treeout.Bran
 		})
 }
 
-func (obj UserCreateFundAccountIdempotent) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj UserCreateFundAccountIdempotentInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `DesiredAccountSize` param (optional):
 	{
 		if obj.DesiredAccountSize == nil {
@@ -373,7 +373,7 @@ func (obj UserCreateFundAccountIdempotent) MarshalWithEncoder(encoder *ag_binary
 	}
 	return nil
 }
-func (obj *UserCreateFundAccountIdempotent) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *UserCreateFundAccountIdempotentInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `DesiredAccountSize` (optional):
 	{
 		ok, err := decoder.ReadBool()
@@ -402,7 +402,7 @@ func NewUserCreateFundAccountIdempotentInstruction(
 	userReceiptTokenAccount ag_solanago.PublicKey,
 	userFundAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *UserCreateFundAccountIdempotent {
+	program ag_solanago.PublicKey) *UserCreateFundAccountIdempotentInstruction {
 	return NewUserCreateFundAccountIdempotentInstructionBuilder().
 		SetDesiredAccountSize(desired_account_size).
 		SetUserAccount(user).

--- a/generated/restaking/usercreatefundaccountidempotent_test.go
+++ b/generated/restaking/usercreatefundaccountidempotent_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_UserCreateFundAccountIdempotent(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("UserCreateFundAccountIdempotent"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(UserCreateFundAccountIdempotent)
+				params := new(UserCreateFundAccountIdempotentInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(UserCreateFundAccountIdempotent)
+				got := new(UserCreateFundAccountIdempotentInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/usercreaterewardaccountidempotent.go
+++ b/generated/restaking/usercreaterewardaccountidempotent.go
@@ -11,7 +11,7 @@ import (
 )
 
 // UserCreateRewardAccountIdempotent is the `user_create_reward_account_idempotent` instruction.
-type UserCreateRewardAccountIdempotent struct {
+type UserCreateRewardAccountIdempotentInstruction struct {
 	DesiredAccountSize *uint32 `bin:"optional"`
 
 	// [0] = [WRITE, SIGNER] user
@@ -34,9 +34,9 @@ type UserCreateRewardAccountIdempotent struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewUserCreateRewardAccountIdempotentInstructionBuilder creates a new `UserCreateRewardAccountIdempotent` instruction builder.
-func NewUserCreateRewardAccountIdempotentInstructionBuilder() *UserCreateRewardAccountIdempotent {
-	nd := &UserCreateRewardAccountIdempotent{
+// NewUserCreateRewardAccountIdempotentInstructionBuilder creates a new `UserCreateRewardAccountIdempotentInstruction` instruction builder.
+func NewUserCreateRewardAccountIdempotentInstructionBuilder() *UserCreateRewardAccountIdempotentInstruction {
+	nd := &UserCreateRewardAccountIdempotentInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 9),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["11111111111111111111111111111111"])
@@ -45,62 +45,62 @@ func NewUserCreateRewardAccountIdempotentInstructionBuilder() *UserCreateRewardA
 }
 
 // SetDesiredAccountSize sets the "desired_account_size" parameter.
-func (inst *UserCreateRewardAccountIdempotent) SetDesiredAccountSize(desired_account_size uint32) *UserCreateRewardAccountIdempotent {
+func (inst *UserCreateRewardAccountIdempotentInstruction) SetDesiredAccountSize(desired_account_size uint32) *UserCreateRewardAccountIdempotentInstruction {
 	inst.DesiredAccountSize = &desired_account_size
 	return inst
 }
 
 // SetUserAccount sets the "user" account.
-func (inst *UserCreateRewardAccountIdempotent) SetUserAccount(user ag_solanago.PublicKey) *UserCreateRewardAccountIdempotent {
+func (inst *UserCreateRewardAccountIdempotentInstruction) SetUserAccount(user ag_solanago.PublicKey) *UserCreateRewardAccountIdempotentInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(user).WRITE().SIGNER()
 	return inst
 }
 
 // GetUserAccount gets the "user" account.
-func (inst *UserCreateRewardAccountIdempotent) GetUserAccount() *ag_solanago.AccountMeta {
+func (inst *UserCreateRewardAccountIdempotentInstruction) GetUserAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *UserCreateRewardAccountIdempotent) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserCreateRewardAccountIdempotent {
+func (inst *UserCreateRewardAccountIdempotentInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserCreateRewardAccountIdempotentInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *UserCreateRewardAccountIdempotent) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserCreateRewardAccountIdempotentInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *UserCreateRewardAccountIdempotent) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserCreateRewardAccountIdempotent {
+func (inst *UserCreateRewardAccountIdempotentInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserCreateRewardAccountIdempotentInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *UserCreateRewardAccountIdempotent) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserCreateRewardAccountIdempotentInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetReceiptTokenProgramAccount sets the "receipt_token_program" account.
-func (inst *UserCreateRewardAccountIdempotent) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserCreateRewardAccountIdempotent {
+func (inst *UserCreateRewardAccountIdempotentInstruction) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserCreateRewardAccountIdempotentInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenProgram)
 	return inst
 }
 
 // GetReceiptTokenProgramAccount gets the "receipt_token_program" account.
-func (inst *UserCreateRewardAccountIdempotent) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserCreateRewardAccountIdempotentInstruction) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetUserReceiptTokenAccountAccount sets the "user_receipt_token_account" account.
-func (inst *UserCreateRewardAccountIdempotent) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserCreateRewardAccountIdempotent {
+func (inst *UserCreateRewardAccountIdempotentInstruction) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserCreateRewardAccountIdempotentInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(userReceiptTokenAccount)
 	return inst
 }
 
-func (inst *UserCreateRewardAccountIdempotent) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: user
 	seeds = append(seeds, user.Bytes())
@@ -121,12 +121,12 @@ func (inst *UserCreateRewardAccountIdempotent) findFindUserReceiptTokenAccountAd
 }
 
 // FindUserReceiptTokenAccountAddressWithBumpSeed calculates UserReceiptTokenAccount account address with given seeds and a known bump seed.
-func (inst *UserCreateRewardAccountIdempotent) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserCreateRewardAccountIdempotent) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -135,12 +135,12 @@ func (inst *UserCreateRewardAccountIdempotent) MustFindUserReceiptTokenAccountAd
 }
 
 // FindUserReceiptTokenAccountAddress finds UserReceiptTokenAccount account address with given seeds.
-func (inst *UserCreateRewardAccountIdempotent) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserCreateRewardAccountIdempotent) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -149,17 +149,17 @@ func (inst *UserCreateRewardAccountIdempotent) MustFindUserReceiptTokenAccountAd
 }
 
 // GetUserReceiptTokenAccountAccount gets the "user_receipt_token_account" account.
-func (inst *UserCreateRewardAccountIdempotent) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserCreateRewardAccountIdempotentInstruction) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *UserCreateRewardAccountIdempotent) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserCreateRewardAccountIdempotent {
+func (inst *UserCreateRewardAccountIdempotentInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserCreateRewardAccountIdempotentInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserCreateRewardAccountIdempotent) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -176,12 +176,12 @@ func (inst *UserCreateRewardAccountIdempotent) findFindRewardAccountAddress(rece
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *UserCreateRewardAccountIdempotent) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserCreateRewardAccountIdempotent) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -190,12 +190,12 @@ func (inst *UserCreateRewardAccountIdempotent) MustFindRewardAccountAddressWithB
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *UserCreateRewardAccountIdempotent) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserCreateRewardAccountIdempotent) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -204,17 +204,17 @@ func (inst *UserCreateRewardAccountIdempotent) MustFindRewardAccountAddress(rece
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *UserCreateRewardAccountIdempotent) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserCreateRewardAccountIdempotentInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetUserRewardAccountAccount sets the "user_reward_account" account.
-func (inst *UserCreateRewardAccountIdempotent) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserCreateRewardAccountIdempotent {
+func (inst *UserCreateRewardAccountIdempotentInstruction) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserCreateRewardAccountIdempotentInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(userRewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserCreateRewardAccountIdempotent) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -233,12 +233,12 @@ func (inst *UserCreateRewardAccountIdempotent) findFindUserRewardAccountAddress(
 }
 
 // FindUserRewardAccountAddressWithBumpSeed calculates UserRewardAccount account address with given seeds and a known bump seed.
-func (inst *UserCreateRewardAccountIdempotent) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserCreateRewardAccountIdempotent) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -247,12 +247,12 @@ func (inst *UserCreateRewardAccountIdempotent) MustFindUserRewardAccountAddressW
 }
 
 // FindUserRewardAccountAddress finds UserRewardAccount account address with given seeds.
-func (inst *UserCreateRewardAccountIdempotent) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserCreateRewardAccountIdempotent) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -261,17 +261,17 @@ func (inst *UserCreateRewardAccountIdempotent) MustFindUserRewardAccountAddress(
 }
 
 // GetUserRewardAccountAccount gets the "user_reward_account" account.
-func (inst *UserCreateRewardAccountIdempotent) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserCreateRewardAccountIdempotentInstruction) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *UserCreateRewardAccountIdempotent) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserCreateRewardAccountIdempotent {
+func (inst *UserCreateRewardAccountIdempotentInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserCreateRewardAccountIdempotentInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *UserCreateRewardAccountIdempotent) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -286,12 +286,12 @@ func (inst *UserCreateRewardAccountIdempotent) findFindEventAuthorityAddress(kno
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *UserCreateRewardAccountIdempotent) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *UserCreateRewardAccountIdempotent) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -300,12 +300,12 @@ func (inst *UserCreateRewardAccountIdempotent) MustFindEventAuthorityAddressWith
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *UserCreateRewardAccountIdempotent) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *UserCreateRewardAccountIdempotent) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -314,22 +314,22 @@ func (inst *UserCreateRewardAccountIdempotent) MustFindEventAuthorityAddress() (
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *UserCreateRewardAccountIdempotent) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *UserCreateRewardAccountIdempotentInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *UserCreateRewardAccountIdempotent) SetProgramAccount(program ag_solanago.PublicKey) *UserCreateRewardAccountIdempotent {
+func (inst *UserCreateRewardAccountIdempotentInstruction) SetProgramAccount(program ag_solanago.PublicKey) *UserCreateRewardAccountIdempotentInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *UserCreateRewardAccountIdempotent) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserCreateRewardAccountIdempotentInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
-func (inst UserCreateRewardAccountIdempotent) Build() *Instruction {
+func (inst UserCreateRewardAccountIdempotentInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_UserCreateRewardAccountIdempotent,
@@ -339,14 +339,14 @@ func (inst UserCreateRewardAccountIdempotent) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst UserCreateRewardAccountIdempotent) ValidateAndBuild() (*Instruction, error) {
+func (inst UserCreateRewardAccountIdempotentInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *UserCreateRewardAccountIdempotent) Validate() error {
+func (inst *UserCreateRewardAccountIdempotentInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 	}
@@ -384,7 +384,7 @@ func (inst *UserCreateRewardAccountIdempotent) Validate() error {
 	return nil
 }
 
-func (inst *UserCreateRewardAccountIdempotent) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *UserCreateRewardAccountIdempotentInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -413,7 +413,7 @@ func (inst *UserCreateRewardAccountIdempotent) EncodeToTree(parent ag_treeout.Br
 		})
 }
 
-func (obj UserCreateRewardAccountIdempotent) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj UserCreateRewardAccountIdempotentInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `DesiredAccountSize` param (optional):
 	{
 		if obj.DesiredAccountSize == nil {
@@ -434,7 +434,7 @@ func (obj UserCreateRewardAccountIdempotent) MarshalWithEncoder(encoder *ag_bina
 	}
 	return nil
 }
-func (obj *UserCreateRewardAccountIdempotent) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *UserCreateRewardAccountIdempotentInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `DesiredAccountSize` (optional):
 	{
 		ok, err := decoder.ReadBool()
@@ -464,7 +464,7 @@ func NewUserCreateRewardAccountIdempotentInstruction(
 	rewardAccount ag_solanago.PublicKey,
 	userRewardAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *UserCreateRewardAccountIdempotent {
+	program ag_solanago.PublicKey) *UserCreateRewardAccountIdempotentInstruction {
 	return NewUserCreateRewardAccountIdempotentInstructionBuilder().
 		SetDesiredAccountSize(desired_account_size).
 		SetUserAccount(user).

--- a/generated/restaking/usercreaterewardaccountidempotent_test.go
+++ b/generated/restaking/usercreaterewardaccountidempotent_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_UserCreateRewardAccountIdempotent(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("UserCreateRewardAccountIdempotent"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(UserCreateRewardAccountIdempotent)
+				params := new(UserCreateRewardAccountIdempotentInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(UserCreateRewardAccountIdempotent)
+				got := new(UserCreateRewardAccountIdempotentInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/userdepositsol.go
+++ b/generated/restaking/userdepositsol.go
@@ -11,7 +11,7 @@ import (
 )
 
 // UserDepositSol is the `user_deposit_sol` instruction.
-type UserDepositSol struct {
+type UserDepositSolInstruction struct {
 	Amount   *uint64
 	Metadata *DepositMetadata `bin:"optional"`
 
@@ -45,9 +45,9 @@ type UserDepositSol struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewUserDepositSolInstructionBuilder creates a new `UserDepositSol` instruction builder.
-func NewUserDepositSolInstructionBuilder() *UserDepositSol {
-	nd := &UserDepositSol{
+// NewUserDepositSolInstructionBuilder creates a new `UserDepositSolInstruction` instruction builder.
+func NewUserDepositSolInstructionBuilder() *UserDepositSolInstruction {
+	nd := &UserDepositSolInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 14),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["11111111111111111111111111111111"])
@@ -57,68 +57,68 @@ func NewUserDepositSolInstructionBuilder() *UserDepositSol {
 }
 
 // SetAmount sets the "amount" parameter.
-func (inst *UserDepositSol) SetAmount(amount uint64) *UserDepositSol {
+func (inst *UserDepositSolInstruction) SetAmount(amount uint64) *UserDepositSolInstruction {
 	inst.Amount = &amount
 	return inst
 }
 
 // SetMetadata sets the "metadata" parameter.
-func (inst *UserDepositSol) SetMetadata(metadata DepositMetadata) *UserDepositSol {
+func (inst *UserDepositSolInstruction) SetMetadata(metadata DepositMetadata) *UserDepositSolInstruction {
 	inst.Metadata = &metadata
 	return inst
 }
 
 // SetUserAccount sets the "user" account.
-func (inst *UserDepositSol) SetUserAccount(user ag_solanago.PublicKey) *UserDepositSol {
+func (inst *UserDepositSolInstruction) SetUserAccount(user ag_solanago.PublicKey) *UserDepositSolInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(user).WRITE().SIGNER()
 	return inst
 }
 
 // GetUserAccount gets the "user" account.
-func (inst *UserDepositSol) GetUserAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSolInstruction) GetUserAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *UserDepositSol) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserDepositSol {
+func (inst *UserDepositSolInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserDepositSolInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *UserDepositSol) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSolInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenProgramAccount sets the "receipt_token_program" account.
-func (inst *UserDepositSol) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserDepositSol {
+func (inst *UserDepositSolInstruction) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserDepositSolInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenProgram)
 	return inst
 }
 
 // GetReceiptTokenProgramAccount gets the "receipt_token_program" account.
-func (inst *UserDepositSol) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSolInstruction) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *UserDepositSol) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserDepositSol {
+func (inst *UserDepositSolInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserDepositSolInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenMint).WRITE()
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *UserDepositSol) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSolInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetReceiptTokenLockAccountAccount sets the "receipt_token_lock_account" account.
-func (inst *UserDepositSol) SetReceiptTokenLockAccountAccount(receiptTokenLockAccount ag_solanago.PublicKey) *UserDepositSol {
+func (inst *UserDepositSolInstruction) SetReceiptTokenLockAccountAccount(receiptTokenLockAccount ag_solanago.PublicKey) *UserDepositSolInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(receiptTokenLockAccount).WRITE()
 	return inst
 }
 
-func (inst *UserDepositSol) findFindReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSolInstruction) findFindReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: fundAccount
 	seeds = append(seeds, fundAccount.Bytes())
@@ -139,12 +139,12 @@ func (inst *UserDepositSol) findFindReceiptTokenLockAccountAddress(fundAccount a
 }
 
 // FindReceiptTokenLockAccountAddressWithBumpSeed calculates ReceiptTokenLockAccount account address with given seeds and a known bump seed.
-func (inst *UserDepositSol) FindReceiptTokenLockAccountAddressWithBumpSeed(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserDepositSolInstruction) FindReceiptTokenLockAccountAddressWithBumpSeed(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindReceiptTokenLockAccountAddress(fundAccount, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserDepositSol) MustFindReceiptTokenLockAccountAddressWithBumpSeed(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSolInstruction) MustFindReceiptTokenLockAccountAddressWithBumpSeed(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindReceiptTokenLockAccountAddress(fundAccount, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -153,12 +153,12 @@ func (inst *UserDepositSol) MustFindReceiptTokenLockAccountAddressWithBumpSeed(f
 }
 
 // FindReceiptTokenLockAccountAddress finds ReceiptTokenLockAccount account address with given seeds.
-func (inst *UserDepositSol) FindReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSolInstruction) FindReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindReceiptTokenLockAccountAddress(fundAccount, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserDepositSol) MustFindReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSolInstruction) MustFindReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindReceiptTokenLockAccountAddress(fundAccount, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -167,17 +167,17 @@ func (inst *UserDepositSol) MustFindReceiptTokenLockAccountAddress(fundAccount a
 }
 
 // GetReceiptTokenLockAccountAccount gets the "receipt_token_lock_account" account.
-func (inst *UserDepositSol) GetReceiptTokenLockAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSolInstruction) GetReceiptTokenLockAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetUserReceiptTokenAccountAccount sets the "user_receipt_token_account" account.
-func (inst *UserDepositSol) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserDepositSol {
+func (inst *UserDepositSolInstruction) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserDepositSolInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(userReceiptTokenAccount).WRITE()
 	return inst
 }
 
-func (inst *UserDepositSol) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSolInstruction) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: user
 	seeds = append(seeds, user.Bytes())
@@ -198,12 +198,12 @@ func (inst *UserDepositSol) findFindUserReceiptTokenAccountAddress(user ag_solan
 }
 
 // FindUserReceiptTokenAccountAddressWithBumpSeed calculates UserReceiptTokenAccount account address with given seeds and a known bump seed.
-func (inst *UserDepositSol) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserDepositSolInstruction) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserDepositSol) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSolInstruction) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -212,12 +212,12 @@ func (inst *UserDepositSol) MustFindUserReceiptTokenAccountAddressWithBumpSeed(u
 }
 
 // FindUserReceiptTokenAccountAddress finds UserReceiptTokenAccount account address with given seeds.
-func (inst *UserDepositSol) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSolInstruction) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserDepositSol) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSolInstruction) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -226,17 +226,17 @@ func (inst *UserDepositSol) MustFindUserReceiptTokenAccountAddress(user ag_solan
 }
 
 // GetUserReceiptTokenAccountAccount gets the "user_receipt_token_account" account.
-func (inst *UserDepositSol) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSolInstruction) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *UserDepositSol) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *UserDepositSol {
+func (inst *UserDepositSolInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *UserDepositSolInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserDepositSol) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSolInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -253,12 +253,12 @@ func (inst *UserDepositSol) findFindFundAccountAddress(receiptTokenMint ag_solan
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *UserDepositSol) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserDepositSolInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserDepositSol) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSolInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -267,12 +267,12 @@ func (inst *UserDepositSol) MustFindFundAccountAddressWithBumpSeed(receiptTokenM
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *UserDepositSol) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSolInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserDepositSol) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSolInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -281,17 +281,17 @@ func (inst *UserDepositSol) MustFindFundAccountAddress(receiptTokenMint ag_solan
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *UserDepositSol) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSolInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetFundReserveAccountAccount sets the "fund_reserve_account" account.
-func (inst *UserDepositSol) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *UserDepositSol {
+func (inst *UserDepositSolInstruction) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *UserDepositSolInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(fundReserveAccount).WRITE()
 	return inst
 }
 
-func (inst *UserDepositSol) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSolInstruction) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_reserve
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x72), byte(0x65), byte(0x73), byte(0x65), byte(0x72), byte(0x76), byte(0x65)})
@@ -308,12 +308,12 @@ func (inst *UserDepositSol) findFindFundReserveAccountAddress(receiptTokenMint a
 }
 
 // FindFundReserveAccountAddressWithBumpSeed calculates FundReserveAccount account address with given seeds and a known bump seed.
-func (inst *UserDepositSol) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserDepositSolInstruction) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserDepositSol) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSolInstruction) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -322,12 +322,12 @@ func (inst *UserDepositSol) MustFindFundReserveAccountAddressWithBumpSeed(receip
 }
 
 // FindFundReserveAccountAddress finds FundReserveAccount account address with given seeds.
-func (inst *UserDepositSol) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSolInstruction) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserDepositSol) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSolInstruction) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -336,17 +336,17 @@ func (inst *UserDepositSol) MustFindFundReserveAccountAddress(receiptTokenMint a
 }
 
 // GetFundReserveAccountAccount gets the "fund_reserve_account" account.
-func (inst *UserDepositSol) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSolInstruction) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetUserFundAccountAccount sets the "user_fund_account" account.
-func (inst *UserDepositSol) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserDepositSol {
+func (inst *UserDepositSolInstruction) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserDepositSolInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(userFundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserDepositSol) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSolInstruction) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_fund
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -365,12 +365,12 @@ func (inst *UserDepositSol) findFindUserFundAccountAddress(receiptTokenMint ag_s
 }
 
 // FindUserFundAccountAddressWithBumpSeed calculates UserFundAccount account address with given seeds and a known bump seed.
-func (inst *UserDepositSol) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserDepositSolInstruction) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserDepositSol) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSolInstruction) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -379,12 +379,12 @@ func (inst *UserDepositSol) MustFindUserFundAccountAddressWithBumpSeed(receiptTo
 }
 
 // FindUserFundAccountAddress finds UserFundAccount account address with given seeds.
-func (inst *UserDepositSol) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSolInstruction) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserDepositSol) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSolInstruction) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -393,17 +393,17 @@ func (inst *UserDepositSol) MustFindUserFundAccountAddress(receiptTokenMint ag_s
 }
 
 // GetUserFundAccountAccount gets the "user_fund_account" account.
-func (inst *UserDepositSol) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSolInstruction) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *UserDepositSol) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserDepositSol {
+func (inst *UserDepositSolInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserDepositSolInstruction {
 	inst.AccountMetaSlice[9] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserDepositSol) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSolInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -420,12 +420,12 @@ func (inst *UserDepositSol) findFindRewardAccountAddress(receiptTokenMint ag_sol
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *UserDepositSol) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserDepositSolInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserDepositSol) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSolInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -434,12 +434,12 @@ func (inst *UserDepositSol) MustFindRewardAccountAddressWithBumpSeed(receiptToke
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *UserDepositSol) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSolInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserDepositSol) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSolInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -448,17 +448,17 @@ func (inst *UserDepositSol) MustFindRewardAccountAddress(receiptTokenMint ag_sol
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *UserDepositSol) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSolInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(9)
 }
 
 // SetUserRewardAccountAccount sets the "user_reward_account" account.
-func (inst *UserDepositSol) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserDepositSol {
+func (inst *UserDepositSolInstruction) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserDepositSolInstruction {
 	inst.AccountMetaSlice[10] = ag_solanago.Meta(userRewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserDepositSol) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSolInstruction) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -477,12 +477,12 @@ func (inst *UserDepositSol) findFindUserRewardAccountAddress(receiptTokenMint ag
 }
 
 // FindUserRewardAccountAddressWithBumpSeed calculates UserRewardAccount account address with given seeds and a known bump seed.
-func (inst *UserDepositSol) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserDepositSolInstruction) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserDepositSol) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSolInstruction) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -491,12 +491,12 @@ func (inst *UserDepositSol) MustFindUserRewardAccountAddressWithBumpSeed(receipt
 }
 
 // FindUserRewardAccountAddress finds UserRewardAccount account address with given seeds.
-func (inst *UserDepositSol) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSolInstruction) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserDepositSol) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSolInstruction) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -505,28 +505,28 @@ func (inst *UserDepositSol) MustFindUserRewardAccountAddress(receiptTokenMint ag
 }
 
 // GetUserRewardAccountAccount gets the "user_reward_account" account.
-func (inst *UserDepositSol) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSolInstruction) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(10)
 }
 
 // SetInstructionsSysvarAccount sets the "instructions_sysvar" account.
-func (inst *UserDepositSol) SetInstructionsSysvarAccount(instructionsSysvar ag_solanago.PublicKey) *UserDepositSol {
+func (inst *UserDepositSolInstruction) SetInstructionsSysvarAccount(instructionsSysvar ag_solanago.PublicKey) *UserDepositSolInstruction {
 	inst.AccountMetaSlice[11] = ag_solanago.Meta(instructionsSysvar)
 	return inst
 }
 
 // GetInstructionsSysvarAccount gets the "instructions_sysvar" account.
-func (inst *UserDepositSol) GetInstructionsSysvarAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSolInstruction) GetInstructionsSysvarAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(11)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *UserDepositSol) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserDepositSol {
+func (inst *UserDepositSolInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserDepositSolInstruction {
 	inst.AccountMetaSlice[12] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *UserDepositSol) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSolInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -541,12 +541,12 @@ func (inst *UserDepositSol) findFindEventAuthorityAddress(knownBumpSeed uint8) (
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *UserDepositSol) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserDepositSolInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *UserDepositSol) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSolInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -555,12 +555,12 @@ func (inst *UserDepositSol) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed u
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *UserDepositSol) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSolInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *UserDepositSol) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSolInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -569,22 +569,22 @@ func (inst *UserDepositSol) MustFindEventAuthorityAddress() (pda ag_solanago.Pub
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *UserDepositSol) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSolInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(12)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *UserDepositSol) SetProgramAccount(program ag_solanago.PublicKey) *UserDepositSol {
+func (inst *UserDepositSolInstruction) SetProgramAccount(program ag_solanago.PublicKey) *UserDepositSolInstruction {
 	inst.AccountMetaSlice[13] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *UserDepositSol) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSolInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(13)
 }
 
-func (inst UserDepositSol) Build() *Instruction {
+func (inst UserDepositSolInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_UserDepositSol,
@@ -594,14 +594,14 @@ func (inst UserDepositSol) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst UserDepositSol) ValidateAndBuild() (*Instruction, error) {
+func (inst UserDepositSolInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *UserDepositSol) Validate() error {
+func (inst *UserDepositSolInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.Amount == nil {
@@ -657,7 +657,7 @@ func (inst *UserDepositSol) Validate() error {
 	return nil
 }
 
-func (inst *UserDepositSol) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *UserDepositSolInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -692,7 +692,7 @@ func (inst *UserDepositSol) EncodeToTree(parent ag_treeout.Branches) {
 		})
 }
 
-func (obj UserDepositSol) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj UserDepositSolInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `Amount` param:
 	err = encoder.Encode(obj.Amount)
 	if err != nil {
@@ -718,7 +718,7 @@ func (obj UserDepositSol) MarshalWithEncoder(encoder *ag_binary.Encoder) (err er
 	}
 	return nil
 }
-func (obj *UserDepositSol) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *UserDepositSolInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `Amount`:
 	err = decoder.Decode(&obj.Amount)
 	if err != nil {
@@ -759,7 +759,7 @@ func NewUserDepositSolInstruction(
 	userRewardAccount ag_solanago.PublicKey,
 	instructionsSysvar ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *UserDepositSol {
+	program ag_solanago.PublicKey) *UserDepositSolInstruction {
 	return NewUserDepositSolInstructionBuilder().
 		SetAmount(amount).
 		SetMetadata(metadata).

--- a/generated/restaking/userdepositsol_test.go
+++ b/generated/restaking/userdepositsol_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_UserDepositSol(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("UserDepositSol"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(UserDepositSol)
+				params := new(UserDepositSolInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(UserDepositSol)
+				got := new(UserDepositSolInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/userdepositsupportedtoken.go
+++ b/generated/restaking/userdepositsupportedtoken.go
@@ -11,7 +11,7 @@ import (
 )
 
 // UserDepositSupportedToken is the `user_deposit_supported_token` instruction.
-type UserDepositSupportedToken struct {
+type UserDepositSupportedTokenInstruction struct {
 	Amount   *uint64
 	Metadata *DepositMetadata `bin:"optional"`
 
@@ -49,9 +49,9 @@ type UserDepositSupportedToken struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewUserDepositSupportedTokenInstructionBuilder creates a new `UserDepositSupportedToken` instruction builder.
-func NewUserDepositSupportedTokenInstructionBuilder() *UserDepositSupportedToken {
-	nd := &UserDepositSupportedToken{
+// NewUserDepositSupportedTokenInstructionBuilder creates a new `UserDepositSupportedTokenInstruction` instruction builder.
+func NewUserDepositSupportedTokenInstructionBuilder() *UserDepositSupportedTokenInstruction {
+	nd := &UserDepositSupportedTokenInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 16),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"])
@@ -60,68 +60,68 @@ func NewUserDepositSupportedTokenInstructionBuilder() *UserDepositSupportedToken
 }
 
 // SetAmount sets the "amount" parameter.
-func (inst *UserDepositSupportedToken) SetAmount(amount uint64) *UserDepositSupportedToken {
+func (inst *UserDepositSupportedTokenInstruction) SetAmount(amount uint64) *UserDepositSupportedTokenInstruction {
 	inst.Amount = &amount
 	return inst
 }
 
 // SetMetadata sets the "metadata" parameter.
-func (inst *UserDepositSupportedToken) SetMetadata(metadata DepositMetadata) *UserDepositSupportedToken {
+func (inst *UserDepositSupportedTokenInstruction) SetMetadata(metadata DepositMetadata) *UserDepositSupportedTokenInstruction {
 	inst.Metadata = &metadata
 	return inst
 }
 
 // SetUserAccount sets the "user" account.
-func (inst *UserDepositSupportedToken) SetUserAccount(user ag_solanago.PublicKey) *UserDepositSupportedToken {
+func (inst *UserDepositSupportedTokenInstruction) SetUserAccount(user ag_solanago.PublicKey) *UserDepositSupportedTokenInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(user).WRITE().SIGNER()
 	return inst
 }
 
 // GetUserAccount gets the "user" account.
-func (inst *UserDepositSupportedToken) GetUserAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSupportedTokenInstruction) GetUserAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetReceiptTokenProgramAccount sets the "receipt_token_program" account.
-func (inst *UserDepositSupportedToken) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserDepositSupportedToken {
+func (inst *UserDepositSupportedTokenInstruction) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserDepositSupportedTokenInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(receiptTokenProgram)
 	return inst
 }
 
 // GetReceiptTokenProgramAccount gets the "receipt_token_program" account.
-func (inst *UserDepositSupportedToken) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSupportedTokenInstruction) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetSupportedTokenProgramAccount sets the "supported_token_program" account.
-func (inst *UserDepositSupportedToken) SetSupportedTokenProgramAccount(supportedTokenProgram ag_solanago.PublicKey) *UserDepositSupportedToken {
+func (inst *UserDepositSupportedTokenInstruction) SetSupportedTokenProgramAccount(supportedTokenProgram ag_solanago.PublicKey) *UserDepositSupportedTokenInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(supportedTokenProgram)
 	return inst
 }
 
 // GetSupportedTokenProgramAccount gets the "supported_token_program" account.
-func (inst *UserDepositSupportedToken) GetSupportedTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSupportedTokenInstruction) GetSupportedTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *UserDepositSupportedToken) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserDepositSupportedToken {
+func (inst *UserDepositSupportedTokenInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserDepositSupportedTokenInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenMint).WRITE()
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *UserDepositSupportedToken) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSupportedTokenInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetUserReceiptTokenAccountAccount sets the "user_receipt_token_account" account.
-func (inst *UserDepositSupportedToken) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserDepositSupportedToken {
+func (inst *UserDepositSupportedTokenInstruction) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserDepositSupportedTokenInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(userReceiptTokenAccount).WRITE()
 	return inst
 }
 
-func (inst *UserDepositSupportedToken) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSupportedTokenInstruction) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: user
 	seeds = append(seeds, user.Bytes())
@@ -142,12 +142,12 @@ func (inst *UserDepositSupportedToken) findFindUserReceiptTokenAccountAddress(us
 }
 
 // FindUserReceiptTokenAccountAddressWithBumpSeed calculates UserReceiptTokenAccount account address with given seeds and a known bump seed.
-func (inst *UserDepositSupportedToken) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserDepositSupportedTokenInstruction) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserDepositSupportedToken) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSupportedTokenInstruction) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -156,12 +156,12 @@ func (inst *UserDepositSupportedToken) MustFindUserReceiptTokenAccountAddressWit
 }
 
 // FindUserReceiptTokenAccountAddress finds UserReceiptTokenAccount account address with given seeds.
-func (inst *UserDepositSupportedToken) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSupportedTokenInstruction) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserDepositSupportedToken) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSupportedTokenInstruction) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -170,28 +170,28 @@ func (inst *UserDepositSupportedToken) MustFindUserReceiptTokenAccountAddress(us
 }
 
 // GetUserReceiptTokenAccountAccount gets the "user_receipt_token_account" account.
-func (inst *UserDepositSupportedToken) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSupportedTokenInstruction) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetSupportedTokenMintAccount sets the "supported_token_mint" account.
-func (inst *UserDepositSupportedToken) SetSupportedTokenMintAccount(supportedTokenMint ag_solanago.PublicKey) *UserDepositSupportedToken {
+func (inst *UserDepositSupportedTokenInstruction) SetSupportedTokenMintAccount(supportedTokenMint ag_solanago.PublicKey) *UserDepositSupportedTokenInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(supportedTokenMint)
 	return inst
 }
 
 // GetSupportedTokenMintAccount gets the "supported_token_mint" account.
-func (inst *UserDepositSupportedToken) GetSupportedTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSupportedTokenInstruction) GetSupportedTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetFundReserveAccountAccount sets the "fund_reserve_account" account.
-func (inst *UserDepositSupportedToken) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *UserDepositSupportedToken {
+func (inst *UserDepositSupportedTokenInstruction) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *UserDepositSupportedTokenInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(fundReserveAccount)
 	return inst
 }
 
-func (inst *UserDepositSupportedToken) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSupportedTokenInstruction) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_reserve
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x72), byte(0x65), byte(0x73), byte(0x65), byte(0x72), byte(0x76), byte(0x65)})
@@ -208,12 +208,12 @@ func (inst *UserDepositSupportedToken) findFindFundReserveAccountAddress(receipt
 }
 
 // FindFundReserveAccountAddressWithBumpSeed calculates FundReserveAccount account address with given seeds and a known bump seed.
-func (inst *UserDepositSupportedToken) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserDepositSupportedTokenInstruction) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserDepositSupportedToken) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSupportedTokenInstruction) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -222,12 +222,12 @@ func (inst *UserDepositSupportedToken) MustFindFundReserveAccountAddressWithBump
 }
 
 // FindFundReserveAccountAddress finds FundReserveAccount account address with given seeds.
-func (inst *UserDepositSupportedToken) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSupportedTokenInstruction) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserDepositSupportedToken) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSupportedTokenInstruction) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -236,17 +236,17 @@ func (inst *UserDepositSupportedToken) MustFindFundReserveAccountAddress(receipt
 }
 
 // GetFundReserveAccountAccount gets the "fund_reserve_account" account.
-func (inst *UserDepositSupportedToken) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSupportedTokenInstruction) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetFundSupportedTokenReserveAccountAccount sets the "fund_supported_token_reserve_account" account.
-func (inst *UserDepositSupportedToken) SetFundSupportedTokenReserveAccountAccount(fundSupportedTokenReserveAccount ag_solanago.PublicKey) *UserDepositSupportedToken {
+func (inst *UserDepositSupportedTokenInstruction) SetFundSupportedTokenReserveAccountAccount(fundSupportedTokenReserveAccount ag_solanago.PublicKey) *UserDepositSupportedTokenInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(fundSupportedTokenReserveAccount).WRITE()
 	return inst
 }
 
-func (inst *UserDepositSupportedToken) findFindFundSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSupportedTokenInstruction) findFindFundSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: fundReserveAccount
 	seeds = append(seeds, fundReserveAccount.Bytes())
@@ -267,12 +267,12 @@ func (inst *UserDepositSupportedToken) findFindFundSupportedTokenReserveAccountA
 }
 
 // FindFundSupportedTokenReserveAccountAddressWithBumpSeed calculates FundSupportedTokenReserveAccount account address with given seeds and a known bump seed.
-func (inst *UserDepositSupportedToken) FindFundSupportedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserDepositSupportedTokenInstruction) FindFundSupportedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundSupportedTokenReserveAccountAddress(fundReserveAccount, supportedTokenProgram, supportedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserDepositSupportedToken) MustFindFundSupportedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSupportedTokenInstruction) MustFindFundSupportedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundSupportedTokenReserveAccountAddress(fundReserveAccount, supportedTokenProgram, supportedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -281,12 +281,12 @@ func (inst *UserDepositSupportedToken) MustFindFundSupportedTokenReserveAccountA
 }
 
 // FindFundSupportedTokenReserveAccountAddress finds FundSupportedTokenReserveAccount account address with given seeds.
-func (inst *UserDepositSupportedToken) FindFundSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSupportedTokenInstruction) FindFundSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundSupportedTokenReserveAccountAddress(fundReserveAccount, supportedTokenProgram, supportedTokenMint, 0)
 	return
 }
 
-func (inst *UserDepositSupportedToken) MustFindFundSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSupportedTokenInstruction) MustFindFundSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundSupportedTokenReserveAccountAddress(fundReserveAccount, supportedTokenProgram, supportedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -295,28 +295,28 @@ func (inst *UserDepositSupportedToken) MustFindFundSupportedTokenReserveAccountA
 }
 
 // GetFundSupportedTokenReserveAccountAccount gets the "fund_supported_token_reserve_account" account.
-func (inst *UserDepositSupportedToken) GetFundSupportedTokenReserveAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSupportedTokenInstruction) GetFundSupportedTokenReserveAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetUserSupportedTokenAccountAccount sets the "user_supported_token_account" account.
-func (inst *UserDepositSupportedToken) SetUserSupportedTokenAccountAccount(userSupportedTokenAccount ag_solanago.PublicKey) *UserDepositSupportedToken {
+func (inst *UserDepositSupportedTokenInstruction) SetUserSupportedTokenAccountAccount(userSupportedTokenAccount ag_solanago.PublicKey) *UserDepositSupportedTokenInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(userSupportedTokenAccount).WRITE()
 	return inst
 }
 
 // GetUserSupportedTokenAccountAccount gets the "user_supported_token_account" account.
-func (inst *UserDepositSupportedToken) GetUserSupportedTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSupportedTokenInstruction) GetUserSupportedTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *UserDepositSupportedToken) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *UserDepositSupportedToken {
+func (inst *UserDepositSupportedTokenInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *UserDepositSupportedTokenInstruction {
 	inst.AccountMetaSlice[9] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserDepositSupportedToken) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSupportedTokenInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -333,12 +333,12 @@ func (inst *UserDepositSupportedToken) findFindFundAccountAddress(receiptTokenMi
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *UserDepositSupportedToken) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserDepositSupportedTokenInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserDepositSupportedToken) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSupportedTokenInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -347,12 +347,12 @@ func (inst *UserDepositSupportedToken) MustFindFundAccountAddressWithBumpSeed(re
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *UserDepositSupportedToken) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSupportedTokenInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserDepositSupportedToken) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSupportedTokenInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -361,17 +361,17 @@ func (inst *UserDepositSupportedToken) MustFindFundAccountAddress(receiptTokenMi
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *UserDepositSupportedToken) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSupportedTokenInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(9)
 }
 
 // SetUserFundAccountAccount sets the "user_fund_account" account.
-func (inst *UserDepositSupportedToken) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserDepositSupportedToken {
+func (inst *UserDepositSupportedTokenInstruction) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserDepositSupportedTokenInstruction {
 	inst.AccountMetaSlice[10] = ag_solanago.Meta(userFundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserDepositSupportedToken) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSupportedTokenInstruction) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_fund
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -390,12 +390,12 @@ func (inst *UserDepositSupportedToken) findFindUserFundAccountAddress(receiptTok
 }
 
 // FindUserFundAccountAddressWithBumpSeed calculates UserFundAccount account address with given seeds and a known bump seed.
-func (inst *UserDepositSupportedToken) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserDepositSupportedTokenInstruction) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserDepositSupportedToken) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSupportedTokenInstruction) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -404,12 +404,12 @@ func (inst *UserDepositSupportedToken) MustFindUserFundAccountAddressWithBumpSee
 }
 
 // FindUserFundAccountAddress finds UserFundAccount account address with given seeds.
-func (inst *UserDepositSupportedToken) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSupportedTokenInstruction) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserDepositSupportedToken) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSupportedTokenInstruction) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -418,17 +418,17 @@ func (inst *UserDepositSupportedToken) MustFindUserFundAccountAddress(receiptTok
 }
 
 // GetUserFundAccountAccount gets the "user_fund_account" account.
-func (inst *UserDepositSupportedToken) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSupportedTokenInstruction) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(10)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *UserDepositSupportedToken) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserDepositSupportedToken {
+func (inst *UserDepositSupportedTokenInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserDepositSupportedTokenInstruction {
 	inst.AccountMetaSlice[11] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserDepositSupportedToken) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSupportedTokenInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -445,12 +445,12 @@ func (inst *UserDepositSupportedToken) findFindRewardAccountAddress(receiptToken
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *UserDepositSupportedToken) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserDepositSupportedTokenInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserDepositSupportedToken) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSupportedTokenInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -459,12 +459,12 @@ func (inst *UserDepositSupportedToken) MustFindRewardAccountAddressWithBumpSeed(
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *UserDepositSupportedToken) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSupportedTokenInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserDepositSupportedToken) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSupportedTokenInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -473,17 +473,17 @@ func (inst *UserDepositSupportedToken) MustFindRewardAccountAddress(receiptToken
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *UserDepositSupportedToken) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSupportedTokenInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(11)
 }
 
 // SetUserRewardAccountAccount sets the "user_reward_account" account.
-func (inst *UserDepositSupportedToken) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserDepositSupportedToken {
+func (inst *UserDepositSupportedTokenInstruction) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserDepositSupportedTokenInstruction {
 	inst.AccountMetaSlice[12] = ag_solanago.Meta(userRewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserDepositSupportedToken) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSupportedTokenInstruction) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -502,12 +502,12 @@ func (inst *UserDepositSupportedToken) findFindUserRewardAccountAddress(receiptT
 }
 
 // FindUserRewardAccountAddressWithBumpSeed calculates UserRewardAccount account address with given seeds and a known bump seed.
-func (inst *UserDepositSupportedToken) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserDepositSupportedTokenInstruction) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserDepositSupportedToken) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSupportedTokenInstruction) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -516,12 +516,12 @@ func (inst *UserDepositSupportedToken) MustFindUserRewardAccountAddressWithBumpS
 }
 
 // FindUserRewardAccountAddress finds UserRewardAccount account address with given seeds.
-func (inst *UserDepositSupportedToken) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSupportedTokenInstruction) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserDepositSupportedToken) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSupportedTokenInstruction) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -530,28 +530,28 @@ func (inst *UserDepositSupportedToken) MustFindUserRewardAccountAddress(receiptT
 }
 
 // GetUserRewardAccountAccount gets the "user_reward_account" account.
-func (inst *UserDepositSupportedToken) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSupportedTokenInstruction) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(12)
 }
 
 // SetInstructionsSysvarAccount sets the "instructions_sysvar" account.
-func (inst *UserDepositSupportedToken) SetInstructionsSysvarAccount(instructionsSysvar ag_solanago.PublicKey) *UserDepositSupportedToken {
+func (inst *UserDepositSupportedTokenInstruction) SetInstructionsSysvarAccount(instructionsSysvar ag_solanago.PublicKey) *UserDepositSupportedTokenInstruction {
 	inst.AccountMetaSlice[13] = ag_solanago.Meta(instructionsSysvar)
 	return inst
 }
 
 // GetInstructionsSysvarAccount gets the "instructions_sysvar" account.
-func (inst *UserDepositSupportedToken) GetInstructionsSysvarAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSupportedTokenInstruction) GetInstructionsSysvarAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(13)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *UserDepositSupportedToken) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserDepositSupportedToken {
+func (inst *UserDepositSupportedTokenInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserDepositSupportedTokenInstruction {
 	inst.AccountMetaSlice[14] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *UserDepositSupportedToken) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSupportedTokenInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -566,12 +566,12 @@ func (inst *UserDepositSupportedToken) findFindEventAuthorityAddress(knownBumpSe
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *UserDepositSupportedToken) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserDepositSupportedTokenInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *UserDepositSupportedToken) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSupportedTokenInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -580,12 +580,12 @@ func (inst *UserDepositSupportedToken) MustFindEventAuthorityAddressWithBumpSeed
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *UserDepositSupportedToken) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserDepositSupportedTokenInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *UserDepositSupportedToken) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *UserDepositSupportedTokenInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -594,22 +594,22 @@ func (inst *UserDepositSupportedToken) MustFindEventAuthorityAddress() (pda ag_s
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *UserDepositSupportedToken) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSupportedTokenInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(14)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *UserDepositSupportedToken) SetProgramAccount(program ag_solanago.PublicKey) *UserDepositSupportedToken {
+func (inst *UserDepositSupportedTokenInstruction) SetProgramAccount(program ag_solanago.PublicKey) *UserDepositSupportedTokenInstruction {
 	inst.AccountMetaSlice[15] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *UserDepositSupportedToken) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserDepositSupportedTokenInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(15)
 }
 
-func (inst UserDepositSupportedToken) Build() *Instruction {
+func (inst UserDepositSupportedTokenInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_UserDepositSupportedToken,
@@ -619,14 +619,14 @@ func (inst UserDepositSupportedToken) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst UserDepositSupportedToken) ValidateAndBuild() (*Instruction, error) {
+func (inst UserDepositSupportedTokenInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *UserDepositSupportedToken) Validate() error {
+func (inst *UserDepositSupportedTokenInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.Amount == nil {
@@ -688,7 +688,7 @@ func (inst *UserDepositSupportedToken) Validate() error {
 	return nil
 }
 
-func (inst *UserDepositSupportedToken) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *UserDepositSupportedTokenInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -725,7 +725,7 @@ func (inst *UserDepositSupportedToken) EncodeToTree(parent ag_treeout.Branches) 
 		})
 }
 
-func (obj UserDepositSupportedToken) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj UserDepositSupportedTokenInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `Amount` param:
 	err = encoder.Encode(obj.Amount)
 	if err != nil {
@@ -751,7 +751,7 @@ func (obj UserDepositSupportedToken) MarshalWithEncoder(encoder *ag_binary.Encod
 	}
 	return nil
 }
-func (obj *UserDepositSupportedToken) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *UserDepositSupportedTokenInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `Amount`:
 	err = decoder.Decode(&obj.Amount)
 	if err != nil {
@@ -794,7 +794,7 @@ func NewUserDepositSupportedTokenInstruction(
 	userRewardAccount ag_solanago.PublicKey,
 	instructionsSysvar ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *UserDepositSupportedToken {
+	program ag_solanago.PublicKey) *UserDepositSupportedTokenInstruction {
 	return NewUserDepositSupportedTokenInstructionBuilder().
 		SetAmount(amount).
 		SetMetadata(metadata).

--- a/generated/restaking/userdepositsupportedtoken_test.go
+++ b/generated/restaking/userdepositsupportedtoken_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_UserDepositSupportedToken(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("UserDepositSupportedToken"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(UserDepositSupportedToken)
+				params := new(UserDepositSupportedTokenInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(UserDepositSupportedToken)
+				got := new(UserDepositSupportedTokenInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/userinitializefundaccount.go
+++ b/generated/restaking/userinitializefundaccount.go
@@ -11,7 +11,7 @@ import (
 )
 
 // UserInitializeFundAccount is the `user_initialize_fund_account` instruction.
-type UserInitializeFundAccount struct {
+type UserInitializeFundAccountInstruction struct {
 
 	// [0] = [WRITE, SIGNER] user
 	//
@@ -31,9 +31,9 @@ type UserInitializeFundAccount struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewUserInitializeFundAccountInstructionBuilder creates a new `UserInitializeFundAccount` instruction builder.
-func NewUserInitializeFundAccountInstructionBuilder() *UserInitializeFundAccount {
-	nd := &UserInitializeFundAccount{
+// NewUserInitializeFundAccountInstructionBuilder creates a new `UserInitializeFundAccountInstruction` instruction builder.
+func NewUserInitializeFundAccountInstructionBuilder() *UserInitializeFundAccountInstruction {
+	nd := &UserInitializeFundAccountInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 8),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["11111111111111111111111111111111"])
@@ -42,56 +42,56 @@ func NewUserInitializeFundAccountInstructionBuilder() *UserInitializeFundAccount
 }
 
 // SetUserAccount sets the "user" account.
-func (inst *UserInitializeFundAccount) SetUserAccount(user ag_solanago.PublicKey) *UserInitializeFundAccount {
+func (inst *UserInitializeFundAccountInstruction) SetUserAccount(user ag_solanago.PublicKey) *UserInitializeFundAccountInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(user).WRITE().SIGNER()
 	return inst
 }
 
 // GetUserAccount gets the "user" account.
-func (inst *UserInitializeFundAccount) GetUserAccount() *ag_solanago.AccountMeta {
+func (inst *UserInitializeFundAccountInstruction) GetUserAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *UserInitializeFundAccount) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserInitializeFundAccount {
+func (inst *UserInitializeFundAccountInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserInitializeFundAccountInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *UserInitializeFundAccount) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserInitializeFundAccountInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *UserInitializeFundAccount) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserInitializeFundAccount {
+func (inst *UserInitializeFundAccountInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserInitializeFundAccountInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *UserInitializeFundAccount) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserInitializeFundAccountInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetReceiptTokenProgramAccount sets the "receipt_token_program" account.
-func (inst *UserInitializeFundAccount) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserInitializeFundAccount {
+func (inst *UserInitializeFundAccountInstruction) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserInitializeFundAccountInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenProgram)
 	return inst
 }
 
 // GetReceiptTokenProgramAccount gets the "receipt_token_program" account.
-func (inst *UserInitializeFundAccount) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserInitializeFundAccountInstruction) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetUserReceiptTokenAccountAccount sets the "user_receipt_token_account" account.
-func (inst *UserInitializeFundAccount) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserInitializeFundAccount {
+func (inst *UserInitializeFundAccountInstruction) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserInitializeFundAccountInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(userReceiptTokenAccount)
 	return inst
 }
 
-func (inst *UserInitializeFundAccount) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserInitializeFundAccountInstruction) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: user
 	seeds = append(seeds, user.Bytes())
@@ -112,12 +112,12 @@ func (inst *UserInitializeFundAccount) findFindUserReceiptTokenAccountAddress(us
 }
 
 // FindUserReceiptTokenAccountAddressWithBumpSeed calculates UserReceiptTokenAccount account address with given seeds and a known bump seed.
-func (inst *UserInitializeFundAccount) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserInitializeFundAccountInstruction) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserInitializeFundAccount) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserInitializeFundAccountInstruction) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -126,12 +126,12 @@ func (inst *UserInitializeFundAccount) MustFindUserReceiptTokenAccountAddressWit
 }
 
 // FindUserReceiptTokenAccountAddress finds UserReceiptTokenAccount account address with given seeds.
-func (inst *UserInitializeFundAccount) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserInitializeFundAccountInstruction) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserInitializeFundAccount) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserInitializeFundAccountInstruction) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -140,17 +140,17 @@ func (inst *UserInitializeFundAccount) MustFindUserReceiptTokenAccountAddress(us
 }
 
 // GetUserReceiptTokenAccountAccount gets the "user_receipt_token_account" account.
-func (inst *UserInitializeFundAccount) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserInitializeFundAccountInstruction) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetUserFundAccountAccount sets the "user_fund_account" account.
-func (inst *UserInitializeFundAccount) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserInitializeFundAccount {
+func (inst *UserInitializeFundAccountInstruction) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserInitializeFundAccountInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(userFundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserInitializeFundAccount) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserInitializeFundAccountInstruction) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_fund
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -169,12 +169,12 @@ func (inst *UserInitializeFundAccount) findFindUserFundAccountAddress(receiptTok
 }
 
 // FindUserFundAccountAddressWithBumpSeed calculates UserFundAccount account address with given seeds and a known bump seed.
-func (inst *UserInitializeFundAccount) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserInitializeFundAccountInstruction) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserInitializeFundAccount) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserInitializeFundAccountInstruction) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -183,12 +183,12 @@ func (inst *UserInitializeFundAccount) MustFindUserFundAccountAddressWithBumpSee
 }
 
 // FindUserFundAccountAddress finds UserFundAccount account address with given seeds.
-func (inst *UserInitializeFundAccount) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserInitializeFundAccountInstruction) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserInitializeFundAccount) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserInitializeFundAccountInstruction) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -197,17 +197,17 @@ func (inst *UserInitializeFundAccount) MustFindUserFundAccountAddress(receiptTok
 }
 
 // GetUserFundAccountAccount gets the "user_fund_account" account.
-func (inst *UserInitializeFundAccount) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserInitializeFundAccountInstruction) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *UserInitializeFundAccount) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserInitializeFundAccount {
+func (inst *UserInitializeFundAccountInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserInitializeFundAccountInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *UserInitializeFundAccount) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserInitializeFundAccountInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -222,12 +222,12 @@ func (inst *UserInitializeFundAccount) findFindEventAuthorityAddress(knownBumpSe
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *UserInitializeFundAccount) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserInitializeFundAccountInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *UserInitializeFundAccount) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserInitializeFundAccountInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -236,12 +236,12 @@ func (inst *UserInitializeFundAccount) MustFindEventAuthorityAddressWithBumpSeed
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *UserInitializeFundAccount) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserInitializeFundAccountInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *UserInitializeFundAccount) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *UserInitializeFundAccountInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -250,22 +250,22 @@ func (inst *UserInitializeFundAccount) MustFindEventAuthorityAddress() (pda ag_s
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *UserInitializeFundAccount) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *UserInitializeFundAccountInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *UserInitializeFundAccount) SetProgramAccount(program ag_solanago.PublicKey) *UserInitializeFundAccount {
+func (inst *UserInitializeFundAccountInstruction) SetProgramAccount(program ag_solanago.PublicKey) *UserInitializeFundAccountInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *UserInitializeFundAccount) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserInitializeFundAccountInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
-func (inst UserInitializeFundAccount) Build() *Instruction {
+func (inst UserInitializeFundAccountInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_UserInitializeFundAccount,
@@ -275,14 +275,14 @@ func (inst UserInitializeFundAccount) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst UserInitializeFundAccount) ValidateAndBuild() (*Instruction, error) {
+func (inst UserInitializeFundAccountInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *UserInitializeFundAccount) Validate() error {
+func (inst *UserInitializeFundAccountInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -313,7 +313,7 @@ func (inst *UserInitializeFundAccount) Validate() error {
 	return nil
 }
 
-func (inst *UserInitializeFundAccount) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *UserInitializeFundAccountInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -339,10 +339,10 @@ func (inst *UserInitializeFundAccount) EncodeToTree(parent ag_treeout.Branches) 
 		})
 }
 
-func (obj UserInitializeFundAccount) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj UserInitializeFundAccountInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *UserInitializeFundAccount) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *UserInitializeFundAccountInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -356,7 +356,7 @@ func NewUserInitializeFundAccountInstruction(
 	userReceiptTokenAccount ag_solanago.PublicKey,
 	userFundAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *UserInitializeFundAccount {
+	program ag_solanago.PublicKey) *UserInitializeFundAccountInstruction {
 	return NewUserInitializeFundAccountInstructionBuilder().
 		SetUserAccount(user).
 		SetSystemProgramAccount(systemProgram).

--- a/generated/restaking/userinitializefundaccount_test.go
+++ b/generated/restaking/userinitializefundaccount_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_UserInitializeFundAccount(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("UserInitializeFundAccount"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(UserInitializeFundAccount)
+				params := new(UserInitializeFundAccountInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(UserInitializeFundAccount)
+				got := new(UserInitializeFundAccountInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/userinitializerewardaccount.go
+++ b/generated/restaking/userinitializerewardaccount.go
@@ -11,7 +11,7 @@ import (
 )
 
 // UserInitializeRewardAccount is the `user_initialize_reward_account` instruction.
-type UserInitializeRewardAccount struct {
+type UserInitializeRewardAccountInstruction struct {
 
 	// [0] = [WRITE, SIGNER] user
 	//
@@ -33,9 +33,9 @@ type UserInitializeRewardAccount struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewUserInitializeRewardAccountInstructionBuilder creates a new `UserInitializeRewardAccount` instruction builder.
-func NewUserInitializeRewardAccountInstructionBuilder() *UserInitializeRewardAccount {
-	nd := &UserInitializeRewardAccount{
+// NewUserInitializeRewardAccountInstructionBuilder creates a new `UserInitializeRewardAccountInstruction` instruction builder.
+func NewUserInitializeRewardAccountInstructionBuilder() *UserInitializeRewardAccountInstruction {
+	nd := &UserInitializeRewardAccountInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 9),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["11111111111111111111111111111111"])
@@ -44,56 +44,56 @@ func NewUserInitializeRewardAccountInstructionBuilder() *UserInitializeRewardAcc
 }
 
 // SetUserAccount sets the "user" account.
-func (inst *UserInitializeRewardAccount) SetUserAccount(user ag_solanago.PublicKey) *UserInitializeRewardAccount {
+func (inst *UserInitializeRewardAccountInstruction) SetUserAccount(user ag_solanago.PublicKey) *UserInitializeRewardAccountInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(user).WRITE().SIGNER()
 	return inst
 }
 
 // GetUserAccount gets the "user" account.
-func (inst *UserInitializeRewardAccount) GetUserAccount() *ag_solanago.AccountMeta {
+func (inst *UserInitializeRewardAccountInstruction) GetUserAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *UserInitializeRewardAccount) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserInitializeRewardAccount {
+func (inst *UserInitializeRewardAccountInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserInitializeRewardAccountInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *UserInitializeRewardAccount) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserInitializeRewardAccountInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *UserInitializeRewardAccount) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserInitializeRewardAccount {
+func (inst *UserInitializeRewardAccountInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserInitializeRewardAccountInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *UserInitializeRewardAccount) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserInitializeRewardAccountInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetReceiptTokenProgramAccount sets the "receipt_token_program" account.
-func (inst *UserInitializeRewardAccount) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserInitializeRewardAccount {
+func (inst *UserInitializeRewardAccountInstruction) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserInitializeRewardAccountInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenProgram)
 	return inst
 }
 
 // GetReceiptTokenProgramAccount gets the "receipt_token_program" account.
-func (inst *UserInitializeRewardAccount) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserInitializeRewardAccountInstruction) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetUserReceiptTokenAccountAccount sets the "user_receipt_token_account" account.
-func (inst *UserInitializeRewardAccount) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserInitializeRewardAccount {
+func (inst *UserInitializeRewardAccountInstruction) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserInitializeRewardAccountInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(userReceiptTokenAccount)
 	return inst
 }
 
-func (inst *UserInitializeRewardAccount) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserInitializeRewardAccountInstruction) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: user
 	seeds = append(seeds, user.Bytes())
@@ -114,12 +114,12 @@ func (inst *UserInitializeRewardAccount) findFindUserReceiptTokenAccountAddress(
 }
 
 // FindUserReceiptTokenAccountAddressWithBumpSeed calculates UserReceiptTokenAccount account address with given seeds and a known bump seed.
-func (inst *UserInitializeRewardAccount) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserInitializeRewardAccountInstruction) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserInitializeRewardAccount) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserInitializeRewardAccountInstruction) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -128,12 +128,12 @@ func (inst *UserInitializeRewardAccount) MustFindUserReceiptTokenAccountAddressW
 }
 
 // FindUserReceiptTokenAccountAddress finds UserReceiptTokenAccount account address with given seeds.
-func (inst *UserInitializeRewardAccount) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserInitializeRewardAccountInstruction) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserInitializeRewardAccount) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserInitializeRewardAccountInstruction) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -142,17 +142,17 @@ func (inst *UserInitializeRewardAccount) MustFindUserReceiptTokenAccountAddress(
 }
 
 // GetUserReceiptTokenAccountAccount gets the "user_receipt_token_account" account.
-func (inst *UserInitializeRewardAccount) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserInitializeRewardAccountInstruction) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *UserInitializeRewardAccount) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserInitializeRewardAccount {
+func (inst *UserInitializeRewardAccountInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserInitializeRewardAccountInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserInitializeRewardAccount) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserInitializeRewardAccountInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -169,12 +169,12 @@ func (inst *UserInitializeRewardAccount) findFindRewardAccountAddress(receiptTok
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *UserInitializeRewardAccount) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserInitializeRewardAccountInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserInitializeRewardAccount) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserInitializeRewardAccountInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -183,12 +183,12 @@ func (inst *UserInitializeRewardAccount) MustFindRewardAccountAddressWithBumpSee
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *UserInitializeRewardAccount) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserInitializeRewardAccountInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserInitializeRewardAccount) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserInitializeRewardAccountInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -197,17 +197,17 @@ func (inst *UserInitializeRewardAccount) MustFindRewardAccountAddress(receiptTok
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *UserInitializeRewardAccount) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserInitializeRewardAccountInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetUserRewardAccountAccount sets the "user_reward_account" account.
-func (inst *UserInitializeRewardAccount) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserInitializeRewardAccount {
+func (inst *UserInitializeRewardAccountInstruction) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserInitializeRewardAccountInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(userRewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserInitializeRewardAccount) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserInitializeRewardAccountInstruction) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -226,12 +226,12 @@ func (inst *UserInitializeRewardAccount) findFindUserRewardAccountAddress(receip
 }
 
 // FindUserRewardAccountAddressWithBumpSeed calculates UserRewardAccount account address with given seeds and a known bump seed.
-func (inst *UserInitializeRewardAccount) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserInitializeRewardAccountInstruction) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserInitializeRewardAccount) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserInitializeRewardAccountInstruction) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -240,12 +240,12 @@ func (inst *UserInitializeRewardAccount) MustFindUserRewardAccountAddressWithBum
 }
 
 // FindUserRewardAccountAddress finds UserRewardAccount account address with given seeds.
-func (inst *UserInitializeRewardAccount) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserInitializeRewardAccountInstruction) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserInitializeRewardAccount) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserInitializeRewardAccountInstruction) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -254,17 +254,17 @@ func (inst *UserInitializeRewardAccount) MustFindUserRewardAccountAddress(receip
 }
 
 // GetUserRewardAccountAccount gets the "user_reward_account" account.
-func (inst *UserInitializeRewardAccount) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserInitializeRewardAccountInstruction) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *UserInitializeRewardAccount) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserInitializeRewardAccount {
+func (inst *UserInitializeRewardAccountInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserInitializeRewardAccountInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *UserInitializeRewardAccount) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserInitializeRewardAccountInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -279,12 +279,12 @@ func (inst *UserInitializeRewardAccount) findFindEventAuthorityAddress(knownBump
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *UserInitializeRewardAccount) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserInitializeRewardAccountInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *UserInitializeRewardAccount) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserInitializeRewardAccountInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -293,12 +293,12 @@ func (inst *UserInitializeRewardAccount) MustFindEventAuthorityAddressWithBumpSe
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *UserInitializeRewardAccount) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserInitializeRewardAccountInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *UserInitializeRewardAccount) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *UserInitializeRewardAccountInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -307,22 +307,22 @@ func (inst *UserInitializeRewardAccount) MustFindEventAuthorityAddress() (pda ag
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *UserInitializeRewardAccount) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *UserInitializeRewardAccountInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *UserInitializeRewardAccount) SetProgramAccount(program ag_solanago.PublicKey) *UserInitializeRewardAccount {
+func (inst *UserInitializeRewardAccountInstruction) SetProgramAccount(program ag_solanago.PublicKey) *UserInitializeRewardAccountInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *UserInitializeRewardAccount) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserInitializeRewardAccountInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
-func (inst UserInitializeRewardAccount) Build() *Instruction {
+func (inst UserInitializeRewardAccountInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_UserInitializeRewardAccount,
@@ -332,14 +332,14 @@ func (inst UserInitializeRewardAccount) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst UserInitializeRewardAccount) ValidateAndBuild() (*Instruction, error) {
+func (inst UserInitializeRewardAccountInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *UserInitializeRewardAccount) Validate() error {
+func (inst *UserInitializeRewardAccountInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -373,7 +373,7 @@ func (inst *UserInitializeRewardAccount) Validate() error {
 	return nil
 }
 
-func (inst *UserInitializeRewardAccount) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *UserInitializeRewardAccountInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -400,10 +400,10 @@ func (inst *UserInitializeRewardAccount) EncodeToTree(parent ag_treeout.Branches
 		})
 }
 
-func (obj UserInitializeRewardAccount) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj UserInitializeRewardAccountInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *UserInitializeRewardAccount) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *UserInitializeRewardAccountInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -418,7 +418,7 @@ func NewUserInitializeRewardAccountInstruction(
 	rewardAccount ag_solanago.PublicKey,
 	userRewardAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *UserInitializeRewardAccount {
+	program ag_solanago.PublicKey) *UserInitializeRewardAccountInstruction {
 	return NewUserInitializeRewardAccountInstructionBuilder().
 		SetUserAccount(user).
 		SetSystemProgramAccount(systemProgram).

--- a/generated/restaking/userinitializerewardaccount_test.go
+++ b/generated/restaking/userinitializerewardaccount_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_UserInitializeRewardAccount(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("UserInitializeRewardAccount"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(UserInitializeRewardAccount)
+				params := new(UserInitializeRewardAccountInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(UserInitializeRewardAccount)
+				got := new(UserInitializeRewardAccountInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/userrequestwithdrawal.go
+++ b/generated/restaking/userrequestwithdrawal.go
@@ -11,7 +11,7 @@ import (
 )
 
 // UserRequestWithdrawal is the `user_request_withdrawal` instruction.
-type UserRequestWithdrawal struct {
+type UserRequestWithdrawalInstruction struct {
 	ReceiptTokenAmount *uint64
 	SupportedTokenMint *ag_solanago.PublicKey `bin:"optional"`
 
@@ -45,9 +45,9 @@ type UserRequestWithdrawal struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewUserRequestWithdrawalInstructionBuilder creates a new `UserRequestWithdrawal` instruction builder.
-func NewUserRequestWithdrawalInstructionBuilder() *UserRequestWithdrawal {
-	nd := &UserRequestWithdrawal{
+// NewUserRequestWithdrawalInstructionBuilder creates a new `UserRequestWithdrawalInstruction` instruction builder.
+func NewUserRequestWithdrawalInstructionBuilder() *UserRequestWithdrawalInstruction {
+	nd := &UserRequestWithdrawalInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 14),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["11111111111111111111111111111111"])
@@ -57,68 +57,68 @@ func NewUserRequestWithdrawalInstructionBuilder() *UserRequestWithdrawal {
 }
 
 // SetReceiptTokenAmount sets the "receipt_token_amount" parameter.
-func (inst *UserRequestWithdrawal) SetReceiptTokenAmount(receipt_token_amount uint64) *UserRequestWithdrawal {
+func (inst *UserRequestWithdrawalInstruction) SetReceiptTokenAmount(receipt_token_amount uint64) *UserRequestWithdrawalInstruction {
 	inst.ReceiptTokenAmount = &receipt_token_amount
 	return inst
 }
 
 // SetSupportedTokenMint sets the "supported_token_mint" parameter.
-func (inst *UserRequestWithdrawal) SetSupportedTokenMint(supported_token_mint ag_solanago.PublicKey) *UserRequestWithdrawal {
+func (inst *UserRequestWithdrawalInstruction) SetSupportedTokenMint(supported_token_mint ag_solanago.PublicKey) *UserRequestWithdrawalInstruction {
 	inst.SupportedTokenMint = &supported_token_mint
 	return inst
 }
 
 // SetUserAccount sets the "user" account.
-func (inst *UserRequestWithdrawal) SetUserAccount(user ag_solanago.PublicKey) *UserRequestWithdrawal {
+func (inst *UserRequestWithdrawalInstruction) SetUserAccount(user ag_solanago.PublicKey) *UserRequestWithdrawalInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(user).WRITE().SIGNER()
 	return inst
 }
 
 // GetUserAccount gets the "user" account.
-func (inst *UserRequestWithdrawal) GetUserAccount() *ag_solanago.AccountMeta {
+func (inst *UserRequestWithdrawalInstruction) GetUserAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *UserRequestWithdrawal) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserRequestWithdrawal {
+func (inst *UserRequestWithdrawalInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserRequestWithdrawalInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *UserRequestWithdrawal) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserRequestWithdrawalInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenProgramAccount sets the "receipt_token_program" account.
-func (inst *UserRequestWithdrawal) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserRequestWithdrawal {
+func (inst *UserRequestWithdrawalInstruction) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserRequestWithdrawalInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenProgram)
 	return inst
 }
 
 // GetReceiptTokenProgramAccount gets the "receipt_token_program" account.
-func (inst *UserRequestWithdrawal) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserRequestWithdrawalInstruction) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *UserRequestWithdrawal) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserRequestWithdrawal {
+func (inst *UserRequestWithdrawalInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserRequestWithdrawalInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenMint).WRITE()
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *UserRequestWithdrawal) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserRequestWithdrawalInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetReceiptTokenLockAccountAccount sets the "receipt_token_lock_account" account.
-func (inst *UserRequestWithdrawal) SetReceiptTokenLockAccountAccount(receiptTokenLockAccount ag_solanago.PublicKey) *UserRequestWithdrawal {
+func (inst *UserRequestWithdrawalInstruction) SetReceiptTokenLockAccountAccount(receiptTokenLockAccount ag_solanago.PublicKey) *UserRequestWithdrawalInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(receiptTokenLockAccount).WRITE()
 	return inst
 }
 
-func (inst *UserRequestWithdrawal) findFindReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserRequestWithdrawalInstruction) findFindReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: fundAccount
 	seeds = append(seeds, fundAccount.Bytes())
@@ -139,12 +139,12 @@ func (inst *UserRequestWithdrawal) findFindReceiptTokenLockAccountAddress(fundAc
 }
 
 // FindReceiptTokenLockAccountAddressWithBumpSeed calculates ReceiptTokenLockAccount account address with given seeds and a known bump seed.
-func (inst *UserRequestWithdrawal) FindReceiptTokenLockAccountAddressWithBumpSeed(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserRequestWithdrawalInstruction) FindReceiptTokenLockAccountAddressWithBumpSeed(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindReceiptTokenLockAccountAddress(fundAccount, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserRequestWithdrawal) MustFindReceiptTokenLockAccountAddressWithBumpSeed(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserRequestWithdrawalInstruction) MustFindReceiptTokenLockAccountAddressWithBumpSeed(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindReceiptTokenLockAccountAddress(fundAccount, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -153,12 +153,12 @@ func (inst *UserRequestWithdrawal) MustFindReceiptTokenLockAccountAddressWithBum
 }
 
 // FindReceiptTokenLockAccountAddress finds ReceiptTokenLockAccount account address with given seeds.
-func (inst *UserRequestWithdrawal) FindReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserRequestWithdrawalInstruction) FindReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindReceiptTokenLockAccountAddress(fundAccount, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserRequestWithdrawal) MustFindReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserRequestWithdrawalInstruction) MustFindReceiptTokenLockAccountAddress(fundAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindReceiptTokenLockAccountAddress(fundAccount, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -167,17 +167,17 @@ func (inst *UserRequestWithdrawal) MustFindReceiptTokenLockAccountAddress(fundAc
 }
 
 // GetReceiptTokenLockAccountAccount gets the "receipt_token_lock_account" account.
-func (inst *UserRequestWithdrawal) GetReceiptTokenLockAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserRequestWithdrawalInstruction) GetReceiptTokenLockAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetUserReceiptTokenAccountAccount sets the "user_receipt_token_account" account.
-func (inst *UserRequestWithdrawal) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserRequestWithdrawal {
+func (inst *UserRequestWithdrawalInstruction) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserRequestWithdrawalInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(userReceiptTokenAccount).WRITE()
 	return inst
 }
 
-func (inst *UserRequestWithdrawal) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserRequestWithdrawalInstruction) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: user
 	seeds = append(seeds, user.Bytes())
@@ -198,12 +198,12 @@ func (inst *UserRequestWithdrawal) findFindUserReceiptTokenAccountAddress(user a
 }
 
 // FindUserReceiptTokenAccountAddressWithBumpSeed calculates UserReceiptTokenAccount account address with given seeds and a known bump seed.
-func (inst *UserRequestWithdrawal) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserRequestWithdrawalInstruction) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserRequestWithdrawal) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserRequestWithdrawalInstruction) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -212,12 +212,12 @@ func (inst *UserRequestWithdrawal) MustFindUserReceiptTokenAccountAddressWithBum
 }
 
 // FindUserReceiptTokenAccountAddress finds UserReceiptTokenAccount account address with given seeds.
-func (inst *UserRequestWithdrawal) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserRequestWithdrawalInstruction) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserRequestWithdrawal) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserRequestWithdrawalInstruction) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -226,17 +226,17 @@ func (inst *UserRequestWithdrawal) MustFindUserReceiptTokenAccountAddress(user a
 }
 
 // GetUserReceiptTokenAccountAccount gets the "user_receipt_token_account" account.
-func (inst *UserRequestWithdrawal) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserRequestWithdrawalInstruction) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *UserRequestWithdrawal) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *UserRequestWithdrawal {
+func (inst *UserRequestWithdrawalInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *UserRequestWithdrawalInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserRequestWithdrawal) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserRequestWithdrawalInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -253,12 +253,12 @@ func (inst *UserRequestWithdrawal) findFindFundAccountAddress(receiptTokenMint a
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *UserRequestWithdrawal) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserRequestWithdrawalInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserRequestWithdrawal) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserRequestWithdrawalInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -267,12 +267,12 @@ func (inst *UserRequestWithdrawal) MustFindFundAccountAddressWithBumpSeed(receip
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *UserRequestWithdrawal) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserRequestWithdrawalInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserRequestWithdrawal) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserRequestWithdrawalInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -281,17 +281,17 @@ func (inst *UserRequestWithdrawal) MustFindFundAccountAddress(receiptTokenMint a
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *UserRequestWithdrawal) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserRequestWithdrawalInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetFundReserveAccountAccount sets the "fund_reserve_account" account.
-func (inst *UserRequestWithdrawal) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *UserRequestWithdrawal {
+func (inst *UserRequestWithdrawalInstruction) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *UserRequestWithdrawalInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(fundReserveAccount).WRITE()
 	return inst
 }
 
-func (inst *UserRequestWithdrawal) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserRequestWithdrawalInstruction) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_reserve
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x72), byte(0x65), byte(0x73), byte(0x65), byte(0x72), byte(0x76), byte(0x65)})
@@ -308,12 +308,12 @@ func (inst *UserRequestWithdrawal) findFindFundReserveAccountAddress(receiptToke
 }
 
 // FindFundReserveAccountAddressWithBumpSeed calculates FundReserveAccount account address with given seeds and a known bump seed.
-func (inst *UserRequestWithdrawal) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserRequestWithdrawalInstruction) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserRequestWithdrawal) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserRequestWithdrawalInstruction) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -322,12 +322,12 @@ func (inst *UserRequestWithdrawal) MustFindFundReserveAccountAddressWithBumpSeed
 }
 
 // FindFundReserveAccountAddress finds FundReserveAccount account address with given seeds.
-func (inst *UserRequestWithdrawal) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserRequestWithdrawalInstruction) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserRequestWithdrawal) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserRequestWithdrawalInstruction) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -336,17 +336,17 @@ func (inst *UserRequestWithdrawal) MustFindFundReserveAccountAddress(receiptToke
 }
 
 // GetFundReserveAccountAccount gets the "fund_reserve_account" account.
-func (inst *UserRequestWithdrawal) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserRequestWithdrawalInstruction) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetUserFundAccountAccount sets the "user_fund_account" account.
-func (inst *UserRequestWithdrawal) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserRequestWithdrawal {
+func (inst *UserRequestWithdrawalInstruction) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserRequestWithdrawalInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(userFundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserRequestWithdrawal) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserRequestWithdrawalInstruction) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_fund
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -365,12 +365,12 @@ func (inst *UserRequestWithdrawal) findFindUserFundAccountAddress(receiptTokenMi
 }
 
 // FindUserFundAccountAddressWithBumpSeed calculates UserFundAccount account address with given seeds and a known bump seed.
-func (inst *UserRequestWithdrawal) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserRequestWithdrawalInstruction) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserRequestWithdrawal) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserRequestWithdrawalInstruction) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -379,12 +379,12 @@ func (inst *UserRequestWithdrawal) MustFindUserFundAccountAddressWithBumpSeed(re
 }
 
 // FindUserFundAccountAddress finds UserFundAccount account address with given seeds.
-func (inst *UserRequestWithdrawal) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserRequestWithdrawalInstruction) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserRequestWithdrawal) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserRequestWithdrawalInstruction) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -393,17 +393,17 @@ func (inst *UserRequestWithdrawal) MustFindUserFundAccountAddress(receiptTokenMi
 }
 
 // GetUserFundAccountAccount gets the "user_fund_account" account.
-func (inst *UserRequestWithdrawal) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserRequestWithdrawalInstruction) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *UserRequestWithdrawal) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserRequestWithdrawal {
+func (inst *UserRequestWithdrawalInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserRequestWithdrawalInstruction {
 	inst.AccountMetaSlice[9] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserRequestWithdrawal) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserRequestWithdrawalInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -420,12 +420,12 @@ func (inst *UserRequestWithdrawal) findFindRewardAccountAddress(receiptTokenMint
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *UserRequestWithdrawal) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserRequestWithdrawalInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserRequestWithdrawal) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserRequestWithdrawalInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -434,12 +434,12 @@ func (inst *UserRequestWithdrawal) MustFindRewardAccountAddressWithBumpSeed(rece
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *UserRequestWithdrawal) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserRequestWithdrawalInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserRequestWithdrawal) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserRequestWithdrawalInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -448,17 +448,17 @@ func (inst *UserRequestWithdrawal) MustFindRewardAccountAddress(receiptTokenMint
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *UserRequestWithdrawal) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserRequestWithdrawalInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(9)
 }
 
 // SetUserRewardAccountAccount sets the "user_reward_account" account.
-func (inst *UserRequestWithdrawal) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserRequestWithdrawal {
+func (inst *UserRequestWithdrawalInstruction) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserRequestWithdrawalInstruction {
 	inst.AccountMetaSlice[10] = ag_solanago.Meta(userRewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserRequestWithdrawal) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserRequestWithdrawalInstruction) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -477,12 +477,12 @@ func (inst *UserRequestWithdrawal) findFindUserRewardAccountAddress(receiptToken
 }
 
 // FindUserRewardAccountAddressWithBumpSeed calculates UserRewardAccount account address with given seeds and a known bump seed.
-func (inst *UserRequestWithdrawal) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserRequestWithdrawalInstruction) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserRequestWithdrawal) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserRequestWithdrawalInstruction) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -491,12 +491,12 @@ func (inst *UserRequestWithdrawal) MustFindUserRewardAccountAddressWithBumpSeed(
 }
 
 // FindUserRewardAccountAddress finds UserRewardAccount account address with given seeds.
-func (inst *UserRequestWithdrawal) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserRequestWithdrawalInstruction) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserRequestWithdrawal) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserRequestWithdrawalInstruction) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -505,28 +505,28 @@ func (inst *UserRequestWithdrawal) MustFindUserRewardAccountAddress(receiptToken
 }
 
 // GetUserRewardAccountAccount gets the "user_reward_account" account.
-func (inst *UserRequestWithdrawal) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserRequestWithdrawalInstruction) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(10)
 }
 
 // SetInstructionsSysvarAccount sets the "instructions_sysvar" account.
-func (inst *UserRequestWithdrawal) SetInstructionsSysvarAccount(instructionsSysvar ag_solanago.PublicKey) *UserRequestWithdrawal {
+func (inst *UserRequestWithdrawalInstruction) SetInstructionsSysvarAccount(instructionsSysvar ag_solanago.PublicKey) *UserRequestWithdrawalInstruction {
 	inst.AccountMetaSlice[11] = ag_solanago.Meta(instructionsSysvar)
 	return inst
 }
 
 // GetInstructionsSysvarAccount gets the "instructions_sysvar" account.
-func (inst *UserRequestWithdrawal) GetInstructionsSysvarAccount() *ag_solanago.AccountMeta {
+func (inst *UserRequestWithdrawalInstruction) GetInstructionsSysvarAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(11)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *UserRequestWithdrawal) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserRequestWithdrawal {
+func (inst *UserRequestWithdrawalInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserRequestWithdrawalInstruction {
 	inst.AccountMetaSlice[12] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *UserRequestWithdrawal) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserRequestWithdrawalInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -541,12 +541,12 @@ func (inst *UserRequestWithdrawal) findFindEventAuthorityAddress(knownBumpSeed u
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *UserRequestWithdrawal) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserRequestWithdrawalInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *UserRequestWithdrawal) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserRequestWithdrawalInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -555,12 +555,12 @@ func (inst *UserRequestWithdrawal) MustFindEventAuthorityAddressWithBumpSeed(bum
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *UserRequestWithdrawal) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserRequestWithdrawalInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *UserRequestWithdrawal) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *UserRequestWithdrawalInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -569,22 +569,22 @@ func (inst *UserRequestWithdrawal) MustFindEventAuthorityAddress() (pda ag_solan
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *UserRequestWithdrawal) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *UserRequestWithdrawalInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(12)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *UserRequestWithdrawal) SetProgramAccount(program ag_solanago.PublicKey) *UserRequestWithdrawal {
+func (inst *UserRequestWithdrawalInstruction) SetProgramAccount(program ag_solanago.PublicKey) *UserRequestWithdrawalInstruction {
 	inst.AccountMetaSlice[13] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *UserRequestWithdrawal) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserRequestWithdrawalInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(13)
 }
 
-func (inst UserRequestWithdrawal) Build() *Instruction {
+func (inst UserRequestWithdrawalInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_UserRequestWithdrawal,
@@ -594,14 +594,14 @@ func (inst UserRequestWithdrawal) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst UserRequestWithdrawal) ValidateAndBuild() (*Instruction, error) {
+func (inst UserRequestWithdrawalInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *UserRequestWithdrawal) Validate() error {
+func (inst *UserRequestWithdrawalInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.ReceiptTokenAmount == nil {
@@ -657,7 +657,7 @@ func (inst *UserRequestWithdrawal) Validate() error {
 	return nil
 }
 
-func (inst *UserRequestWithdrawal) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *UserRequestWithdrawalInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -692,7 +692,7 @@ func (inst *UserRequestWithdrawal) EncodeToTree(parent ag_treeout.Branches) {
 		})
 }
 
-func (obj UserRequestWithdrawal) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj UserRequestWithdrawalInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `ReceiptTokenAmount` param:
 	err = encoder.Encode(obj.ReceiptTokenAmount)
 	if err != nil {
@@ -718,7 +718,7 @@ func (obj UserRequestWithdrawal) MarshalWithEncoder(encoder *ag_binary.Encoder) 
 	}
 	return nil
 }
-func (obj *UserRequestWithdrawal) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *UserRequestWithdrawalInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `ReceiptTokenAmount`:
 	err = decoder.Decode(&obj.ReceiptTokenAmount)
 	if err != nil {
@@ -759,7 +759,7 @@ func NewUserRequestWithdrawalInstruction(
 	userRewardAccount ag_solanago.PublicKey,
 	instructionsSysvar ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *UserRequestWithdrawal {
+	program ag_solanago.PublicKey) *UserRequestWithdrawalInstruction {
 	return NewUserRequestWithdrawalInstructionBuilder().
 		SetReceiptTokenAmount(receipt_token_amount).
 		SetSupportedTokenMint(supported_token_mint).

--- a/generated/restaking/userrequestwithdrawal_test.go
+++ b/generated/restaking/userrequestwithdrawal_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_UserRequestWithdrawal(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("UserRequestWithdrawal"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(UserRequestWithdrawal)
+				params := new(UserRequestWithdrawalInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(UserRequestWithdrawal)
+				got := new(UserRequestWithdrawalInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/userunwrapreceipttoken.go
+++ b/generated/restaking/userunwrapreceipttoken.go
@@ -11,7 +11,7 @@ import (
 )
 
 // UserUnwrapReceiptToken is the `user_unwrap_receipt_token` instruction.
-type UserUnwrapReceiptToken struct {
+type UserUnwrapReceiptTokenInstruction struct {
 	Amount *uint64
 
 	// [0] = [SIGNER] user
@@ -48,9 +48,9 @@ type UserUnwrapReceiptToken struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewUserUnwrapReceiptTokenInstructionBuilder creates a new `UserUnwrapReceiptToken` instruction builder.
-func NewUserUnwrapReceiptTokenInstructionBuilder() *UserUnwrapReceiptToken {
-	nd := &UserUnwrapReceiptToken{
+// NewUserUnwrapReceiptTokenInstructionBuilder creates a new `UserUnwrapReceiptTokenInstruction` instruction builder.
+func NewUserUnwrapReceiptTokenInstructionBuilder() *UserUnwrapReceiptTokenInstruction {
+	nd := &UserUnwrapReceiptTokenInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 16),
 	}
 	nd.AccountMetaSlice[2] = ag_solanago.Meta(Addresses["TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"])
@@ -59,29 +59,29 @@ func NewUserUnwrapReceiptTokenInstructionBuilder() *UserUnwrapReceiptToken {
 }
 
 // SetAmount sets the "amount" parameter.
-func (inst *UserUnwrapReceiptToken) SetAmount(amount uint64) *UserUnwrapReceiptToken {
+func (inst *UserUnwrapReceiptTokenInstruction) SetAmount(amount uint64) *UserUnwrapReceiptTokenInstruction {
 	inst.Amount = &amount
 	return inst
 }
 
 // SetUserAccount sets the "user" account.
-func (inst *UserUnwrapReceiptToken) SetUserAccount(user ag_solanago.PublicKey) *UserUnwrapReceiptToken {
+func (inst *UserUnwrapReceiptTokenInstruction) SetUserAccount(user ag_solanago.PublicKey) *UserUnwrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(user).SIGNER()
 	return inst
 }
 
 // GetUserAccount gets the "user" account.
-func (inst *UserUnwrapReceiptToken) GetUserAccount() *ag_solanago.AccountMeta {
+func (inst *UserUnwrapReceiptTokenInstruction) GetUserAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetFundWrapAccountAccount sets the "fund_wrap_account" account.
-func (inst *UserUnwrapReceiptToken) SetFundWrapAccountAccount(fundWrapAccount ag_solanago.PublicKey) *UserUnwrapReceiptToken {
+func (inst *UserUnwrapReceiptTokenInstruction) SetFundWrapAccountAccount(fundWrapAccount ag_solanago.PublicKey) *UserUnwrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(fundWrapAccount)
 	return inst
 }
 
-func (inst *UserUnwrapReceiptToken) findFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) findFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_wrap
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x77), byte(0x72), byte(0x61), byte(0x70)})
@@ -98,12 +98,12 @@ func (inst *UserUnwrapReceiptToken) findFindFundWrapAccountAddress(receiptTokenM
 }
 
 // FindFundWrapAccountAddressWithBumpSeed calculates FundWrapAccount account address with given seeds and a known bump seed.
-func (inst *UserUnwrapReceiptToken) FindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundWrapAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -112,12 +112,12 @@ func (inst *UserUnwrapReceiptToken) MustFindFundWrapAccountAddressWithBumpSeed(r
 }
 
 // FindFundWrapAccountAddress finds FundWrapAccount account address with given seeds.
-func (inst *UserUnwrapReceiptToken) FindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundWrapAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -126,61 +126,61 @@ func (inst *UserUnwrapReceiptToken) MustFindFundWrapAccountAddress(receiptTokenM
 }
 
 // GetFundWrapAccountAccount gets the "fund_wrap_account" account.
-func (inst *UserUnwrapReceiptToken) GetFundWrapAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserUnwrapReceiptTokenInstruction) GetFundWrapAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenProgramAccount sets the "receipt_token_program" account.
-func (inst *UserUnwrapReceiptToken) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserUnwrapReceiptToken {
+func (inst *UserUnwrapReceiptTokenInstruction) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserUnwrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenProgram)
 	return inst
 }
 
 // GetReceiptTokenProgramAccount gets the "receipt_token_program" account.
-func (inst *UserUnwrapReceiptToken) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserUnwrapReceiptTokenInstruction) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetWrappedTokenProgramAccount sets the "wrapped_token_program" account.
-func (inst *UserUnwrapReceiptToken) SetWrappedTokenProgramAccount(wrappedTokenProgram ag_solanago.PublicKey) *UserUnwrapReceiptToken {
+func (inst *UserUnwrapReceiptTokenInstruction) SetWrappedTokenProgramAccount(wrappedTokenProgram ag_solanago.PublicKey) *UserUnwrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(wrappedTokenProgram)
 	return inst
 }
 
 // GetWrappedTokenProgramAccount gets the "wrapped_token_program" account.
-func (inst *UserUnwrapReceiptToken) GetWrappedTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserUnwrapReceiptTokenInstruction) GetWrappedTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *UserUnwrapReceiptToken) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserUnwrapReceiptToken {
+func (inst *UserUnwrapReceiptTokenInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserUnwrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(receiptTokenMint).WRITE()
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *UserUnwrapReceiptToken) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserUnwrapReceiptTokenInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetWrappedTokenMintAccount sets the "wrapped_token_mint" account.
-func (inst *UserUnwrapReceiptToken) SetWrappedTokenMintAccount(wrappedTokenMint ag_solanago.PublicKey) *UserUnwrapReceiptToken {
+func (inst *UserUnwrapReceiptTokenInstruction) SetWrappedTokenMintAccount(wrappedTokenMint ag_solanago.PublicKey) *UserUnwrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(wrappedTokenMint).WRITE()
 	return inst
 }
 
 // GetWrappedTokenMintAccount gets the "wrapped_token_mint" account.
-func (inst *UserUnwrapReceiptToken) GetWrappedTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserUnwrapReceiptTokenInstruction) GetWrappedTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetUserReceiptTokenAccountAccount sets the "user_receipt_token_account" account.
-func (inst *UserUnwrapReceiptToken) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserUnwrapReceiptToken {
+func (inst *UserUnwrapReceiptTokenInstruction) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserUnwrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(userReceiptTokenAccount).WRITE()
 	return inst
 }
 
-func (inst *UserUnwrapReceiptToken) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: user
 	seeds = append(seeds, user.Bytes())
@@ -201,12 +201,12 @@ func (inst *UserUnwrapReceiptToken) findFindUserReceiptTokenAccountAddress(user 
 }
 
 // FindUserReceiptTokenAccountAddressWithBumpSeed calculates UserReceiptTokenAccount account address with given seeds and a known bump seed.
-func (inst *UserUnwrapReceiptToken) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -215,12 +215,12 @@ func (inst *UserUnwrapReceiptToken) MustFindUserReceiptTokenAccountAddressWithBu
 }
 
 // FindUserReceiptTokenAccountAddress finds UserReceiptTokenAccount account address with given seeds.
-func (inst *UserUnwrapReceiptToken) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -229,17 +229,17 @@ func (inst *UserUnwrapReceiptToken) MustFindUserReceiptTokenAccountAddress(user 
 }
 
 // GetUserReceiptTokenAccountAccount gets the "user_receipt_token_account" account.
-func (inst *UserUnwrapReceiptToken) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserUnwrapReceiptTokenInstruction) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetReceiptTokenWrapAccountAccount sets the "receipt_token_wrap_account" account.
-func (inst *UserUnwrapReceiptToken) SetReceiptTokenWrapAccountAccount(receiptTokenWrapAccount ag_solanago.PublicKey) *UserUnwrapReceiptToken {
+func (inst *UserUnwrapReceiptTokenInstruction) SetReceiptTokenWrapAccountAccount(receiptTokenWrapAccount ag_solanago.PublicKey) *UserUnwrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(receiptTokenWrapAccount).WRITE()
 	return inst
 }
 
-func (inst *UserUnwrapReceiptToken) findFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) findFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: fundWrapAccount
 	seeds = append(seeds, fundWrapAccount.Bytes())
@@ -260,12 +260,12 @@ func (inst *UserUnwrapReceiptToken) findFindReceiptTokenWrapAccountAddress(fundW
 }
 
 // FindReceiptTokenWrapAccountAddressWithBumpSeed calculates ReceiptTokenWrapAccount account address with given seeds and a known bump seed.
-func (inst *UserUnwrapReceiptToken) FindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -274,12 +274,12 @@ func (inst *UserUnwrapReceiptToken) MustFindReceiptTokenWrapAccountAddressWithBu
 }
 
 // FindReceiptTokenWrapAccountAddress finds ReceiptTokenWrapAccount account address with given seeds.
-func (inst *UserUnwrapReceiptToken) FindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -288,17 +288,17 @@ func (inst *UserUnwrapReceiptToken) MustFindReceiptTokenWrapAccountAddress(fundW
 }
 
 // GetReceiptTokenWrapAccountAccount gets the "receipt_token_wrap_account" account.
-func (inst *UserUnwrapReceiptToken) GetReceiptTokenWrapAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserUnwrapReceiptTokenInstruction) GetReceiptTokenWrapAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetUserWrappedTokenAccountAccount sets the "user_wrapped_token_account" account.
-func (inst *UserUnwrapReceiptToken) SetUserWrappedTokenAccountAccount(userWrappedTokenAccount ag_solanago.PublicKey) *UserUnwrapReceiptToken {
+func (inst *UserUnwrapReceiptTokenInstruction) SetUserWrappedTokenAccountAccount(userWrappedTokenAccount ag_solanago.PublicKey) *UserUnwrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(userWrappedTokenAccount).WRITE()
 	return inst
 }
 
-func (inst *UserUnwrapReceiptToken) findFindUserWrappedTokenAccountAddress(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) findFindUserWrappedTokenAccountAddress(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: user
 	seeds = append(seeds, user.Bytes())
@@ -319,12 +319,12 @@ func (inst *UserUnwrapReceiptToken) findFindUserWrappedTokenAccountAddress(user 
 }
 
 // FindUserWrappedTokenAccountAddressWithBumpSeed calculates UserWrappedTokenAccount account address with given seeds and a known bump seed.
-func (inst *UserUnwrapReceiptToken) FindUserWrappedTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindUserWrappedTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserWrappedTokenAccountAddress(user, wrappedTokenProgram, wrappedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindUserWrappedTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindUserWrappedTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserWrappedTokenAccountAddress(user, wrappedTokenProgram, wrappedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -333,12 +333,12 @@ func (inst *UserUnwrapReceiptToken) MustFindUserWrappedTokenAccountAddressWithBu
 }
 
 // FindUserWrappedTokenAccountAddress finds UserWrappedTokenAccount account address with given seeds.
-func (inst *UserUnwrapReceiptToken) FindUserWrappedTokenAccountAddress(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindUserWrappedTokenAccountAddress(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserWrappedTokenAccountAddress(user, wrappedTokenProgram, wrappedTokenMint, 0)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindUserWrappedTokenAccountAddress(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindUserWrappedTokenAccountAddress(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserWrappedTokenAccountAddress(user, wrappedTokenProgram, wrappedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -347,17 +347,17 @@ func (inst *UserUnwrapReceiptToken) MustFindUserWrappedTokenAccountAddress(user 
 }
 
 // GetUserWrappedTokenAccountAccount gets the "user_wrapped_token_account" account.
-func (inst *UserUnwrapReceiptToken) GetUserWrappedTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserUnwrapReceiptTokenInstruction) GetUserWrappedTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *UserUnwrapReceiptToken) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *UserUnwrapReceiptToken {
+func (inst *UserUnwrapReceiptTokenInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *UserUnwrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[9] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserUnwrapReceiptToken) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -374,12 +374,12 @@ func (inst *UserUnwrapReceiptToken) findFindFundAccountAddress(receiptTokenMint 
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *UserUnwrapReceiptToken) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -388,12 +388,12 @@ func (inst *UserUnwrapReceiptToken) MustFindFundAccountAddressWithBumpSeed(recei
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *UserUnwrapReceiptToken) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -402,17 +402,17 @@ func (inst *UserUnwrapReceiptToken) MustFindFundAccountAddress(receiptTokenMint 
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *UserUnwrapReceiptToken) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserUnwrapReceiptTokenInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(9)
 }
 
 // SetUserFundAccountAccount sets the "user_fund_account" account.
-func (inst *UserUnwrapReceiptToken) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserUnwrapReceiptToken {
+func (inst *UserUnwrapReceiptTokenInstruction) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserUnwrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[10] = ag_solanago.Meta(userFundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserUnwrapReceiptToken) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_fund
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -431,12 +431,12 @@ func (inst *UserUnwrapReceiptToken) findFindUserFundAccountAddress(receiptTokenM
 }
 
 // FindUserFundAccountAddressWithBumpSeed calculates UserFundAccount account address with given seeds and a known bump seed.
-func (inst *UserUnwrapReceiptToken) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -445,12 +445,12 @@ func (inst *UserUnwrapReceiptToken) MustFindUserFundAccountAddressWithBumpSeed(r
 }
 
 // FindUserFundAccountAddress finds UserFundAccount account address with given seeds.
-func (inst *UserUnwrapReceiptToken) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -459,17 +459,17 @@ func (inst *UserUnwrapReceiptToken) MustFindUserFundAccountAddress(receiptTokenM
 }
 
 // GetUserFundAccountAccount gets the "user_fund_account" account.
-func (inst *UserUnwrapReceiptToken) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserUnwrapReceiptTokenInstruction) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(10)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *UserUnwrapReceiptToken) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserUnwrapReceiptToken {
+func (inst *UserUnwrapReceiptTokenInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserUnwrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[11] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserUnwrapReceiptToken) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -486,12 +486,12 @@ func (inst *UserUnwrapReceiptToken) findFindRewardAccountAddress(receiptTokenMin
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *UserUnwrapReceiptToken) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -500,12 +500,12 @@ func (inst *UserUnwrapReceiptToken) MustFindRewardAccountAddressWithBumpSeed(rec
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *UserUnwrapReceiptToken) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -514,17 +514,17 @@ func (inst *UserUnwrapReceiptToken) MustFindRewardAccountAddress(receiptTokenMin
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *UserUnwrapReceiptToken) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserUnwrapReceiptTokenInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(11)
 }
 
 // SetUserRewardAccountAccount sets the "user_reward_account" account.
-func (inst *UserUnwrapReceiptToken) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserUnwrapReceiptToken {
+func (inst *UserUnwrapReceiptTokenInstruction) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserUnwrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[12] = ag_solanago.Meta(userRewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserUnwrapReceiptToken) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -543,12 +543,12 @@ func (inst *UserUnwrapReceiptToken) findFindUserRewardAccountAddress(receiptToke
 }
 
 // FindUserRewardAccountAddressWithBumpSeed calculates UserRewardAccount account address with given seeds and a known bump seed.
-func (inst *UserUnwrapReceiptToken) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -557,12 +557,12 @@ func (inst *UserUnwrapReceiptToken) MustFindUserRewardAccountAddressWithBumpSeed
 }
 
 // FindUserRewardAccountAddress finds UserRewardAccount account address with given seeds.
-func (inst *UserUnwrapReceiptToken) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -571,17 +571,17 @@ func (inst *UserUnwrapReceiptToken) MustFindUserRewardAccountAddress(receiptToke
 }
 
 // GetUserRewardAccountAccount gets the "user_reward_account" account.
-func (inst *UserUnwrapReceiptToken) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserUnwrapReceiptTokenInstruction) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(12)
 }
 
 // SetFundWrapAccountRewardAccountAccount sets the "fund_wrap_account_reward_account" account.
-func (inst *UserUnwrapReceiptToken) SetFundWrapAccountRewardAccountAccount(fundWrapAccountRewardAccount ag_solanago.PublicKey) *UserUnwrapReceiptToken {
+func (inst *UserUnwrapReceiptTokenInstruction) SetFundWrapAccountRewardAccountAccount(fundWrapAccountRewardAccount ag_solanago.PublicKey) *UserUnwrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[13] = ag_solanago.Meta(fundWrapAccountRewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserUnwrapReceiptToken) findFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) findFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -600,12 +600,12 @@ func (inst *UserUnwrapReceiptToken) findFindFundWrapAccountRewardAccountAddress(
 }
 
 // FindFundWrapAccountRewardAccountAddressWithBumpSeed calculates FundWrapAccountRewardAccount account address with given seeds and a known bump seed.
-func (inst *UserUnwrapReceiptToken) FindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, bumpSeed)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -614,12 +614,12 @@ func (inst *UserUnwrapReceiptToken) MustFindFundWrapAccountRewardAccountAddressW
 }
 
 // FindFundWrapAccountRewardAccountAddress finds FundWrapAccountRewardAccount account address with given seeds.
-func (inst *UserUnwrapReceiptToken) FindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, 0)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, 0)
 	if err != nil {
 		panic(err)
@@ -628,17 +628,17 @@ func (inst *UserUnwrapReceiptToken) MustFindFundWrapAccountRewardAccountAddress(
 }
 
 // GetFundWrapAccountRewardAccountAccount gets the "fund_wrap_account_reward_account" account.
-func (inst *UserUnwrapReceiptToken) GetFundWrapAccountRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserUnwrapReceiptTokenInstruction) GetFundWrapAccountRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(13)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *UserUnwrapReceiptToken) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserUnwrapReceiptToken {
+func (inst *UserUnwrapReceiptTokenInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserUnwrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[14] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *UserUnwrapReceiptToken) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -653,12 +653,12 @@ func (inst *UserUnwrapReceiptToken) findFindEventAuthorityAddress(knownBumpSeed 
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *UserUnwrapReceiptToken) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -667,12 +667,12 @@ func (inst *UserUnwrapReceiptToken) MustFindEventAuthorityAddressWithBumpSeed(bu
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *UserUnwrapReceiptToken) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUnwrapReceiptTokenInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *UserUnwrapReceiptToken) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *UserUnwrapReceiptTokenInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -681,22 +681,22 @@ func (inst *UserUnwrapReceiptToken) MustFindEventAuthorityAddress() (pda ag_sola
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *UserUnwrapReceiptToken) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *UserUnwrapReceiptTokenInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(14)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *UserUnwrapReceiptToken) SetProgramAccount(program ag_solanago.PublicKey) *UserUnwrapReceiptToken {
+func (inst *UserUnwrapReceiptTokenInstruction) SetProgramAccount(program ag_solanago.PublicKey) *UserUnwrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[15] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *UserUnwrapReceiptToken) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserUnwrapReceiptTokenInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(15)
 }
 
-func (inst UserUnwrapReceiptToken) Build() *Instruction {
+func (inst UserUnwrapReceiptTokenInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_UserUnwrapReceiptToken,
@@ -706,14 +706,14 @@ func (inst UserUnwrapReceiptToken) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst UserUnwrapReceiptToken) ValidateAndBuild() (*Instruction, error) {
+func (inst UserUnwrapReceiptTokenInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *UserUnwrapReceiptToken) Validate() error {
+func (inst *UserUnwrapReceiptTokenInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.Amount == nil {
@@ -775,7 +775,7 @@ func (inst *UserUnwrapReceiptToken) Validate() error {
 	return nil
 }
 
-func (inst *UserUnwrapReceiptToken) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *UserUnwrapReceiptTokenInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -811,7 +811,7 @@ func (inst *UserUnwrapReceiptToken) EncodeToTree(parent ag_treeout.Branches) {
 		})
 }
 
-func (obj UserUnwrapReceiptToken) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj UserUnwrapReceiptTokenInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `Amount` param:
 	err = encoder.Encode(obj.Amount)
 	if err != nil {
@@ -819,7 +819,7 @@ func (obj UserUnwrapReceiptToken) MarshalWithEncoder(encoder *ag_binary.Encoder)
 	}
 	return nil
 }
-func (obj *UserUnwrapReceiptToken) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *UserUnwrapReceiptTokenInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `Amount`:
 	err = decoder.Decode(&obj.Amount)
 	if err != nil {
@@ -848,7 +848,7 @@ func NewUserUnwrapReceiptTokenInstruction(
 	userRewardAccount ag_solanago.PublicKey,
 	fundWrapAccountRewardAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *UserUnwrapReceiptToken {
+	program ag_solanago.PublicKey) *UserUnwrapReceiptTokenInstruction {
 	return NewUserUnwrapReceiptTokenInstructionBuilder().
 		SetAmount(amount).
 		SetUserAccount(user).

--- a/generated/restaking/userunwrapreceipttoken_test.go
+++ b/generated/restaking/userunwrapreceipttoken_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_UserUnwrapReceiptToken(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("UserUnwrapReceiptToken"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(UserUnwrapReceiptToken)
+				params := new(UserUnwrapReceiptTokenInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(UserUnwrapReceiptToken)
+				got := new(UserUnwrapReceiptTokenInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/userupdatefundaccountifneeded.go
+++ b/generated/restaking/userupdatefundaccountifneeded.go
@@ -11,7 +11,7 @@ import (
 )
 
 // UserUpdateFundAccountIfNeeded is the `user_update_fund_account_if_needed` instruction.
-type UserUpdateFundAccountIfNeeded struct {
+type UserUpdateFundAccountIfNeededInstruction struct {
 
 	// [0] = [WRITE, SIGNER] user
 	//
@@ -31,9 +31,9 @@ type UserUpdateFundAccountIfNeeded struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewUserUpdateFundAccountIfNeededInstructionBuilder creates a new `UserUpdateFundAccountIfNeeded` instruction builder.
-func NewUserUpdateFundAccountIfNeededInstructionBuilder() *UserUpdateFundAccountIfNeeded {
-	nd := &UserUpdateFundAccountIfNeeded{
+// NewUserUpdateFundAccountIfNeededInstructionBuilder creates a new `UserUpdateFundAccountIfNeededInstruction` instruction builder.
+func NewUserUpdateFundAccountIfNeededInstructionBuilder() *UserUpdateFundAccountIfNeededInstruction {
+	nd := &UserUpdateFundAccountIfNeededInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 8),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["11111111111111111111111111111111"])
@@ -42,56 +42,56 @@ func NewUserUpdateFundAccountIfNeededInstructionBuilder() *UserUpdateFundAccount
 }
 
 // SetUserAccount sets the "user" account.
-func (inst *UserUpdateFundAccountIfNeeded) SetUserAccount(user ag_solanago.PublicKey) *UserUpdateFundAccountIfNeeded {
+func (inst *UserUpdateFundAccountIfNeededInstruction) SetUserAccount(user ag_solanago.PublicKey) *UserUpdateFundAccountIfNeededInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(user).WRITE().SIGNER()
 	return inst
 }
 
 // GetUserAccount gets the "user" account.
-func (inst *UserUpdateFundAccountIfNeeded) GetUserAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateFundAccountIfNeededInstruction) GetUserAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *UserUpdateFundAccountIfNeeded) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserUpdateFundAccountIfNeeded {
+func (inst *UserUpdateFundAccountIfNeededInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserUpdateFundAccountIfNeededInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *UserUpdateFundAccountIfNeeded) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateFundAccountIfNeededInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *UserUpdateFundAccountIfNeeded) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserUpdateFundAccountIfNeeded {
+func (inst *UserUpdateFundAccountIfNeededInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserUpdateFundAccountIfNeededInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *UserUpdateFundAccountIfNeeded) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateFundAccountIfNeededInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetReceiptTokenProgramAccount sets the "receipt_token_program" account.
-func (inst *UserUpdateFundAccountIfNeeded) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserUpdateFundAccountIfNeeded {
+func (inst *UserUpdateFundAccountIfNeededInstruction) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserUpdateFundAccountIfNeededInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenProgram)
 	return inst
 }
 
 // GetReceiptTokenProgramAccount gets the "receipt_token_program" account.
-func (inst *UserUpdateFundAccountIfNeeded) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateFundAccountIfNeededInstruction) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetUserReceiptTokenAccountAccount sets the "user_receipt_token_account" account.
-func (inst *UserUpdateFundAccountIfNeeded) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserUpdateFundAccountIfNeeded {
+func (inst *UserUpdateFundAccountIfNeededInstruction) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserUpdateFundAccountIfNeededInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(userReceiptTokenAccount)
 	return inst
 }
 
-func (inst *UserUpdateFundAccountIfNeeded) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateFundAccountIfNeededInstruction) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: user
 	seeds = append(seeds, user.Bytes())
@@ -112,12 +112,12 @@ func (inst *UserUpdateFundAccountIfNeeded) findFindUserReceiptTokenAccountAddres
 }
 
 // FindUserReceiptTokenAccountAddressWithBumpSeed calculates UserReceiptTokenAccount account address with given seeds and a known bump seed.
-func (inst *UserUpdateFundAccountIfNeeded) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUpdateFundAccountIfNeededInstruction) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserUpdateFundAccountIfNeeded) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateFundAccountIfNeededInstruction) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -126,12 +126,12 @@ func (inst *UserUpdateFundAccountIfNeeded) MustFindUserReceiptTokenAccountAddres
 }
 
 // FindUserReceiptTokenAccountAddress finds UserReceiptTokenAccount account address with given seeds.
-func (inst *UserUpdateFundAccountIfNeeded) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateFundAccountIfNeededInstruction) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserUpdateFundAccountIfNeeded) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateFundAccountIfNeededInstruction) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -140,17 +140,17 @@ func (inst *UserUpdateFundAccountIfNeeded) MustFindUserReceiptTokenAccountAddres
 }
 
 // GetUserReceiptTokenAccountAccount gets the "user_receipt_token_account" account.
-func (inst *UserUpdateFundAccountIfNeeded) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateFundAccountIfNeededInstruction) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetUserFundAccountAccount sets the "user_fund_account" account.
-func (inst *UserUpdateFundAccountIfNeeded) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserUpdateFundAccountIfNeeded {
+func (inst *UserUpdateFundAccountIfNeededInstruction) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserUpdateFundAccountIfNeededInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(userFundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserUpdateFundAccountIfNeeded) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateFundAccountIfNeededInstruction) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_fund
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -169,12 +169,12 @@ func (inst *UserUpdateFundAccountIfNeeded) findFindUserFundAccountAddress(receip
 }
 
 // FindUserFundAccountAddressWithBumpSeed calculates UserFundAccount account address with given seeds and a known bump seed.
-func (inst *UserUpdateFundAccountIfNeeded) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUpdateFundAccountIfNeededInstruction) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserUpdateFundAccountIfNeeded) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateFundAccountIfNeededInstruction) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -183,12 +183,12 @@ func (inst *UserUpdateFundAccountIfNeeded) MustFindUserFundAccountAddressWithBum
 }
 
 // FindUserFundAccountAddress finds UserFundAccount account address with given seeds.
-func (inst *UserUpdateFundAccountIfNeeded) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateFundAccountIfNeededInstruction) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserUpdateFundAccountIfNeeded) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateFundAccountIfNeededInstruction) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -197,17 +197,17 @@ func (inst *UserUpdateFundAccountIfNeeded) MustFindUserFundAccountAddress(receip
 }
 
 // GetUserFundAccountAccount gets the "user_fund_account" account.
-func (inst *UserUpdateFundAccountIfNeeded) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateFundAccountIfNeededInstruction) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *UserUpdateFundAccountIfNeeded) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserUpdateFundAccountIfNeeded {
+func (inst *UserUpdateFundAccountIfNeededInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserUpdateFundAccountIfNeededInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *UserUpdateFundAccountIfNeeded) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateFundAccountIfNeededInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -222,12 +222,12 @@ func (inst *UserUpdateFundAccountIfNeeded) findFindEventAuthorityAddress(knownBu
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *UserUpdateFundAccountIfNeeded) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUpdateFundAccountIfNeededInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *UserUpdateFundAccountIfNeeded) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateFundAccountIfNeededInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -236,12 +236,12 @@ func (inst *UserUpdateFundAccountIfNeeded) MustFindEventAuthorityAddressWithBump
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *UserUpdateFundAccountIfNeeded) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateFundAccountIfNeededInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *UserUpdateFundAccountIfNeeded) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateFundAccountIfNeededInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -250,22 +250,22 @@ func (inst *UserUpdateFundAccountIfNeeded) MustFindEventAuthorityAddress() (pda 
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *UserUpdateFundAccountIfNeeded) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateFundAccountIfNeededInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *UserUpdateFundAccountIfNeeded) SetProgramAccount(program ag_solanago.PublicKey) *UserUpdateFundAccountIfNeeded {
+func (inst *UserUpdateFundAccountIfNeededInstruction) SetProgramAccount(program ag_solanago.PublicKey) *UserUpdateFundAccountIfNeededInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *UserUpdateFundAccountIfNeeded) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateFundAccountIfNeededInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
-func (inst UserUpdateFundAccountIfNeeded) Build() *Instruction {
+func (inst UserUpdateFundAccountIfNeededInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_UserUpdateFundAccountIfNeeded,
@@ -275,14 +275,14 @@ func (inst UserUpdateFundAccountIfNeeded) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst UserUpdateFundAccountIfNeeded) ValidateAndBuild() (*Instruction, error) {
+func (inst UserUpdateFundAccountIfNeededInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *UserUpdateFundAccountIfNeeded) Validate() error {
+func (inst *UserUpdateFundAccountIfNeededInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -313,7 +313,7 @@ func (inst *UserUpdateFundAccountIfNeeded) Validate() error {
 	return nil
 }
 
-func (inst *UserUpdateFundAccountIfNeeded) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *UserUpdateFundAccountIfNeededInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -339,10 +339,10 @@ func (inst *UserUpdateFundAccountIfNeeded) EncodeToTree(parent ag_treeout.Branch
 		})
 }
 
-func (obj UserUpdateFundAccountIfNeeded) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj UserUpdateFundAccountIfNeededInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *UserUpdateFundAccountIfNeeded) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *UserUpdateFundAccountIfNeededInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -356,7 +356,7 @@ func NewUserUpdateFundAccountIfNeededInstruction(
 	userReceiptTokenAccount ag_solanago.PublicKey,
 	userFundAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *UserUpdateFundAccountIfNeeded {
+	program ag_solanago.PublicKey) *UserUpdateFundAccountIfNeededInstruction {
 	return NewUserUpdateFundAccountIfNeededInstructionBuilder().
 		SetUserAccount(user).
 		SetSystemProgramAccount(systemProgram).

--- a/generated/restaking/userupdatefundaccountifneeded_test.go
+++ b/generated/restaking/userupdatefundaccountifneeded_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_UserUpdateFundAccountIfNeeded(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("UserUpdateFundAccountIfNeeded"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(UserUpdateFundAccountIfNeeded)
+				params := new(UserUpdateFundAccountIfNeededInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(UserUpdateFundAccountIfNeeded)
+				got := new(UserUpdateFundAccountIfNeededInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/userupdaterewardaccountifneeded.go
+++ b/generated/restaking/userupdaterewardaccountifneeded.go
@@ -11,7 +11,7 @@ import (
 )
 
 // UserUpdateRewardAccountIfNeeded is the `user_update_reward_account_if_needed` instruction.
-type UserUpdateRewardAccountIfNeeded struct {
+type UserUpdateRewardAccountIfNeededInstruction struct {
 	DesiredAccountSize *uint32 `bin:"optional"`
 
 	// [0] = [WRITE, SIGNER] user
@@ -34,9 +34,9 @@ type UserUpdateRewardAccountIfNeeded struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewUserUpdateRewardAccountIfNeededInstructionBuilder creates a new `UserUpdateRewardAccountIfNeeded` instruction builder.
-func NewUserUpdateRewardAccountIfNeededInstructionBuilder() *UserUpdateRewardAccountIfNeeded {
-	nd := &UserUpdateRewardAccountIfNeeded{
+// NewUserUpdateRewardAccountIfNeededInstructionBuilder creates a new `UserUpdateRewardAccountIfNeededInstruction` instruction builder.
+func NewUserUpdateRewardAccountIfNeededInstructionBuilder() *UserUpdateRewardAccountIfNeededInstruction {
+	nd := &UserUpdateRewardAccountIfNeededInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 9),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["11111111111111111111111111111111"])
@@ -45,62 +45,62 @@ func NewUserUpdateRewardAccountIfNeededInstructionBuilder() *UserUpdateRewardAcc
 }
 
 // SetDesiredAccountSize sets the "desired_account_size" parameter.
-func (inst *UserUpdateRewardAccountIfNeeded) SetDesiredAccountSize(desired_account_size uint32) *UserUpdateRewardAccountIfNeeded {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) SetDesiredAccountSize(desired_account_size uint32) *UserUpdateRewardAccountIfNeededInstruction {
 	inst.DesiredAccountSize = &desired_account_size
 	return inst
 }
 
 // SetUserAccount sets the "user" account.
-func (inst *UserUpdateRewardAccountIfNeeded) SetUserAccount(user ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeeded {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) SetUserAccount(user ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(user).WRITE().SIGNER()
 	return inst
 }
 
 // GetUserAccount gets the "user" account.
-func (inst *UserUpdateRewardAccountIfNeeded) GetUserAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) GetUserAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *UserUpdateRewardAccountIfNeeded) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeeded {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *UserUpdateRewardAccountIfNeeded) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *UserUpdateRewardAccountIfNeeded) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeeded {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *UserUpdateRewardAccountIfNeeded) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetReceiptTokenProgramAccount sets the "receipt_token_program" account.
-func (inst *UserUpdateRewardAccountIfNeeded) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeeded {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenProgram)
 	return inst
 }
 
 // GetReceiptTokenProgramAccount gets the "receipt_token_program" account.
-func (inst *UserUpdateRewardAccountIfNeeded) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetUserReceiptTokenAccountAccount sets the "user_receipt_token_account" account.
-func (inst *UserUpdateRewardAccountIfNeeded) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeeded {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(userReceiptTokenAccount)
 	return inst
 }
 
-func (inst *UserUpdateRewardAccountIfNeeded) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: user
 	seeds = append(seeds, user.Bytes())
@@ -121,12 +121,12 @@ func (inst *UserUpdateRewardAccountIfNeeded) findFindUserReceiptTokenAccountAddr
 }
 
 // FindUserReceiptTokenAccountAddressWithBumpSeed calculates UserReceiptTokenAccount account address with given seeds and a known bump seed.
-func (inst *UserUpdateRewardAccountIfNeeded) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserUpdateRewardAccountIfNeeded) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -135,12 +135,12 @@ func (inst *UserUpdateRewardAccountIfNeeded) MustFindUserReceiptTokenAccountAddr
 }
 
 // FindUserReceiptTokenAccountAddress finds UserReceiptTokenAccount account address with given seeds.
-func (inst *UserUpdateRewardAccountIfNeeded) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserUpdateRewardAccountIfNeeded) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -149,17 +149,17 @@ func (inst *UserUpdateRewardAccountIfNeeded) MustFindUserReceiptTokenAccountAddr
 }
 
 // GetUserReceiptTokenAccountAccount gets the "user_receipt_token_account" account.
-func (inst *UserUpdateRewardAccountIfNeeded) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *UserUpdateRewardAccountIfNeeded) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeeded {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserUpdateRewardAccountIfNeeded) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -176,12 +176,12 @@ func (inst *UserUpdateRewardAccountIfNeeded) findFindRewardAccountAddress(receip
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *UserUpdateRewardAccountIfNeeded) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserUpdateRewardAccountIfNeeded) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -190,12 +190,12 @@ func (inst *UserUpdateRewardAccountIfNeeded) MustFindRewardAccountAddressWithBum
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *UserUpdateRewardAccountIfNeeded) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserUpdateRewardAccountIfNeeded) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -204,17 +204,17 @@ func (inst *UserUpdateRewardAccountIfNeeded) MustFindRewardAccountAddress(receip
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *UserUpdateRewardAccountIfNeeded) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetUserRewardAccountAccount sets the "user_reward_account" account.
-func (inst *UserUpdateRewardAccountIfNeeded) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeeded {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(userRewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserUpdateRewardAccountIfNeeded) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -233,12 +233,12 @@ func (inst *UserUpdateRewardAccountIfNeeded) findFindUserRewardAccountAddress(re
 }
 
 // FindUserRewardAccountAddressWithBumpSeed calculates UserRewardAccount account address with given seeds and a known bump seed.
-func (inst *UserUpdateRewardAccountIfNeeded) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserUpdateRewardAccountIfNeeded) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -247,12 +247,12 @@ func (inst *UserUpdateRewardAccountIfNeeded) MustFindUserRewardAccountAddressWit
 }
 
 // FindUserRewardAccountAddress finds UserRewardAccount account address with given seeds.
-func (inst *UserUpdateRewardAccountIfNeeded) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserUpdateRewardAccountIfNeeded) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -261,17 +261,17 @@ func (inst *UserUpdateRewardAccountIfNeeded) MustFindUserRewardAccountAddress(re
 }
 
 // GetUserRewardAccountAccount gets the "user_reward_account" account.
-func (inst *UserUpdateRewardAccountIfNeeded) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *UserUpdateRewardAccountIfNeeded) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeeded {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *UserUpdateRewardAccountIfNeeded) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -286,12 +286,12 @@ func (inst *UserUpdateRewardAccountIfNeeded) findFindEventAuthorityAddress(known
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *UserUpdateRewardAccountIfNeeded) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *UserUpdateRewardAccountIfNeeded) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -300,12 +300,12 @@ func (inst *UserUpdateRewardAccountIfNeeded) MustFindEventAuthorityAddressWithBu
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *UserUpdateRewardAccountIfNeeded) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *UserUpdateRewardAccountIfNeeded) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -314,22 +314,22 @@ func (inst *UserUpdateRewardAccountIfNeeded) MustFindEventAuthorityAddress() (pd
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *UserUpdateRewardAccountIfNeeded) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *UserUpdateRewardAccountIfNeeded) SetProgramAccount(program ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeeded {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) SetProgramAccount(program ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeededInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *UserUpdateRewardAccountIfNeeded) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
-func (inst UserUpdateRewardAccountIfNeeded) Build() *Instruction {
+func (inst UserUpdateRewardAccountIfNeededInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_UserUpdateRewardAccountIfNeeded,
@@ -339,14 +339,14 @@ func (inst UserUpdateRewardAccountIfNeeded) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst UserUpdateRewardAccountIfNeeded) ValidateAndBuild() (*Instruction, error) {
+func (inst UserUpdateRewardAccountIfNeededInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *UserUpdateRewardAccountIfNeeded) Validate() error {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 	}
@@ -384,7 +384,7 @@ func (inst *UserUpdateRewardAccountIfNeeded) Validate() error {
 	return nil
 }
 
-func (inst *UserUpdateRewardAccountIfNeeded) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *UserUpdateRewardAccountIfNeededInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -413,7 +413,7 @@ func (inst *UserUpdateRewardAccountIfNeeded) EncodeToTree(parent ag_treeout.Bran
 		})
 }
 
-func (obj UserUpdateRewardAccountIfNeeded) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj UserUpdateRewardAccountIfNeededInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `DesiredAccountSize` param (optional):
 	{
 		if obj.DesiredAccountSize == nil {
@@ -434,7 +434,7 @@ func (obj UserUpdateRewardAccountIfNeeded) MarshalWithEncoder(encoder *ag_binary
 	}
 	return nil
 }
-func (obj *UserUpdateRewardAccountIfNeeded) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *UserUpdateRewardAccountIfNeededInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `DesiredAccountSize` (optional):
 	{
 		ok, err := decoder.ReadBool()
@@ -464,7 +464,7 @@ func NewUserUpdateRewardAccountIfNeededInstruction(
 	rewardAccount ag_solanago.PublicKey,
 	userRewardAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeeded {
+	program ag_solanago.PublicKey) *UserUpdateRewardAccountIfNeededInstruction {
 	return NewUserUpdateRewardAccountIfNeededInstructionBuilder().
 		SetDesiredAccountSize(desired_account_size).
 		SetUserAccount(user).

--- a/generated/restaking/userupdaterewardaccountifneeded_test.go
+++ b/generated/restaking/userupdaterewardaccountifneeded_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_UserUpdateRewardAccountIfNeeded(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("UserUpdateRewardAccountIfNeeded"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(UserUpdateRewardAccountIfNeeded)
+				params := new(UserUpdateRewardAccountIfNeededInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(UserUpdateRewardAccountIfNeeded)
+				got := new(UserUpdateRewardAccountIfNeededInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/userupdaterewardpools.go
+++ b/generated/restaking/userupdaterewardpools.go
@@ -11,7 +11,7 @@ import (
 )
 
 // UserUpdateRewardPools is the `user_update_reward_pools` instruction.
-type UserUpdateRewardPools struct {
+type UserUpdateRewardPoolsInstruction struct {
 
 	// [0] = [WRITE, SIGNER] user
 	//
@@ -29,9 +29,9 @@ type UserUpdateRewardPools struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewUserUpdateRewardPoolsInstructionBuilder creates a new `UserUpdateRewardPools` instruction builder.
-func NewUserUpdateRewardPoolsInstructionBuilder() *UserUpdateRewardPools {
-	nd := &UserUpdateRewardPools{
+// NewUserUpdateRewardPoolsInstructionBuilder creates a new `UserUpdateRewardPoolsInstruction` instruction builder.
+func NewUserUpdateRewardPoolsInstructionBuilder() *UserUpdateRewardPoolsInstruction {
+	nd := &UserUpdateRewardPoolsInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 7),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["11111111111111111111111111111111"])
@@ -39,45 +39,45 @@ func NewUserUpdateRewardPoolsInstructionBuilder() *UserUpdateRewardPools {
 }
 
 // SetUserAccount sets the "user" account.
-func (inst *UserUpdateRewardPools) SetUserAccount(user ag_solanago.PublicKey) *UserUpdateRewardPools {
+func (inst *UserUpdateRewardPoolsInstruction) SetUserAccount(user ag_solanago.PublicKey) *UserUpdateRewardPoolsInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(user).WRITE().SIGNER()
 	return inst
 }
 
 // GetUserAccount gets the "user" account.
-func (inst *UserUpdateRewardPools) GetUserAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateRewardPoolsInstruction) GetUserAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *UserUpdateRewardPools) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserUpdateRewardPools {
+func (inst *UserUpdateRewardPoolsInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserUpdateRewardPoolsInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *UserUpdateRewardPools) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateRewardPoolsInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *UserUpdateRewardPools) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserUpdateRewardPools {
+func (inst *UserUpdateRewardPoolsInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserUpdateRewardPoolsInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *UserUpdateRewardPools) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateRewardPoolsInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *UserUpdateRewardPools) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserUpdateRewardPools {
+func (inst *UserUpdateRewardPoolsInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserUpdateRewardPoolsInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserUpdateRewardPools) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateRewardPoolsInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -94,12 +94,12 @@ func (inst *UserUpdateRewardPools) findFindRewardAccountAddress(receiptTokenMint
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *UserUpdateRewardPools) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUpdateRewardPoolsInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserUpdateRewardPools) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateRewardPoolsInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -108,12 +108,12 @@ func (inst *UserUpdateRewardPools) MustFindRewardAccountAddressWithBumpSeed(rece
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *UserUpdateRewardPools) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateRewardPoolsInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserUpdateRewardPools) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateRewardPoolsInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -122,17 +122,17 @@ func (inst *UserUpdateRewardPools) MustFindRewardAccountAddress(receiptTokenMint
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *UserUpdateRewardPools) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateRewardPoolsInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetUserRewardAccountAccount sets the "user_reward_account" account.
-func (inst *UserUpdateRewardPools) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserUpdateRewardPools {
+func (inst *UserUpdateRewardPoolsInstruction) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserUpdateRewardPoolsInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(userRewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserUpdateRewardPools) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateRewardPoolsInstruction) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -151,12 +151,12 @@ func (inst *UserUpdateRewardPools) findFindUserRewardAccountAddress(receiptToken
 }
 
 // FindUserRewardAccountAddressWithBumpSeed calculates UserRewardAccount account address with given seeds and a known bump seed.
-func (inst *UserUpdateRewardPools) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUpdateRewardPoolsInstruction) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserUpdateRewardPools) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateRewardPoolsInstruction) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -165,12 +165,12 @@ func (inst *UserUpdateRewardPools) MustFindUserRewardAccountAddressWithBumpSeed(
 }
 
 // FindUserRewardAccountAddress finds UserRewardAccount account address with given seeds.
-func (inst *UserUpdateRewardPools) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateRewardPoolsInstruction) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserUpdateRewardPools) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateRewardPoolsInstruction) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -179,17 +179,17 @@ func (inst *UserUpdateRewardPools) MustFindUserRewardAccountAddress(receiptToken
 }
 
 // GetUserRewardAccountAccount gets the "user_reward_account" account.
-func (inst *UserUpdateRewardPools) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateRewardPoolsInstruction) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *UserUpdateRewardPools) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserUpdateRewardPools {
+func (inst *UserUpdateRewardPoolsInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserUpdateRewardPoolsInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *UserUpdateRewardPools) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateRewardPoolsInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -204,12 +204,12 @@ func (inst *UserUpdateRewardPools) findFindEventAuthorityAddress(knownBumpSeed u
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *UserUpdateRewardPools) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserUpdateRewardPoolsInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *UserUpdateRewardPools) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateRewardPoolsInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -218,12 +218,12 @@ func (inst *UserUpdateRewardPools) MustFindEventAuthorityAddressWithBumpSeed(bum
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *UserUpdateRewardPools) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserUpdateRewardPoolsInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *UserUpdateRewardPools) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *UserUpdateRewardPoolsInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -232,22 +232,22 @@ func (inst *UserUpdateRewardPools) MustFindEventAuthorityAddress() (pda ag_solan
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *UserUpdateRewardPools) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateRewardPoolsInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *UserUpdateRewardPools) SetProgramAccount(program ag_solanago.PublicKey) *UserUpdateRewardPools {
+func (inst *UserUpdateRewardPoolsInstruction) SetProgramAccount(program ag_solanago.PublicKey) *UserUpdateRewardPoolsInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *UserUpdateRewardPools) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserUpdateRewardPoolsInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
-func (inst UserUpdateRewardPools) Build() *Instruction {
+func (inst UserUpdateRewardPoolsInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_UserUpdateRewardPools,
@@ -257,14 +257,14 @@ func (inst UserUpdateRewardPools) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst UserUpdateRewardPools) ValidateAndBuild() (*Instruction, error) {
+func (inst UserUpdateRewardPoolsInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *UserUpdateRewardPools) Validate() error {
+func (inst *UserUpdateRewardPoolsInstruction) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
@@ -292,7 +292,7 @@ func (inst *UserUpdateRewardPools) Validate() error {
 	return nil
 }
 
-func (inst *UserUpdateRewardPools) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *UserUpdateRewardPoolsInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -317,10 +317,10 @@ func (inst *UserUpdateRewardPools) EncodeToTree(parent ag_treeout.Branches) {
 		})
 }
 
-func (obj UserUpdateRewardPools) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj UserUpdateRewardPoolsInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	return nil
 }
-func (obj *UserUpdateRewardPools) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *UserUpdateRewardPoolsInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	return nil
 }
 
@@ -333,7 +333,7 @@ func NewUserUpdateRewardPoolsInstruction(
 	rewardAccount ag_solanago.PublicKey,
 	userRewardAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *UserUpdateRewardPools {
+	program ag_solanago.PublicKey) *UserUpdateRewardPoolsInstruction {
 	return NewUserUpdateRewardPoolsInstructionBuilder().
 		SetUserAccount(user).
 		SetSystemProgramAccount(systemProgram).

--- a/generated/restaking/userupdaterewardpools_test.go
+++ b/generated/restaking/userupdaterewardpools_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_UserUpdateRewardPools(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("UserUpdateRewardPools"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(UserUpdateRewardPools)
+				params := new(UserUpdateRewardPoolsInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(UserUpdateRewardPools)
+				got := new(UserUpdateRewardPoolsInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/userwithdrawsol.go
+++ b/generated/restaking/userwithdrawsol.go
@@ -12,7 +12,7 @@ import (
 )
 
 // UserWithdrawSol is the `user_withdraw_sol` instruction.
-type UserWithdrawSol struct {
+type UserWithdrawSolInstruction struct {
 	BatchId   *uint64
 	RequestId *uint64
 
@@ -48,9 +48,9 @@ type UserWithdrawSol struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewUserWithdrawSolInstructionBuilder creates a new `UserWithdrawSol` instruction builder.
-func NewUserWithdrawSolInstructionBuilder() *UserWithdrawSol {
-	nd := &UserWithdrawSol{
+// NewUserWithdrawSolInstructionBuilder creates a new `UserWithdrawSolInstruction` instruction builder.
+func NewUserWithdrawSolInstructionBuilder() *UserWithdrawSolInstruction {
+	nd := &UserWithdrawSolInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 14),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["11111111111111111111111111111111"])
@@ -59,68 +59,68 @@ func NewUserWithdrawSolInstructionBuilder() *UserWithdrawSol {
 }
 
 // SetBatchId sets the "_batch_id" parameter.
-func (inst *UserWithdrawSol) SetBatchId(_batch_id uint64) *UserWithdrawSol {
+func (inst *UserWithdrawSolInstruction) SetBatchId(_batch_id uint64) *UserWithdrawSolInstruction {
 	inst.BatchId = &_batch_id
 	return inst
 }
 
 // SetRequestId sets the "request_id" parameter.
-func (inst *UserWithdrawSol) SetRequestId(request_id uint64) *UserWithdrawSol {
+func (inst *UserWithdrawSolInstruction) SetRequestId(request_id uint64) *UserWithdrawSolInstruction {
 	inst.RequestId = &request_id
 	return inst
 }
 
 // SetUserAccount sets the "user" account.
-func (inst *UserWithdrawSol) SetUserAccount(user ag_solanago.PublicKey) *UserWithdrawSol {
+func (inst *UserWithdrawSolInstruction) SetUserAccount(user ag_solanago.PublicKey) *UserWithdrawSolInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(user).WRITE().SIGNER()
 	return inst
 }
 
 // GetUserAccount gets the "user" account.
-func (inst *UserWithdrawSol) GetUserAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSolInstruction) GetUserAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *UserWithdrawSol) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserWithdrawSol {
+func (inst *UserWithdrawSolInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserWithdrawSolInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *UserWithdrawSol) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSolInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenProgramAccount sets the "receipt_token_program" account.
-func (inst *UserWithdrawSol) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserWithdrawSol {
+func (inst *UserWithdrawSolInstruction) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserWithdrawSolInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenProgram)
 	return inst
 }
 
 // GetReceiptTokenProgramAccount gets the "receipt_token_program" account.
-func (inst *UserWithdrawSol) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSolInstruction) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *UserWithdrawSol) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserWithdrawSol {
+func (inst *UserWithdrawSolInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserWithdrawSolInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(receiptTokenMint)
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *UserWithdrawSol) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSolInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetUserReceiptTokenAccountAccount sets the "user_receipt_token_account" account.
-func (inst *UserWithdrawSol) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserWithdrawSol {
+func (inst *UserWithdrawSolInstruction) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserWithdrawSolInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(userReceiptTokenAccount)
 	return inst
 }
 
-func (inst *UserWithdrawSol) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSolInstruction) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: user
 	seeds = append(seeds, user.Bytes())
@@ -141,12 +141,12 @@ func (inst *UserWithdrawSol) findFindUserReceiptTokenAccountAddress(user ag_sola
 }
 
 // FindUserReceiptTokenAccountAddressWithBumpSeed calculates UserReceiptTokenAccount account address with given seeds and a known bump seed.
-func (inst *UserWithdrawSol) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWithdrawSolInstruction) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWithdrawSol) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSolInstruction) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -155,12 +155,12 @@ func (inst *UserWithdrawSol) MustFindUserReceiptTokenAccountAddressWithBumpSeed(
 }
 
 // FindUserReceiptTokenAccountAddress finds UserReceiptTokenAccount account address with given seeds.
-func (inst *UserWithdrawSol) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSolInstruction) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWithdrawSol) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSolInstruction) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -169,17 +169,17 @@ func (inst *UserWithdrawSol) MustFindUserReceiptTokenAccountAddress(user ag_sola
 }
 
 // GetUserReceiptTokenAccountAccount gets the "user_receipt_token_account" account.
-func (inst *UserWithdrawSol) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSolInstruction) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *UserWithdrawSol) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *UserWithdrawSol {
+func (inst *UserWithdrawSolInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *UserWithdrawSolInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWithdrawSol) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSolInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -196,12 +196,12 @@ func (inst *UserWithdrawSol) findFindFundAccountAddress(receiptTokenMint ag_sola
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *UserWithdrawSol) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWithdrawSolInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWithdrawSol) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSolInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -210,12 +210,12 @@ func (inst *UserWithdrawSol) MustFindFundAccountAddressWithBumpSeed(receiptToken
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *UserWithdrawSol) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSolInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWithdrawSol) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSolInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -224,17 +224,17 @@ func (inst *UserWithdrawSol) MustFindFundAccountAddress(receiptTokenMint ag_sola
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *UserWithdrawSol) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSolInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetFundReserveAccountAccount sets the "fund_reserve_account" account.
-func (inst *UserWithdrawSol) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *UserWithdrawSol {
+func (inst *UserWithdrawSolInstruction) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *UserWithdrawSolInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(fundReserveAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWithdrawSol) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSolInstruction) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_reserve
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x72), byte(0x65), byte(0x73), byte(0x65), byte(0x72), byte(0x76), byte(0x65)})
@@ -251,12 +251,12 @@ func (inst *UserWithdrawSol) findFindFundReserveAccountAddress(receiptTokenMint 
 }
 
 // FindFundReserveAccountAddressWithBumpSeed calculates FundReserveAccount account address with given seeds and a known bump seed.
-func (inst *UserWithdrawSol) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWithdrawSolInstruction) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWithdrawSol) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSolInstruction) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -265,12 +265,12 @@ func (inst *UserWithdrawSol) MustFindFundReserveAccountAddressWithBumpSeed(recei
 }
 
 // FindFundReserveAccountAddress finds FundReserveAccount account address with given seeds.
-func (inst *UserWithdrawSol) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSolInstruction) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWithdrawSol) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSolInstruction) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -279,19 +279,19 @@ func (inst *UserWithdrawSol) MustFindFundReserveAccountAddress(receiptTokenMint 
 }
 
 // GetFundReserveAccountAccount gets the "fund_reserve_account" account.
-func (inst *UserWithdrawSol) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSolInstruction) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetFundWithdrawalBatchAccountAccount sets the "fund_withdrawal_batch_account" account.
 // Users can derive proper account address with target batch id for each withdrawal requests.
 // And the batch id can be read from a user fund account which the withdrawal requests belong to.
-func (inst *UserWithdrawSol) SetFundWithdrawalBatchAccountAccount(fundWithdrawalBatchAccount ag_solanago.PublicKey) *UserWithdrawSol {
+func (inst *UserWithdrawSolInstruction) SetFundWithdrawalBatchAccountAccount(fundWithdrawalBatchAccount ag_solanago.PublicKey) *UserWithdrawSolInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(fundWithdrawalBatchAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWithdrawSol) findFindFundWithdrawalBatchAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSolInstruction) findFindFundWithdrawalBatchAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: withdrawal_batch
 	seeds = append(seeds, []byte{byte(0x77), byte(0x69), byte(0x74), byte(0x68), byte(0x64), byte(0x72), byte(0x61), byte(0x77), byte(0x61), byte(0x6c), byte(0x5f), byte(0x62), byte(0x61), byte(0x74), byte(0x63), byte(0x68)})
@@ -316,12 +316,12 @@ func (inst *UserWithdrawSol) findFindFundWithdrawalBatchAccountAddress(receiptTo
 }
 
 // FindFundWithdrawalBatchAccountAddressWithBumpSeed calculates FundWithdrawalBatchAccount account address with given seeds and a known bump seed.
-func (inst *UserWithdrawSol) FindFundWithdrawalBatchAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWithdrawSolInstruction) FindFundWithdrawalBatchAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundWithdrawalBatchAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWithdrawSol) MustFindFundWithdrawalBatchAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSolInstruction) MustFindFundWithdrawalBatchAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWithdrawalBatchAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -330,12 +330,12 @@ func (inst *UserWithdrawSol) MustFindFundWithdrawalBatchAccountAddressWithBumpSe
 }
 
 // FindFundWithdrawalBatchAccountAddress finds FundWithdrawalBatchAccount account address with given seeds.
-func (inst *UserWithdrawSol) FindFundWithdrawalBatchAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSolInstruction) FindFundWithdrawalBatchAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundWithdrawalBatchAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWithdrawSol) MustFindFundWithdrawalBatchAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSolInstruction) MustFindFundWithdrawalBatchAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWithdrawalBatchAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -346,17 +346,17 @@ func (inst *UserWithdrawSol) MustFindFundWithdrawalBatchAccountAddress(receiptTo
 // GetFundWithdrawalBatchAccountAccount gets the "fund_withdrawal_batch_account" account.
 // Users can derive proper account address with target batch id for each withdrawal requests.
 // And the batch id can be read from a user fund account which the withdrawal requests belong to.
-func (inst *UserWithdrawSol) GetFundWithdrawalBatchAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSolInstruction) GetFundWithdrawalBatchAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetFundTreasuryAccountAccount sets the "fund_treasury_account" account.
-func (inst *UserWithdrawSol) SetFundTreasuryAccountAccount(fundTreasuryAccount ag_solanago.PublicKey) *UserWithdrawSol {
+func (inst *UserWithdrawSolInstruction) SetFundTreasuryAccountAccount(fundTreasuryAccount ag_solanago.PublicKey) *UserWithdrawSolInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(fundTreasuryAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWithdrawSol) findFindFundTreasuryAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSolInstruction) findFindFundTreasuryAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_treasury
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x74), byte(0x72), byte(0x65), byte(0x61), byte(0x73), byte(0x75), byte(0x72), byte(0x79)})
@@ -373,12 +373,12 @@ func (inst *UserWithdrawSol) findFindFundTreasuryAccountAddress(receiptTokenMint
 }
 
 // FindFundTreasuryAccountAddressWithBumpSeed calculates FundTreasuryAccount account address with given seeds and a known bump seed.
-func (inst *UserWithdrawSol) FindFundTreasuryAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWithdrawSolInstruction) FindFundTreasuryAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundTreasuryAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWithdrawSol) MustFindFundTreasuryAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSolInstruction) MustFindFundTreasuryAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundTreasuryAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -387,12 +387,12 @@ func (inst *UserWithdrawSol) MustFindFundTreasuryAccountAddressWithBumpSeed(rece
 }
 
 // FindFundTreasuryAccountAddress finds FundTreasuryAccount account address with given seeds.
-func (inst *UserWithdrawSol) FindFundTreasuryAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSolInstruction) FindFundTreasuryAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundTreasuryAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWithdrawSol) MustFindFundTreasuryAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSolInstruction) MustFindFundTreasuryAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundTreasuryAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -401,17 +401,17 @@ func (inst *UserWithdrawSol) MustFindFundTreasuryAccountAddress(receiptTokenMint
 }
 
 // GetFundTreasuryAccountAccount gets the "fund_treasury_account" account.
-func (inst *UserWithdrawSol) GetFundTreasuryAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSolInstruction) GetFundTreasuryAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
 // SetUserFundAccountAccount sets the "user_fund_account" account.
-func (inst *UserWithdrawSol) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserWithdrawSol {
+func (inst *UserWithdrawSolInstruction) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserWithdrawSolInstruction {
 	inst.AccountMetaSlice[9] = ag_solanago.Meta(userFundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWithdrawSol) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSolInstruction) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_fund
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -430,12 +430,12 @@ func (inst *UserWithdrawSol) findFindUserFundAccountAddress(receiptTokenMint ag_
 }
 
 // FindUserFundAccountAddressWithBumpSeed calculates UserFundAccount account address with given seeds and a known bump seed.
-func (inst *UserWithdrawSol) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWithdrawSolInstruction) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserWithdrawSol) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSolInstruction) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -444,12 +444,12 @@ func (inst *UserWithdrawSol) MustFindUserFundAccountAddressWithBumpSeed(receiptT
 }
 
 // FindUserFundAccountAddress finds UserFundAccount account address with given seeds.
-func (inst *UserWithdrawSol) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSolInstruction) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserWithdrawSol) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSolInstruction) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -458,17 +458,17 @@ func (inst *UserWithdrawSol) MustFindUserFundAccountAddress(receiptTokenMint ag_
 }
 
 // GetUserFundAccountAccount gets the "user_fund_account" account.
-func (inst *UserWithdrawSol) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSolInstruction) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(9)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *UserWithdrawSol) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserWithdrawSol {
+func (inst *UserWithdrawSolInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserWithdrawSolInstruction {
 	inst.AccountMetaSlice[10] = ag_solanago.Meta(rewardAccount)
 	return inst
 }
 
-func (inst *UserWithdrawSol) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSolInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -485,12 +485,12 @@ func (inst *UserWithdrawSol) findFindRewardAccountAddress(receiptTokenMint ag_so
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *UserWithdrawSol) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWithdrawSolInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWithdrawSol) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSolInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -499,12 +499,12 @@ func (inst *UserWithdrawSol) MustFindRewardAccountAddressWithBumpSeed(receiptTok
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *UserWithdrawSol) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSolInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWithdrawSol) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSolInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -513,17 +513,17 @@ func (inst *UserWithdrawSol) MustFindRewardAccountAddress(receiptTokenMint ag_so
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *UserWithdrawSol) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSolInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(10)
 }
 
 // SetUserRewardAccountAccount sets the "user_reward_account" account.
-func (inst *UserWithdrawSol) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserWithdrawSol {
+func (inst *UserWithdrawSolInstruction) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserWithdrawSolInstruction {
 	inst.AccountMetaSlice[11] = ag_solanago.Meta(userRewardAccount)
 	return inst
 }
 
-func (inst *UserWithdrawSol) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSolInstruction) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -542,12 +542,12 @@ func (inst *UserWithdrawSol) findFindUserRewardAccountAddress(receiptTokenMint a
 }
 
 // FindUserRewardAccountAddressWithBumpSeed calculates UserRewardAccount account address with given seeds and a known bump seed.
-func (inst *UserWithdrawSol) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWithdrawSolInstruction) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserWithdrawSol) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSolInstruction) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -556,12 +556,12 @@ func (inst *UserWithdrawSol) MustFindUserRewardAccountAddressWithBumpSeed(receip
 }
 
 // FindUserRewardAccountAddress finds UserRewardAccount account address with given seeds.
-func (inst *UserWithdrawSol) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSolInstruction) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserWithdrawSol) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSolInstruction) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -570,17 +570,17 @@ func (inst *UserWithdrawSol) MustFindUserRewardAccountAddress(receiptTokenMint a
 }
 
 // GetUserRewardAccountAccount gets the "user_reward_account" account.
-func (inst *UserWithdrawSol) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSolInstruction) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(11)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *UserWithdrawSol) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserWithdrawSol {
+func (inst *UserWithdrawSolInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserWithdrawSolInstruction {
 	inst.AccountMetaSlice[12] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *UserWithdrawSol) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSolInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -595,12 +595,12 @@ func (inst *UserWithdrawSol) findFindEventAuthorityAddress(knownBumpSeed uint8) 
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *UserWithdrawSol) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWithdrawSolInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *UserWithdrawSol) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSolInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -609,12 +609,12 @@ func (inst *UserWithdrawSol) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed 
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *UserWithdrawSol) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSolInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *UserWithdrawSol) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSolInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -623,22 +623,22 @@ func (inst *UserWithdrawSol) MustFindEventAuthorityAddress() (pda ag_solanago.Pu
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *UserWithdrawSol) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSolInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(12)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *UserWithdrawSol) SetProgramAccount(program ag_solanago.PublicKey) *UserWithdrawSol {
+func (inst *UserWithdrawSolInstruction) SetProgramAccount(program ag_solanago.PublicKey) *UserWithdrawSolInstruction {
 	inst.AccountMetaSlice[13] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *UserWithdrawSol) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSolInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(13)
 }
 
-func (inst UserWithdrawSol) Build() *Instruction {
+func (inst UserWithdrawSolInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_UserWithdrawSol,
@@ -648,14 +648,14 @@ func (inst UserWithdrawSol) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst UserWithdrawSol) ValidateAndBuild() (*Instruction, error) {
+func (inst UserWithdrawSolInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *UserWithdrawSol) Validate() error {
+func (inst *UserWithdrawSolInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.BatchId == nil {
@@ -714,7 +714,7 @@ func (inst *UserWithdrawSol) Validate() error {
 	return nil
 }
 
-func (inst *UserWithdrawSol) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *UserWithdrawSolInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -749,7 +749,7 @@ func (inst *UserWithdrawSol) EncodeToTree(parent ag_treeout.Branches) {
 		})
 }
 
-func (obj UserWithdrawSol) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj UserWithdrawSolInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `BatchId` param:
 	err = encoder.Encode(obj.BatchId)
 	if err != nil {
@@ -762,7 +762,7 @@ func (obj UserWithdrawSol) MarshalWithEncoder(encoder *ag_binary.Encoder) (err e
 	}
 	return nil
 }
-func (obj *UserWithdrawSol) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *UserWithdrawSolInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `BatchId`:
 	err = decoder.Decode(&obj.BatchId)
 	if err != nil {
@@ -795,7 +795,7 @@ func NewUserWithdrawSolInstruction(
 	rewardAccount ag_solanago.PublicKey,
 	userRewardAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *UserWithdrawSol {
+	program ag_solanago.PublicKey) *UserWithdrawSolInstruction {
 	return NewUserWithdrawSolInstructionBuilder().
 		SetBatchId(_batch_id).
 		SetRequestId(request_id).

--- a/generated/restaking/userwithdrawsol_test.go
+++ b/generated/restaking/userwithdrawsol_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_UserWithdrawSol(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("UserWithdrawSol"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(UserWithdrawSol)
+				params := new(UserWithdrawSolInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(UserWithdrawSol)
+				got := new(UserWithdrawSolInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/userwithdrawsupportedtoken.go
+++ b/generated/restaking/userwithdrawsupportedtoken.go
@@ -12,7 +12,7 @@ import (
 )
 
 // UserWithdrawSupportedToken is the `user_withdraw_supported_token` instruction.
-type UserWithdrawSupportedToken struct {
+type UserWithdrawSupportedTokenInstruction struct {
 	BatchId   *uint64
 	RequestId *uint64
 
@@ -58,9 +58,9 @@ type UserWithdrawSupportedToken struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewUserWithdrawSupportedTokenInstructionBuilder creates a new `UserWithdrawSupportedToken` instruction builder.
-func NewUserWithdrawSupportedTokenInstructionBuilder() *UserWithdrawSupportedToken {
-	nd := &UserWithdrawSupportedToken{
+// NewUserWithdrawSupportedTokenInstructionBuilder creates a new `UserWithdrawSupportedTokenInstruction` instruction builder.
+func NewUserWithdrawSupportedTokenInstructionBuilder() *UserWithdrawSupportedTokenInstruction {
+	nd := &UserWithdrawSupportedTokenInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 19),
 	}
 	nd.AccountMetaSlice[1] = ag_solanago.Meta(Addresses["11111111111111111111111111111111"])
@@ -70,79 +70,79 @@ func NewUserWithdrawSupportedTokenInstructionBuilder() *UserWithdrawSupportedTok
 }
 
 // SetBatchId sets the "_batch_id" parameter.
-func (inst *UserWithdrawSupportedToken) SetBatchId(_batch_id uint64) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetBatchId(_batch_id uint64) *UserWithdrawSupportedTokenInstruction {
 	inst.BatchId = &_batch_id
 	return inst
 }
 
 // SetRequestId sets the "request_id" parameter.
-func (inst *UserWithdrawSupportedToken) SetRequestId(request_id uint64) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetRequestId(request_id uint64) *UserWithdrawSupportedTokenInstruction {
 	inst.RequestId = &request_id
 	return inst
 }
 
 // SetUserAccount sets the "user" account.
-func (inst *UserWithdrawSupportedToken) SetUserAccount(user ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetUserAccount(user ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(user).WRITE().SIGNER()
 	return inst
 }
 
 // GetUserAccount gets the "user" account.
-func (inst *UserWithdrawSupportedToken) GetUserAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSupportedTokenInstruction) GetUserAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetSystemProgramAccount sets the "system_program" account.
-func (inst *UserWithdrawSupportedToken) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "system_program" account.
-func (inst *UserWithdrawSupportedToken) GetSystemProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSupportedTokenInstruction) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenProgramAccount sets the "receipt_token_program" account.
-func (inst *UserWithdrawSupportedToken) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenProgram)
 	return inst
 }
 
 // GetReceiptTokenProgramAccount gets the "receipt_token_program" account.
-func (inst *UserWithdrawSupportedToken) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSupportedTokenInstruction) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetSupportedTokenProgramAccount sets the "supported_token_program" account.
-func (inst *UserWithdrawSupportedToken) SetSupportedTokenProgramAccount(supportedTokenProgram ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetSupportedTokenProgramAccount(supportedTokenProgram ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(supportedTokenProgram)
 	return inst
 }
 
 // GetSupportedTokenProgramAccount gets the "supported_token_program" account.
-func (inst *UserWithdrawSupportedToken) GetSupportedTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSupportedTokenInstruction) GetSupportedTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *UserWithdrawSupportedToken) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(receiptTokenMint).WRITE()
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *UserWithdrawSupportedToken) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSupportedTokenInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetUserReceiptTokenAccountAccount sets the "user_receipt_token_account" account.
-func (inst *UserWithdrawSupportedToken) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(userReceiptTokenAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWithdrawSupportedToken) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: user
 	seeds = append(seeds, user.Bytes())
@@ -163,12 +163,12 @@ func (inst *UserWithdrawSupportedToken) findFindUserReceiptTokenAccountAddress(u
 }
 
 // FindUserReceiptTokenAccountAddressWithBumpSeed calculates UserReceiptTokenAccount account address with given seeds and a known bump seed.
-func (inst *UserWithdrawSupportedToken) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -177,12 +177,12 @@ func (inst *UserWithdrawSupportedToken) MustFindUserReceiptTokenAccountAddressWi
 }
 
 // FindUserReceiptTokenAccountAddress finds UserReceiptTokenAccount account address with given seeds.
-func (inst *UserWithdrawSupportedToken) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -191,39 +191,39 @@ func (inst *UserWithdrawSupportedToken) MustFindUserReceiptTokenAccountAddress(u
 }
 
 // GetUserReceiptTokenAccountAccount gets the "user_receipt_token_account" account.
-func (inst *UserWithdrawSupportedToken) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSupportedTokenInstruction) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetSupportedTokenMintAccount sets the "supported_token_mint" account.
-func (inst *UserWithdrawSupportedToken) SetSupportedTokenMintAccount(supportedTokenMint ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetSupportedTokenMintAccount(supportedTokenMint ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(supportedTokenMint)
 	return inst
 }
 
 // GetSupportedTokenMintAccount gets the "supported_token_mint" account.
-func (inst *UserWithdrawSupportedToken) GetSupportedTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSupportedTokenInstruction) GetSupportedTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetUserSupportedTokenAccountAccount sets the "user_supported_token_account" account.
-func (inst *UserWithdrawSupportedToken) SetUserSupportedTokenAccountAccount(userSupportedTokenAccount ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetUserSupportedTokenAccountAccount(userSupportedTokenAccount ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(userSupportedTokenAccount).WRITE()
 	return inst
 }
 
 // GetUserSupportedTokenAccountAccount gets the "user_supported_token_account" account.
-func (inst *UserWithdrawSupportedToken) GetUserSupportedTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSupportedTokenInstruction) GetUserSupportedTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *UserWithdrawSupportedToken) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWithdrawSupportedToken) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -240,12 +240,12 @@ func (inst *UserWithdrawSupportedToken) findFindFundAccountAddress(receiptTokenM
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *UserWithdrawSupportedToken) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -254,12 +254,12 @@ func (inst *UserWithdrawSupportedToken) MustFindFundAccountAddressWithBumpSeed(r
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *UserWithdrawSupportedToken) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -268,17 +268,17 @@ func (inst *UserWithdrawSupportedToken) MustFindFundAccountAddress(receiptTokenM
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *UserWithdrawSupportedToken) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSupportedTokenInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
 // SetFundReserveAccountAccount sets the "fund_reserve_account" account.
-func (inst *UserWithdrawSupportedToken) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetFundReserveAccountAccount(fundReserveAccount ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	inst.AccountMetaSlice[9] = ag_solanago.Meta(fundReserveAccount)
 	return inst
 }
 
-func (inst *UserWithdrawSupportedToken) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) findFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_reserve
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x72), byte(0x65), byte(0x73), byte(0x65), byte(0x72), byte(0x76), byte(0x65)})
@@ -295,12 +295,12 @@ func (inst *UserWithdrawSupportedToken) findFindFundReserveAccountAddress(receip
 }
 
 // FindFundReserveAccountAddressWithBumpSeed calculates FundReserveAccount account address with given seeds and a known bump seed.
-func (inst *UserWithdrawSupportedToken) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindFundReserveAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -309,12 +309,12 @@ func (inst *UserWithdrawSupportedToken) MustFindFundReserveAccountAddressWithBum
 }
 
 // FindFundReserveAccountAddress finds FundReserveAccount account address with given seeds.
-func (inst *UserWithdrawSupportedToken) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindFundReserveAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundReserveAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -323,19 +323,19 @@ func (inst *UserWithdrawSupportedToken) MustFindFundReserveAccountAddress(receip
 }
 
 // GetFundReserveAccountAccount gets the "fund_reserve_account" account.
-func (inst *UserWithdrawSupportedToken) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSupportedTokenInstruction) GetFundReserveAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(9)
 }
 
 // SetFundWithdrawalBatchAccountAccount sets the "fund_withdrawal_batch_account" account.
 // Users can derive proper account address with target batch id for each withdrawal requests.
 // And the batch id can be read from a user fund account which the withdrawal requests belong to.
-func (inst *UserWithdrawSupportedToken) SetFundWithdrawalBatchAccountAccount(fundWithdrawalBatchAccount ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetFundWithdrawalBatchAccountAccount(fundWithdrawalBatchAccount ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	inst.AccountMetaSlice[10] = ag_solanago.Meta(fundWithdrawalBatchAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWithdrawSupportedToken) findFindFundWithdrawalBatchAccountAddress(receiptTokenMint ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) findFindFundWithdrawalBatchAccountAddress(receiptTokenMint ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: withdrawal_batch
 	seeds = append(seeds, []byte{byte(0x77), byte(0x69), byte(0x74), byte(0x68), byte(0x64), byte(0x72), byte(0x61), byte(0x77), byte(0x61), byte(0x6c), byte(0x5f), byte(0x62), byte(0x61), byte(0x74), byte(0x63), byte(0x68)})
@@ -360,12 +360,12 @@ func (inst *UserWithdrawSupportedToken) findFindFundWithdrawalBatchAccountAddres
 }
 
 // FindFundWithdrawalBatchAccountAddressWithBumpSeed calculates FundWithdrawalBatchAccount account address with given seeds and a known bump seed.
-func (inst *UserWithdrawSupportedToken) FindFundWithdrawalBatchAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindFundWithdrawalBatchAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundWithdrawalBatchAccountAddress(receiptTokenMint, supportedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindFundWithdrawalBatchAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindFundWithdrawalBatchAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWithdrawalBatchAccountAddress(receiptTokenMint, supportedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -374,12 +374,12 @@ func (inst *UserWithdrawSupportedToken) MustFindFundWithdrawalBatchAccountAddres
 }
 
 // FindFundWithdrawalBatchAccountAddress finds FundWithdrawalBatchAccount account address with given seeds.
-func (inst *UserWithdrawSupportedToken) FindFundWithdrawalBatchAccountAddress(receiptTokenMint ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindFundWithdrawalBatchAccountAddress(receiptTokenMint ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundWithdrawalBatchAccountAddress(receiptTokenMint, supportedTokenMint, 0)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindFundWithdrawalBatchAccountAddress(receiptTokenMint ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindFundWithdrawalBatchAccountAddress(receiptTokenMint ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWithdrawalBatchAccountAddress(receiptTokenMint, supportedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -390,17 +390,17 @@ func (inst *UserWithdrawSupportedToken) MustFindFundWithdrawalBatchAccountAddres
 // GetFundWithdrawalBatchAccountAccount gets the "fund_withdrawal_batch_account" account.
 // Users can derive proper account address with target batch id for each withdrawal requests.
 // And the batch id can be read from a user fund account which the withdrawal requests belong to.
-func (inst *UserWithdrawSupportedToken) GetFundWithdrawalBatchAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSupportedTokenInstruction) GetFundWithdrawalBatchAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(10)
 }
 
 // SetFundSupportedTokenReserveAccountAccount sets the "fund_supported_token_reserve_account" account.
-func (inst *UserWithdrawSupportedToken) SetFundSupportedTokenReserveAccountAccount(fundSupportedTokenReserveAccount ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetFundSupportedTokenReserveAccountAccount(fundSupportedTokenReserveAccount ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	inst.AccountMetaSlice[11] = ag_solanago.Meta(fundSupportedTokenReserveAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWithdrawSupportedToken) findFindFundSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) findFindFundSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: fundReserveAccount
 	seeds = append(seeds, fundReserveAccount.Bytes())
@@ -421,12 +421,12 @@ func (inst *UserWithdrawSupportedToken) findFindFundSupportedTokenReserveAccount
 }
 
 // FindFundSupportedTokenReserveAccountAddressWithBumpSeed calculates FundSupportedTokenReserveAccount account address with given seeds and a known bump seed.
-func (inst *UserWithdrawSupportedToken) FindFundSupportedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindFundSupportedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundSupportedTokenReserveAccountAddress(fundReserveAccount, supportedTokenProgram, supportedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindFundSupportedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindFundSupportedTokenReserveAccountAddressWithBumpSeed(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundSupportedTokenReserveAccountAddress(fundReserveAccount, supportedTokenProgram, supportedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -435,12 +435,12 @@ func (inst *UserWithdrawSupportedToken) MustFindFundSupportedTokenReserveAccount
 }
 
 // FindFundSupportedTokenReserveAccountAddress finds FundSupportedTokenReserveAccount account address with given seeds.
-func (inst *UserWithdrawSupportedToken) FindFundSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindFundSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundSupportedTokenReserveAccountAddress(fundReserveAccount, supportedTokenProgram, supportedTokenMint, 0)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindFundSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindFundSupportedTokenReserveAccountAddress(fundReserveAccount ag_solanago.PublicKey, supportedTokenProgram ag_solanago.PublicKey, supportedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundSupportedTokenReserveAccountAddress(fundReserveAccount, supportedTokenProgram, supportedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -449,17 +449,17 @@ func (inst *UserWithdrawSupportedToken) MustFindFundSupportedTokenReserveAccount
 }
 
 // GetFundSupportedTokenReserveAccountAccount gets the "fund_supported_token_reserve_account" account.
-func (inst *UserWithdrawSupportedToken) GetFundSupportedTokenReserveAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSupportedTokenInstruction) GetFundSupportedTokenReserveAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(11)
 }
 
 // SetFundTreasuryAccountAccount sets the "fund_treasury_account" account.
-func (inst *UserWithdrawSupportedToken) SetFundTreasuryAccountAccount(fundTreasuryAccount ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetFundTreasuryAccountAccount(fundTreasuryAccount ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	inst.AccountMetaSlice[12] = ag_solanago.Meta(fundTreasuryAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWithdrawSupportedToken) findFindFundTreasuryAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) findFindFundTreasuryAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_treasury
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x74), byte(0x72), byte(0x65), byte(0x61), byte(0x73), byte(0x75), byte(0x72), byte(0x79)})
@@ -476,12 +476,12 @@ func (inst *UserWithdrawSupportedToken) findFindFundTreasuryAccountAddress(recei
 }
 
 // FindFundTreasuryAccountAddressWithBumpSeed calculates FundTreasuryAccount account address with given seeds and a known bump seed.
-func (inst *UserWithdrawSupportedToken) FindFundTreasuryAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindFundTreasuryAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundTreasuryAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindFundTreasuryAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindFundTreasuryAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundTreasuryAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -490,12 +490,12 @@ func (inst *UserWithdrawSupportedToken) MustFindFundTreasuryAccountAddressWithBu
 }
 
 // FindFundTreasuryAccountAddress finds FundTreasuryAccount account address with given seeds.
-func (inst *UserWithdrawSupportedToken) FindFundTreasuryAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindFundTreasuryAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundTreasuryAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindFundTreasuryAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindFundTreasuryAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundTreasuryAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -504,17 +504,17 @@ func (inst *UserWithdrawSupportedToken) MustFindFundTreasuryAccountAddress(recei
 }
 
 // GetFundTreasuryAccountAccount gets the "fund_treasury_account" account.
-func (inst *UserWithdrawSupportedToken) GetFundTreasuryAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSupportedTokenInstruction) GetFundTreasuryAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(12)
 }
 
 // SetUserFundAccountAccount sets the "user_fund_account" account.
-func (inst *UserWithdrawSupportedToken) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	inst.AccountMetaSlice[13] = ag_solanago.Meta(userFundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWithdrawSupportedToken) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_fund
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -533,12 +533,12 @@ func (inst *UserWithdrawSupportedToken) findFindUserFundAccountAddress(receiptTo
 }
 
 // FindUserFundAccountAddressWithBumpSeed calculates UserFundAccount account address with given seeds and a known bump seed.
-func (inst *UserWithdrawSupportedToken) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -547,12 +547,12 @@ func (inst *UserWithdrawSupportedToken) MustFindUserFundAccountAddressWithBumpSe
 }
 
 // FindUserFundAccountAddress finds UserFundAccount account address with given seeds.
-func (inst *UserWithdrawSupportedToken) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -561,17 +561,17 @@ func (inst *UserWithdrawSupportedToken) MustFindUserFundAccountAddress(receiptTo
 }
 
 // GetUserFundAccountAccount gets the "user_fund_account" account.
-func (inst *UserWithdrawSupportedToken) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSupportedTokenInstruction) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(13)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *UserWithdrawSupportedToken) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	inst.AccountMetaSlice[14] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWithdrawSupportedToken) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -588,12 +588,12 @@ func (inst *UserWithdrawSupportedToken) findFindRewardAccountAddress(receiptToke
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *UserWithdrawSupportedToken) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -602,12 +602,12 @@ func (inst *UserWithdrawSupportedToken) MustFindRewardAccountAddressWithBumpSeed
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *UserWithdrawSupportedToken) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -616,17 +616,17 @@ func (inst *UserWithdrawSupportedToken) MustFindRewardAccountAddress(receiptToke
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *UserWithdrawSupportedToken) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSupportedTokenInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(14)
 }
 
 // SetUserRewardAccountAccount sets the "user_reward_account" account.
-func (inst *UserWithdrawSupportedToken) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	inst.AccountMetaSlice[15] = ag_solanago.Meta(userRewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWithdrawSupportedToken) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -645,12 +645,12 @@ func (inst *UserWithdrawSupportedToken) findFindUserRewardAccountAddress(receipt
 }
 
 // FindUserRewardAccountAddressWithBumpSeed calculates UserRewardAccount account address with given seeds and a known bump seed.
-func (inst *UserWithdrawSupportedToken) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -659,12 +659,12 @@ func (inst *UserWithdrawSupportedToken) MustFindUserRewardAccountAddressWithBump
 }
 
 // FindUserRewardAccountAddress finds UserRewardAccount account address with given seeds.
-func (inst *UserWithdrawSupportedToken) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -673,28 +673,28 @@ func (inst *UserWithdrawSupportedToken) MustFindUserRewardAccountAddress(receipt
 }
 
 // GetUserRewardAccountAccount gets the "user_reward_account" account.
-func (inst *UserWithdrawSupportedToken) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSupportedTokenInstruction) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(15)
 }
 
 // SetInstructionsSysvarAccount sets the "instructions_sysvar" account.
-func (inst *UserWithdrawSupportedToken) SetInstructionsSysvarAccount(instructionsSysvar ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetInstructionsSysvarAccount(instructionsSysvar ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	inst.AccountMetaSlice[16] = ag_solanago.Meta(instructionsSysvar)
 	return inst
 }
 
 // GetInstructionsSysvarAccount gets the "instructions_sysvar" account.
-func (inst *UserWithdrawSupportedToken) GetInstructionsSysvarAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSupportedTokenInstruction) GetInstructionsSysvarAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(16)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *UserWithdrawSupportedToken) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	inst.AccountMetaSlice[17] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *UserWithdrawSupportedToken) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -709,12 +709,12 @@ func (inst *UserWithdrawSupportedToken) findFindEventAuthorityAddress(knownBumpS
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *UserWithdrawSupportedToken) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -723,12 +723,12 @@ func (inst *UserWithdrawSupportedToken) MustFindEventAuthorityAddressWithBumpSee
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *UserWithdrawSupportedToken) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWithdrawSupportedTokenInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *UserWithdrawSupportedToken) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *UserWithdrawSupportedTokenInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -737,22 +737,22 @@ func (inst *UserWithdrawSupportedToken) MustFindEventAuthorityAddress() (pda ag_
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *UserWithdrawSupportedToken) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSupportedTokenInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(17)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *UserWithdrawSupportedToken) SetProgramAccount(program ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+func (inst *UserWithdrawSupportedTokenInstruction) SetProgramAccount(program ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	inst.AccountMetaSlice[18] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *UserWithdrawSupportedToken) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserWithdrawSupportedTokenInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(18)
 }
 
-func (inst UserWithdrawSupportedToken) Build() *Instruction {
+func (inst UserWithdrawSupportedTokenInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_UserWithdrawSupportedToken,
@@ -762,14 +762,14 @@ func (inst UserWithdrawSupportedToken) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst UserWithdrawSupportedToken) ValidateAndBuild() (*Instruction, error) {
+func (inst UserWithdrawSupportedTokenInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *UserWithdrawSupportedToken) Validate() error {
+func (inst *UserWithdrawSupportedTokenInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.BatchId == nil {
@@ -843,7 +843,7 @@ func (inst *UserWithdrawSupportedToken) Validate() error {
 	return nil
 }
 
-func (inst *UserWithdrawSupportedToken) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *UserWithdrawSupportedTokenInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -883,7 +883,7 @@ func (inst *UserWithdrawSupportedToken) EncodeToTree(parent ag_treeout.Branches)
 		})
 }
 
-func (obj UserWithdrawSupportedToken) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj UserWithdrawSupportedTokenInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `BatchId` param:
 	err = encoder.Encode(obj.BatchId)
 	if err != nil {
@@ -896,7 +896,7 @@ func (obj UserWithdrawSupportedToken) MarshalWithEncoder(encoder *ag_binary.Enco
 	}
 	return nil
 }
-func (obj *UserWithdrawSupportedToken) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *UserWithdrawSupportedTokenInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `BatchId`:
 	err = decoder.Decode(&obj.BatchId)
 	if err != nil {
@@ -934,7 +934,7 @@ func NewUserWithdrawSupportedTokenInstruction(
 	userRewardAccount ag_solanago.PublicKey,
 	instructionsSysvar ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *UserWithdrawSupportedToken {
+	program ag_solanago.PublicKey) *UserWithdrawSupportedTokenInstruction {
 	return NewUserWithdrawSupportedTokenInstructionBuilder().
 		SetBatchId(_batch_id).
 		SetRequestId(request_id).

--- a/generated/restaking/userwithdrawsupportedtoken_test.go
+++ b/generated/restaking/userwithdrawsupportedtoken_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_UserWithdrawSupportedToken(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("UserWithdrawSupportedToken"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(UserWithdrawSupportedToken)
+				params := new(UserWithdrawSupportedTokenInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(UserWithdrawSupportedToken)
+				got := new(UserWithdrawSupportedTokenInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/userwrapreceipttoken.go
+++ b/generated/restaking/userwrapreceipttoken.go
@@ -11,7 +11,7 @@ import (
 )
 
 // UserWrapReceiptToken is the `user_wrap_receipt_token` instruction.
-type UserWrapReceiptToken struct {
+type UserWrapReceiptTokenInstruction struct {
 	Amount *uint64
 
 	// [0] = [SIGNER] user
@@ -48,9 +48,9 @@ type UserWrapReceiptToken struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewUserWrapReceiptTokenInstructionBuilder creates a new `UserWrapReceiptToken` instruction builder.
-func NewUserWrapReceiptTokenInstructionBuilder() *UserWrapReceiptToken {
-	nd := &UserWrapReceiptToken{
+// NewUserWrapReceiptTokenInstructionBuilder creates a new `UserWrapReceiptTokenInstruction` instruction builder.
+func NewUserWrapReceiptTokenInstructionBuilder() *UserWrapReceiptTokenInstruction {
+	nd := &UserWrapReceiptTokenInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 16),
 	}
 	nd.AccountMetaSlice[2] = ag_solanago.Meta(Addresses["TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"])
@@ -59,29 +59,29 @@ func NewUserWrapReceiptTokenInstructionBuilder() *UserWrapReceiptToken {
 }
 
 // SetAmount sets the "amount" parameter.
-func (inst *UserWrapReceiptToken) SetAmount(amount uint64) *UserWrapReceiptToken {
+func (inst *UserWrapReceiptTokenInstruction) SetAmount(amount uint64) *UserWrapReceiptTokenInstruction {
 	inst.Amount = &amount
 	return inst
 }
 
 // SetUserAccount sets the "user" account.
-func (inst *UserWrapReceiptToken) SetUserAccount(user ag_solanago.PublicKey) *UserWrapReceiptToken {
+func (inst *UserWrapReceiptTokenInstruction) SetUserAccount(user ag_solanago.PublicKey) *UserWrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(user).SIGNER()
 	return inst
 }
 
 // GetUserAccount gets the "user" account.
-func (inst *UserWrapReceiptToken) GetUserAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenInstruction) GetUserAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetFundWrapAccountAccount sets the "fund_wrap_account" account.
-func (inst *UserWrapReceiptToken) SetFundWrapAccountAccount(fundWrapAccount ag_solanago.PublicKey) *UserWrapReceiptToken {
+func (inst *UserWrapReceiptTokenInstruction) SetFundWrapAccountAccount(fundWrapAccount ag_solanago.PublicKey) *UserWrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(fundWrapAccount)
 	return inst
 }
 
-func (inst *UserWrapReceiptToken) findFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) findFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_wrap
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x77), byte(0x72), byte(0x61), byte(0x70)})
@@ -98,12 +98,12 @@ func (inst *UserWrapReceiptToken) findFindFundWrapAccountAddress(receiptTokenMin
 }
 
 // FindFundWrapAccountAddressWithBumpSeed calculates FundWrapAccount account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptToken) FindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundWrapAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -112,12 +112,12 @@ func (inst *UserWrapReceiptToken) MustFindFundWrapAccountAddressWithBumpSeed(rec
 }
 
 // FindFundWrapAccountAddress finds FundWrapAccount account address with given seeds.
-func (inst *UserWrapReceiptToken) FindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundWrapAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -126,61 +126,61 @@ func (inst *UserWrapReceiptToken) MustFindFundWrapAccountAddress(receiptTokenMin
 }
 
 // GetFundWrapAccountAccount gets the "fund_wrap_account" account.
-func (inst *UserWrapReceiptToken) GetFundWrapAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenInstruction) GetFundWrapAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenProgramAccount sets the "receipt_token_program" account.
-func (inst *UserWrapReceiptToken) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserWrapReceiptToken {
+func (inst *UserWrapReceiptTokenInstruction) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserWrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenProgram)
 	return inst
 }
 
 // GetReceiptTokenProgramAccount gets the "receipt_token_program" account.
-func (inst *UserWrapReceiptToken) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenInstruction) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetWrappedTokenProgramAccount sets the "wrapped_token_program" account.
-func (inst *UserWrapReceiptToken) SetWrappedTokenProgramAccount(wrappedTokenProgram ag_solanago.PublicKey) *UserWrapReceiptToken {
+func (inst *UserWrapReceiptTokenInstruction) SetWrappedTokenProgramAccount(wrappedTokenProgram ag_solanago.PublicKey) *UserWrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(wrappedTokenProgram)
 	return inst
 }
 
 // GetWrappedTokenProgramAccount gets the "wrapped_token_program" account.
-func (inst *UserWrapReceiptToken) GetWrappedTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenInstruction) GetWrappedTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *UserWrapReceiptToken) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserWrapReceiptToken {
+func (inst *UserWrapReceiptTokenInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserWrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(receiptTokenMint).WRITE()
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *UserWrapReceiptToken) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetWrappedTokenMintAccount sets the "wrapped_token_mint" account.
-func (inst *UserWrapReceiptToken) SetWrappedTokenMintAccount(wrappedTokenMint ag_solanago.PublicKey) *UserWrapReceiptToken {
+func (inst *UserWrapReceiptTokenInstruction) SetWrappedTokenMintAccount(wrappedTokenMint ag_solanago.PublicKey) *UserWrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(wrappedTokenMint).WRITE()
 	return inst
 }
 
 // GetWrappedTokenMintAccount gets the "wrapped_token_mint" account.
-func (inst *UserWrapReceiptToken) GetWrappedTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenInstruction) GetWrappedTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetUserReceiptTokenAccountAccount sets the "user_receipt_token_account" account.
-func (inst *UserWrapReceiptToken) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserWrapReceiptToken {
+func (inst *UserWrapReceiptTokenInstruction) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserWrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(userReceiptTokenAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWrapReceiptToken) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: user
 	seeds = append(seeds, user.Bytes())
@@ -201,12 +201,12 @@ func (inst *UserWrapReceiptToken) findFindUserReceiptTokenAccountAddress(user ag
 }
 
 // FindUserReceiptTokenAccountAddressWithBumpSeed calculates UserReceiptTokenAccount account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptToken) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -215,12 +215,12 @@ func (inst *UserWrapReceiptToken) MustFindUserReceiptTokenAccountAddressWithBump
 }
 
 // FindUserReceiptTokenAccountAddress finds UserReceiptTokenAccount account address with given seeds.
-func (inst *UserWrapReceiptToken) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -229,17 +229,17 @@ func (inst *UserWrapReceiptToken) MustFindUserReceiptTokenAccountAddress(user ag
 }
 
 // GetUserReceiptTokenAccountAccount gets the "user_receipt_token_account" account.
-func (inst *UserWrapReceiptToken) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenInstruction) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetReceiptTokenWrapAccountAccount sets the "receipt_token_wrap_account" account.
-func (inst *UserWrapReceiptToken) SetReceiptTokenWrapAccountAccount(receiptTokenWrapAccount ag_solanago.PublicKey) *UserWrapReceiptToken {
+func (inst *UserWrapReceiptTokenInstruction) SetReceiptTokenWrapAccountAccount(receiptTokenWrapAccount ag_solanago.PublicKey) *UserWrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(receiptTokenWrapAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWrapReceiptToken) findFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) findFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: fundWrapAccount
 	seeds = append(seeds, fundWrapAccount.Bytes())
@@ -260,12 +260,12 @@ func (inst *UserWrapReceiptToken) findFindReceiptTokenWrapAccountAddress(fundWra
 }
 
 // FindReceiptTokenWrapAccountAddressWithBumpSeed calculates ReceiptTokenWrapAccount account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptToken) FindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -274,12 +274,12 @@ func (inst *UserWrapReceiptToken) MustFindReceiptTokenWrapAccountAddressWithBump
 }
 
 // FindReceiptTokenWrapAccountAddress finds ReceiptTokenWrapAccount account address with given seeds.
-func (inst *UserWrapReceiptToken) FindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -288,17 +288,17 @@ func (inst *UserWrapReceiptToken) MustFindReceiptTokenWrapAccountAddress(fundWra
 }
 
 // GetReceiptTokenWrapAccountAccount gets the "receipt_token_wrap_account" account.
-func (inst *UserWrapReceiptToken) GetReceiptTokenWrapAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenInstruction) GetReceiptTokenWrapAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetUserWrappedTokenAccountAccount sets the "user_wrapped_token_account" account.
-func (inst *UserWrapReceiptToken) SetUserWrappedTokenAccountAccount(userWrappedTokenAccount ag_solanago.PublicKey) *UserWrapReceiptToken {
+func (inst *UserWrapReceiptTokenInstruction) SetUserWrappedTokenAccountAccount(userWrappedTokenAccount ag_solanago.PublicKey) *UserWrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(userWrappedTokenAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWrapReceiptToken) findFindUserWrappedTokenAccountAddress(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) findFindUserWrappedTokenAccountAddress(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: user
 	seeds = append(seeds, user.Bytes())
@@ -319,12 +319,12 @@ func (inst *UserWrapReceiptToken) findFindUserWrappedTokenAccountAddress(user ag
 }
 
 // FindUserWrappedTokenAccountAddressWithBumpSeed calculates UserWrappedTokenAccount account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptToken) FindUserWrappedTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindUserWrappedTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserWrappedTokenAccountAddress(user, wrappedTokenProgram, wrappedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindUserWrappedTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindUserWrappedTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserWrappedTokenAccountAddress(user, wrappedTokenProgram, wrappedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -333,12 +333,12 @@ func (inst *UserWrapReceiptToken) MustFindUserWrappedTokenAccountAddressWithBump
 }
 
 // FindUserWrappedTokenAccountAddress finds UserWrappedTokenAccount account address with given seeds.
-func (inst *UserWrapReceiptToken) FindUserWrappedTokenAccountAddress(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindUserWrappedTokenAccountAddress(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserWrappedTokenAccountAddress(user, wrappedTokenProgram, wrappedTokenMint, 0)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindUserWrappedTokenAccountAddress(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindUserWrappedTokenAccountAddress(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserWrappedTokenAccountAddress(user, wrappedTokenProgram, wrappedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -347,17 +347,17 @@ func (inst *UserWrapReceiptToken) MustFindUserWrappedTokenAccountAddress(user ag
 }
 
 // GetUserWrappedTokenAccountAccount gets the "user_wrapped_token_account" account.
-func (inst *UserWrapReceiptToken) GetUserWrappedTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenInstruction) GetUserWrappedTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *UserWrapReceiptToken) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *UserWrapReceiptToken {
+func (inst *UserWrapReceiptTokenInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *UserWrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[9] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWrapReceiptToken) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -374,12 +374,12 @@ func (inst *UserWrapReceiptToken) findFindFundAccountAddress(receiptTokenMint ag
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptToken) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -388,12 +388,12 @@ func (inst *UserWrapReceiptToken) MustFindFundAccountAddressWithBumpSeed(receipt
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *UserWrapReceiptToken) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -402,17 +402,17 @@ func (inst *UserWrapReceiptToken) MustFindFundAccountAddress(receiptTokenMint ag
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *UserWrapReceiptToken) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(9)
 }
 
 // SetUserFundAccountAccount sets the "user_fund_account" account.
-func (inst *UserWrapReceiptToken) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserWrapReceiptToken {
+func (inst *UserWrapReceiptTokenInstruction) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserWrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[10] = ag_solanago.Meta(userFundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWrapReceiptToken) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_fund
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -431,12 +431,12 @@ func (inst *UserWrapReceiptToken) findFindUserFundAccountAddress(receiptTokenMin
 }
 
 // FindUserFundAccountAddressWithBumpSeed calculates UserFundAccount account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptToken) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -445,12 +445,12 @@ func (inst *UserWrapReceiptToken) MustFindUserFundAccountAddressWithBumpSeed(rec
 }
 
 // FindUserFundAccountAddress finds UserFundAccount account address with given seeds.
-func (inst *UserWrapReceiptToken) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -459,17 +459,17 @@ func (inst *UserWrapReceiptToken) MustFindUserFundAccountAddress(receiptTokenMin
 }
 
 // GetUserFundAccountAccount gets the "user_fund_account" account.
-func (inst *UserWrapReceiptToken) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenInstruction) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(10)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *UserWrapReceiptToken) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserWrapReceiptToken {
+func (inst *UserWrapReceiptTokenInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserWrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[11] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWrapReceiptToken) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -486,12 +486,12 @@ func (inst *UserWrapReceiptToken) findFindRewardAccountAddress(receiptTokenMint 
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptToken) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -500,12 +500,12 @@ func (inst *UserWrapReceiptToken) MustFindRewardAccountAddressWithBumpSeed(recei
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *UserWrapReceiptToken) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -514,17 +514,17 @@ func (inst *UserWrapReceiptToken) MustFindRewardAccountAddress(receiptTokenMint 
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *UserWrapReceiptToken) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(11)
 }
 
 // SetUserRewardAccountAccount sets the "user_reward_account" account.
-func (inst *UserWrapReceiptToken) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserWrapReceiptToken {
+func (inst *UserWrapReceiptTokenInstruction) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserWrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[12] = ag_solanago.Meta(userRewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWrapReceiptToken) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -543,12 +543,12 @@ func (inst *UserWrapReceiptToken) findFindUserRewardAccountAddress(receiptTokenM
 }
 
 // FindUserRewardAccountAddressWithBumpSeed calculates UserRewardAccount account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptToken) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -557,12 +557,12 @@ func (inst *UserWrapReceiptToken) MustFindUserRewardAccountAddressWithBumpSeed(r
 }
 
 // FindUserRewardAccountAddress finds UserRewardAccount account address with given seeds.
-func (inst *UserWrapReceiptToken) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -571,17 +571,17 @@ func (inst *UserWrapReceiptToken) MustFindUserRewardAccountAddress(receiptTokenM
 }
 
 // GetUserRewardAccountAccount gets the "user_reward_account" account.
-func (inst *UserWrapReceiptToken) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenInstruction) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(12)
 }
 
 // SetFundWrapAccountRewardAccountAccount sets the "fund_wrap_account_reward_account" account.
-func (inst *UserWrapReceiptToken) SetFundWrapAccountRewardAccountAccount(fundWrapAccountRewardAccount ag_solanago.PublicKey) *UserWrapReceiptToken {
+func (inst *UserWrapReceiptTokenInstruction) SetFundWrapAccountRewardAccountAccount(fundWrapAccountRewardAccount ag_solanago.PublicKey) *UserWrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[13] = ag_solanago.Meta(fundWrapAccountRewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWrapReceiptToken) findFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) findFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -600,12 +600,12 @@ func (inst *UserWrapReceiptToken) findFindFundWrapAccountRewardAccountAddress(re
 }
 
 // FindFundWrapAccountRewardAccountAddressWithBumpSeed calculates FundWrapAccountRewardAccount account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptToken) FindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -614,12 +614,12 @@ func (inst *UserWrapReceiptToken) MustFindFundWrapAccountRewardAccountAddressWit
 }
 
 // FindFundWrapAccountRewardAccountAddress finds FundWrapAccountRewardAccount account address with given seeds.
-func (inst *UserWrapReceiptToken) FindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, 0)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, 0)
 	if err != nil {
 		panic(err)
@@ -628,17 +628,17 @@ func (inst *UserWrapReceiptToken) MustFindFundWrapAccountRewardAccountAddress(re
 }
 
 // GetFundWrapAccountRewardAccountAccount gets the "fund_wrap_account_reward_account" account.
-func (inst *UserWrapReceiptToken) GetFundWrapAccountRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenInstruction) GetFundWrapAccountRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(13)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *UserWrapReceiptToken) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserWrapReceiptToken {
+func (inst *UserWrapReceiptTokenInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserWrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[14] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *UserWrapReceiptToken) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -653,12 +653,12 @@ func (inst *UserWrapReceiptToken) findFindEventAuthorityAddress(knownBumpSeed ui
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptToken) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -667,12 +667,12 @@ func (inst *UserWrapReceiptToken) MustFindEventAuthorityAddressWithBumpSeed(bump
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *UserWrapReceiptToken) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *UserWrapReceiptToken) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -681,22 +681,22 @@ func (inst *UserWrapReceiptToken) MustFindEventAuthorityAddress() (pda ag_solana
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *UserWrapReceiptToken) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(14)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *UserWrapReceiptToken) SetProgramAccount(program ag_solanago.PublicKey) *UserWrapReceiptToken {
+func (inst *UserWrapReceiptTokenInstruction) SetProgramAccount(program ag_solanago.PublicKey) *UserWrapReceiptTokenInstruction {
 	inst.AccountMetaSlice[15] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *UserWrapReceiptToken) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(15)
 }
 
-func (inst UserWrapReceiptToken) Build() *Instruction {
+func (inst UserWrapReceiptTokenInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_UserWrapReceiptToken,
@@ -706,14 +706,14 @@ func (inst UserWrapReceiptToken) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst UserWrapReceiptToken) ValidateAndBuild() (*Instruction, error) {
+func (inst UserWrapReceiptTokenInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *UserWrapReceiptToken) Validate() error {
+func (inst *UserWrapReceiptTokenInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.Amount == nil {
@@ -775,7 +775,7 @@ func (inst *UserWrapReceiptToken) Validate() error {
 	return nil
 }
 
-func (inst *UserWrapReceiptToken) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *UserWrapReceiptTokenInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -811,7 +811,7 @@ func (inst *UserWrapReceiptToken) EncodeToTree(parent ag_treeout.Branches) {
 		})
 }
 
-func (obj UserWrapReceiptToken) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj UserWrapReceiptTokenInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `Amount` param:
 	err = encoder.Encode(obj.Amount)
 	if err != nil {
@@ -819,7 +819,7 @@ func (obj UserWrapReceiptToken) MarshalWithEncoder(encoder *ag_binary.Encoder) (
 	}
 	return nil
 }
-func (obj *UserWrapReceiptToken) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *UserWrapReceiptTokenInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `Amount`:
 	err = decoder.Decode(&obj.Amount)
 	if err != nil {
@@ -848,7 +848,7 @@ func NewUserWrapReceiptTokenInstruction(
 	userRewardAccount ag_solanago.PublicKey,
 	fundWrapAccountRewardAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *UserWrapReceiptToken {
+	program ag_solanago.PublicKey) *UserWrapReceiptTokenInstruction {
 	return NewUserWrapReceiptTokenInstructionBuilder().
 		SetAmount(amount).
 		SetUserAccount(user).

--- a/generated/restaking/userwrapreceipttoken_test.go
+++ b/generated/restaking/userwrapreceipttoken_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_UserWrapReceiptToken(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("UserWrapReceiptToken"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(UserWrapReceiptToken)
+				params := new(UserWrapReceiptTokenInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(UserWrapReceiptToken)
+				got := new(UserWrapReceiptTokenInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generated/restaking/userwrapreceipttokenifneeded.go
+++ b/generated/restaking/userwrapreceipttokenifneeded.go
@@ -11,7 +11,7 @@ import (
 )
 
 // UserWrapReceiptTokenIfNeeded is the `user_wrap_receipt_token_if_needed` instruction.
-type UserWrapReceiptTokenIfNeeded struct {
+type UserWrapReceiptTokenIfNeededInstruction struct {
 	TargetBalance *uint64
 
 	// [0] = [SIGNER] user
@@ -48,9 +48,9 @@ type UserWrapReceiptTokenIfNeeded struct {
 	ag_solanago.AccountMetaSlice `bin:"-"`
 }
 
-// NewUserWrapReceiptTokenIfNeededInstructionBuilder creates a new `UserWrapReceiptTokenIfNeeded` instruction builder.
-func NewUserWrapReceiptTokenIfNeededInstructionBuilder() *UserWrapReceiptTokenIfNeeded {
-	nd := &UserWrapReceiptTokenIfNeeded{
+// NewUserWrapReceiptTokenIfNeededInstructionBuilder creates a new `UserWrapReceiptTokenIfNeededInstruction` instruction builder.
+func NewUserWrapReceiptTokenIfNeededInstructionBuilder() *UserWrapReceiptTokenIfNeededInstruction {
+	nd := &UserWrapReceiptTokenIfNeededInstruction{
 		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 16),
 	}
 	nd.AccountMetaSlice[2] = ag_solanago.Meta(Addresses["TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"])
@@ -59,29 +59,29 @@ func NewUserWrapReceiptTokenIfNeededInstructionBuilder() *UserWrapReceiptTokenIf
 }
 
 // SetTargetBalance sets the "target_balance" parameter.
-func (inst *UserWrapReceiptTokenIfNeeded) SetTargetBalance(target_balance uint64) *UserWrapReceiptTokenIfNeeded {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) SetTargetBalance(target_balance uint64) *UserWrapReceiptTokenIfNeededInstruction {
 	inst.TargetBalance = &target_balance
 	return inst
 }
 
 // SetUserAccount sets the "user" account.
-func (inst *UserWrapReceiptTokenIfNeeded) SetUserAccount(user ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeeded {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) SetUserAccount(user ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeededInstruction {
 	inst.AccountMetaSlice[0] = ag_solanago.Meta(user).SIGNER()
 	return inst
 }
 
 // GetUserAccount gets the "user" account.
-func (inst *UserWrapReceiptTokenIfNeeded) GetUserAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) GetUserAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(0)
 }
 
 // SetFundWrapAccountAccount sets the "fund_wrap_account" account.
-func (inst *UserWrapReceiptTokenIfNeeded) SetFundWrapAccountAccount(fundWrapAccount ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeeded {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) SetFundWrapAccountAccount(fundWrapAccount ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeededInstruction {
 	inst.AccountMetaSlice[1] = ag_solanago.Meta(fundWrapAccount)
 	return inst
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) findFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) findFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund_wrap
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64), byte(0x5f), byte(0x77), byte(0x72), byte(0x61), byte(0x70)})
@@ -98,12 +98,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) findFindFundWrapAccountAddress(receipt
 }
 
 // FindFundWrapAccountAddressWithBumpSeed calculates FundWrapAccount account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptTokenIfNeeded) FindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundWrapAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindFundWrapAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -112,12 +112,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindFundWrapAccountAddressWithBump
 }
 
 // FindFundWrapAccountAddress finds FundWrapAccount account address with given seeds.
-func (inst *UserWrapReceiptTokenIfNeeded) FindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundWrapAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindFundWrapAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -126,61 +126,61 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindFundWrapAccountAddress(receipt
 }
 
 // GetFundWrapAccountAccount gets the "fund_wrap_account" account.
-func (inst *UserWrapReceiptTokenIfNeeded) GetFundWrapAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) GetFundWrapAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(1)
 }
 
 // SetReceiptTokenProgramAccount sets the "receipt_token_program" account.
-func (inst *UserWrapReceiptTokenIfNeeded) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeeded {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) SetReceiptTokenProgramAccount(receiptTokenProgram ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeededInstruction {
 	inst.AccountMetaSlice[2] = ag_solanago.Meta(receiptTokenProgram)
 	return inst
 }
 
 // GetReceiptTokenProgramAccount gets the "receipt_token_program" account.
-func (inst *UserWrapReceiptTokenIfNeeded) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) GetReceiptTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(2)
 }
 
 // SetWrappedTokenProgramAccount sets the "wrapped_token_program" account.
-func (inst *UserWrapReceiptTokenIfNeeded) SetWrappedTokenProgramAccount(wrappedTokenProgram ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeeded {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) SetWrappedTokenProgramAccount(wrappedTokenProgram ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeededInstruction {
 	inst.AccountMetaSlice[3] = ag_solanago.Meta(wrappedTokenProgram)
 	return inst
 }
 
 // GetWrappedTokenProgramAccount gets the "wrapped_token_program" account.
-func (inst *UserWrapReceiptTokenIfNeeded) GetWrappedTokenProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) GetWrappedTokenProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(3)
 }
 
 // SetReceiptTokenMintAccount sets the "receipt_token_mint" account.
-func (inst *UserWrapReceiptTokenIfNeeded) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeeded {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) SetReceiptTokenMintAccount(receiptTokenMint ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeededInstruction {
 	inst.AccountMetaSlice[4] = ag_solanago.Meta(receiptTokenMint).WRITE()
 	return inst
 }
 
 // GetReceiptTokenMintAccount gets the "receipt_token_mint" account.
-func (inst *UserWrapReceiptTokenIfNeeded) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) GetReceiptTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(4)
 }
 
 // SetWrappedTokenMintAccount sets the "wrapped_token_mint" account.
-func (inst *UserWrapReceiptTokenIfNeeded) SetWrappedTokenMintAccount(wrappedTokenMint ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeeded {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) SetWrappedTokenMintAccount(wrappedTokenMint ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeededInstruction {
 	inst.AccountMetaSlice[5] = ag_solanago.Meta(wrappedTokenMint).WRITE()
 	return inst
 }
 
 // GetWrappedTokenMintAccount gets the "wrapped_token_mint" account.
-func (inst *UserWrapReceiptTokenIfNeeded) GetWrappedTokenMintAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) GetWrappedTokenMintAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(5)
 }
 
 // SetUserReceiptTokenAccountAccount sets the "user_receipt_token_account" account.
-func (inst *UserWrapReceiptTokenIfNeeded) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeeded {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) SetUserReceiptTokenAccountAccount(userReceiptTokenAccount ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeededInstruction {
 	inst.AccountMetaSlice[6] = ag_solanago.Meta(userReceiptTokenAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) findFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: user
 	seeds = append(seeds, user.Bytes())
@@ -201,12 +201,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) findFindUserReceiptTokenAccountAddress
 }
 
 // FindUserReceiptTokenAccountAddressWithBumpSeed calculates UserReceiptTokenAccount account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptTokenIfNeeded) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindUserReceiptTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -215,12 +215,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindUserReceiptTokenAccountAddress
 }
 
 // FindUserReceiptTokenAccountAddress finds UserReceiptTokenAccount account address with given seeds.
-func (inst *UserWrapReceiptTokenIfNeeded) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindUserReceiptTokenAccountAddress(user ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserReceiptTokenAccountAddress(user, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -229,17 +229,17 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindUserReceiptTokenAccountAddress
 }
 
 // GetUserReceiptTokenAccountAccount gets the "user_receipt_token_account" account.
-func (inst *UserWrapReceiptTokenIfNeeded) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) GetUserReceiptTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(6)
 }
 
 // SetReceiptTokenWrapAccountAccount sets the "receipt_token_wrap_account" account.
-func (inst *UserWrapReceiptTokenIfNeeded) SetReceiptTokenWrapAccountAccount(receiptTokenWrapAccount ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeeded {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) SetReceiptTokenWrapAccountAccount(receiptTokenWrapAccount ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeededInstruction {
 	inst.AccountMetaSlice[7] = ag_solanago.Meta(receiptTokenWrapAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) findFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) findFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: fundWrapAccount
 	seeds = append(seeds, fundWrapAccount.Bytes())
@@ -260,12 +260,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) findFindReceiptTokenWrapAccountAddress
 }
 
 // FindReceiptTokenWrapAccountAddressWithBumpSeed calculates ReceiptTokenWrapAccount account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptTokenIfNeeded) FindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindReceiptTokenWrapAccountAddressWithBumpSeed(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenProgram, receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -274,12 +274,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindReceiptTokenWrapAccountAddress
 }
 
 // FindReceiptTokenWrapAccountAddress finds ReceiptTokenWrapAccount account address with given seeds.
-func (inst *UserWrapReceiptTokenIfNeeded) FindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenProgram, receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindReceiptTokenWrapAccountAddress(fundWrapAccount ag_solanago.PublicKey, receiptTokenProgram ag_solanago.PublicKey, receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindReceiptTokenWrapAccountAddress(fundWrapAccount, receiptTokenProgram, receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -288,17 +288,17 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindReceiptTokenWrapAccountAddress
 }
 
 // GetReceiptTokenWrapAccountAccount gets the "receipt_token_wrap_account" account.
-func (inst *UserWrapReceiptTokenIfNeeded) GetReceiptTokenWrapAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) GetReceiptTokenWrapAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(7)
 }
 
 // SetUserWrappedTokenAccountAccount sets the "user_wrapped_token_account" account.
-func (inst *UserWrapReceiptTokenIfNeeded) SetUserWrappedTokenAccountAccount(userWrappedTokenAccount ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeeded {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) SetUserWrappedTokenAccountAccount(userWrappedTokenAccount ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeededInstruction {
 	inst.AccountMetaSlice[8] = ag_solanago.Meta(userWrappedTokenAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) findFindUserWrappedTokenAccountAddress(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) findFindUserWrappedTokenAccountAddress(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// path: user
 	seeds = append(seeds, user.Bytes())
@@ -319,12 +319,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) findFindUserWrappedTokenAccountAddress
 }
 
 // FindUserWrappedTokenAccountAddressWithBumpSeed calculates UserWrappedTokenAccount account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptTokenIfNeeded) FindUserWrappedTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindUserWrappedTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserWrappedTokenAccountAddress(user, wrappedTokenProgram, wrappedTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindUserWrappedTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindUserWrappedTokenAccountAddressWithBumpSeed(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserWrappedTokenAccountAddress(user, wrappedTokenProgram, wrappedTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -333,12 +333,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindUserWrappedTokenAccountAddress
 }
 
 // FindUserWrappedTokenAccountAddress finds UserWrappedTokenAccount account address with given seeds.
-func (inst *UserWrapReceiptTokenIfNeeded) FindUserWrappedTokenAccountAddress(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindUserWrappedTokenAccountAddress(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserWrappedTokenAccountAddress(user, wrappedTokenProgram, wrappedTokenMint, 0)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindUserWrappedTokenAccountAddress(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindUserWrappedTokenAccountAddress(user ag_solanago.PublicKey, wrappedTokenProgram ag_solanago.PublicKey, wrappedTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserWrappedTokenAccountAddress(user, wrappedTokenProgram, wrappedTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -347,17 +347,17 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindUserWrappedTokenAccountAddress
 }
 
 // GetUserWrappedTokenAccountAccount gets the "user_wrapped_token_account" account.
-func (inst *UserWrapReceiptTokenIfNeeded) GetUserWrappedTokenAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) GetUserWrappedTokenAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(8)
 }
 
 // SetFundAccountAccount sets the "fund_account" account.
-func (inst *UserWrapReceiptTokenIfNeeded) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeeded {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) SetFundAccountAccount(fundAccount ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeededInstruction {
 	inst.AccountMetaSlice[9] = ag_solanago.Meta(fundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) findFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: fund
 	seeds = append(seeds, []byte{byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -374,12 +374,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) findFindFundAccountAddress(receiptToke
 }
 
 // FindFundAccountAddressWithBumpSeed calculates FundAccount account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptTokenIfNeeded) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -388,12 +388,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindFundAccountAddressWithBumpSeed
 }
 
 // FindFundAccountAddress finds FundAccount account address with given seeds.
-func (inst *UserWrapReceiptTokenIfNeeded) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindFundAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -402,17 +402,17 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindFundAccountAddress(receiptToke
 }
 
 // GetFundAccountAccount gets the "fund_account" account.
-func (inst *UserWrapReceiptTokenIfNeeded) GetFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) GetFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(9)
 }
 
 // SetUserFundAccountAccount sets the "user_fund_account" account.
-func (inst *UserWrapReceiptTokenIfNeeded) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeeded {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) SetUserFundAccountAccount(userFundAccount ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeededInstruction {
 	inst.AccountMetaSlice[10] = ag_solanago.Meta(userFundAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) findFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_fund
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x66), byte(0x75), byte(0x6e), byte(0x64)})
@@ -431,12 +431,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) findFindUserFundAccountAddress(receipt
 }
 
 // FindUserFundAccountAddressWithBumpSeed calculates UserFundAccount account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptTokenIfNeeded) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindUserFundAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -445,12 +445,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindUserFundAccountAddressWithBump
 }
 
 // FindUserFundAccountAddress finds UserFundAccount account address with given seeds.
-func (inst *UserWrapReceiptTokenIfNeeded) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindUserFundAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserFundAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -459,17 +459,17 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindUserFundAccountAddress(receipt
 }
 
 // GetUserFundAccountAccount gets the "user_fund_account" account.
-func (inst *UserWrapReceiptTokenIfNeeded) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) GetUserFundAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(10)
 }
 
 // SetRewardAccountAccount sets the "reward_account" account.
-func (inst *UserWrapReceiptTokenIfNeeded) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeeded {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) SetRewardAccountAccount(rewardAccount ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeededInstruction {
 	inst.AccountMetaSlice[11] = ag_solanago.Meta(rewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) findFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: reward
 	seeds = append(seeds, []byte{byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -486,12 +486,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) findFindRewardAccountAddress(receiptTo
 }
 
 // FindRewardAccountAddressWithBumpSeed calculates RewardAccount account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptTokenIfNeeded) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -500,12 +500,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindRewardAccountAddressWithBumpSe
 }
 
 // FindRewardAccountAddress finds RewardAccount account address with given seeds.
-func (inst *UserWrapReceiptTokenIfNeeded) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindRewardAccountAddress(receiptTokenMint, 0)
 	if err != nil {
 		panic(err)
@@ -514,17 +514,17 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindRewardAccountAddress(receiptTo
 }
 
 // GetRewardAccountAccount gets the "reward_account" account.
-func (inst *UserWrapReceiptTokenIfNeeded) GetRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) GetRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(11)
 }
 
 // SetUserRewardAccountAccount sets the "user_reward_account" account.
-func (inst *UserWrapReceiptTokenIfNeeded) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeeded {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) SetUserRewardAccountAccount(userRewardAccount ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeededInstruction {
 	inst.AccountMetaSlice[12] = ag_solanago.Meta(userRewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) findFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -543,12 +543,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) findFindUserRewardAccountAddress(recei
 }
 
 // FindUserRewardAccountAddressWithBumpSeed calculates UserRewardAccount account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptTokenIfNeeded) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindUserRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -557,12 +557,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindUserRewardAccountAddressWithBu
 }
 
 // FindUserRewardAccountAddress finds UserRewardAccount account address with given seeds.
-func (inst *UserWrapReceiptTokenIfNeeded) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindUserRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, user ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindUserRewardAccountAddress(receiptTokenMint, user, 0)
 	if err != nil {
 		panic(err)
@@ -571,17 +571,17 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindUserRewardAccountAddress(recei
 }
 
 // GetUserRewardAccountAccount gets the "user_reward_account" account.
-func (inst *UserWrapReceiptTokenIfNeeded) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) GetUserRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(12)
 }
 
 // SetFundWrapAccountRewardAccountAccount sets the "fund_wrap_account_reward_account" account.
-func (inst *UserWrapReceiptTokenIfNeeded) SetFundWrapAccountRewardAccountAccount(fundWrapAccountRewardAccount ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeeded {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) SetFundWrapAccountRewardAccountAccount(fundWrapAccountRewardAccount ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeededInstruction {
 	inst.AccountMetaSlice[13] = ag_solanago.Meta(fundWrapAccountRewardAccount).WRITE()
 	return inst
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) findFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) findFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: user_reward
 	seeds = append(seeds, []byte{byte(0x75), byte(0x73), byte(0x65), byte(0x72), byte(0x5f), byte(0x72), byte(0x65), byte(0x77), byte(0x61), byte(0x72), byte(0x64)})
@@ -600,12 +600,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) findFindFundWrapAccountRewardAccountAd
 }
 
 // FindFundWrapAccountRewardAccountAddressWithBumpSeed calculates FundWrapAccountRewardAccount account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptTokenIfNeeded) FindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindFundWrapAccountRewardAccountAddressWithBumpSeed(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey, bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, bumpSeed)
 	if err != nil {
 		panic(err)
@@ -614,12 +614,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindFundWrapAccountRewardAccountAd
 }
 
 // FindFundWrapAccountRewardAccountAddress finds FundWrapAccountRewardAccount account address with given seeds.
-func (inst *UserWrapReceiptTokenIfNeeded) FindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, 0)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindFundWrapAccountRewardAccountAddress(receiptTokenMint ag_solanago.PublicKey, fundWrapAccount ag_solanago.PublicKey) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindFundWrapAccountRewardAccountAddress(receiptTokenMint, fundWrapAccount, 0)
 	if err != nil {
 		panic(err)
@@ -628,17 +628,17 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindFundWrapAccountRewardAccountAd
 }
 
 // GetFundWrapAccountRewardAccountAccount gets the "fund_wrap_account_reward_account" account.
-func (inst *UserWrapReceiptTokenIfNeeded) GetFundWrapAccountRewardAccountAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) GetFundWrapAccountRewardAccountAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(13)
 }
 
 // SetEventAuthorityAccount sets the "event_authority" account.
-func (inst *UserWrapReceiptTokenIfNeeded) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeeded {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) SetEventAuthorityAccount(eventAuthority ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeededInstruction {
 	inst.AccountMetaSlice[14] = ag_solanago.Meta(eventAuthority)
 	return inst
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) findFindEventAuthorityAddress(knownBumpSeed uint8) (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	var seeds [][]byte
 	// const: __event_authority
 	seeds = append(seeds, []byte{byte(0x5f), byte(0x5f), byte(0x65), byte(0x76), byte(0x65), byte(0x6e), byte(0x74), byte(0x5f), byte(0x61), byte(0x75), byte(0x74), byte(0x68), byte(0x6f), byte(0x72), byte(0x69), byte(0x74), byte(0x79)})
@@ -653,12 +653,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) findFindEventAuthorityAddress(knownBum
 }
 
 // FindEventAuthorityAddressWithBumpSeed calculates EventAuthority account address with given seeds and a known bump seed.
-func (inst *UserWrapReceiptTokenIfNeeded) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey, err error) {
 	pda, _, err = inst.findFindEventAuthorityAddress(bumpSeed)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindEventAuthorityAddressWithBumpSeed(bumpSeed uint8) (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(bumpSeed)
 	if err != nil {
 		panic(err)
@@ -667,12 +667,12 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindEventAuthorityAddressWithBumpS
 }
 
 // FindEventAuthorityAddress finds EventAuthority account address with given seeds.
-func (inst *UserWrapReceiptTokenIfNeeded) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) FindEventAuthorityAddress() (pda ag_solanago.PublicKey, bumpSeed uint8, err error) {
 	pda, bumpSeed, err = inst.findFindEventAuthorityAddress(0)
 	return
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) MustFindEventAuthorityAddress() (pda ag_solanago.PublicKey) {
 	pda, _, err := inst.findFindEventAuthorityAddress(0)
 	if err != nil {
 		panic(err)
@@ -681,22 +681,22 @@ func (inst *UserWrapReceiptTokenIfNeeded) MustFindEventAuthorityAddress() (pda a
 }
 
 // GetEventAuthorityAccount gets the "event_authority" account.
-func (inst *UserWrapReceiptTokenIfNeeded) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) GetEventAuthorityAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(14)
 }
 
 // SetProgramAccount sets the "program" account.
-func (inst *UserWrapReceiptTokenIfNeeded) SetProgramAccount(program ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeeded {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) SetProgramAccount(program ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeededInstruction {
 	inst.AccountMetaSlice[15] = ag_solanago.Meta(program)
 	return inst
 }
 
 // GetProgramAccount gets the "program" account.
-func (inst *UserWrapReceiptTokenIfNeeded) GetProgramAccount() *ag_solanago.AccountMeta {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) GetProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice.Get(15)
 }
 
-func (inst UserWrapReceiptTokenIfNeeded) Build() *Instruction {
+func (inst UserWrapReceiptTokenIfNeededInstruction) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
 		TypeID: Instruction_UserWrapReceiptTokenIfNeeded,
@@ -706,14 +706,14 @@ func (inst UserWrapReceiptTokenIfNeeded) Build() *Instruction {
 // ValidateAndBuild validates the instruction parameters and accounts;
 // if there is a validation error, it returns the error.
 // Otherwise, it builds and returns the instruction.
-func (inst UserWrapReceiptTokenIfNeeded) ValidateAndBuild() (*Instruction, error) {
+func (inst UserWrapReceiptTokenIfNeededInstruction) ValidateAndBuild() (*Instruction, error) {
 	if err := inst.Validate(); err != nil {
 		return nil, err
 	}
 	return inst.Build(), nil
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) Validate() error {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) Validate() error {
 	// Check whether all (required) parameters are set:
 	{
 		if inst.TargetBalance == nil {
@@ -775,7 +775,7 @@ func (inst *UserWrapReceiptTokenIfNeeded) Validate() error {
 	return nil
 }
 
-func (inst *UserWrapReceiptTokenIfNeeded) EncodeToTree(parent ag_treeout.Branches) {
+func (inst *UserWrapReceiptTokenIfNeededInstruction) EncodeToTree(parent ag_treeout.Branches) {
 	parent.Child(ag_format.Program(ProgramName, ProgramID)).
 		//
 		ParentFunc(func(programBranch ag_treeout.Branches) {
@@ -811,7 +811,7 @@ func (inst *UserWrapReceiptTokenIfNeeded) EncodeToTree(parent ag_treeout.Branche
 		})
 }
 
-func (obj UserWrapReceiptTokenIfNeeded) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+func (obj UserWrapReceiptTokenIfNeededInstruction) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Serialize `TargetBalance` param:
 	err = encoder.Encode(obj.TargetBalance)
 	if err != nil {
@@ -819,7 +819,7 @@ func (obj UserWrapReceiptTokenIfNeeded) MarshalWithEncoder(encoder *ag_binary.En
 	}
 	return nil
 }
-func (obj *UserWrapReceiptTokenIfNeeded) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+func (obj *UserWrapReceiptTokenIfNeededInstruction) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
 	// Deserialize `TargetBalance`:
 	err = decoder.Decode(&obj.TargetBalance)
 	if err != nil {
@@ -848,7 +848,7 @@ func NewUserWrapReceiptTokenIfNeededInstruction(
 	userRewardAccount ag_solanago.PublicKey,
 	fundWrapAccountRewardAccount ag_solanago.PublicKey,
 	eventAuthority ag_solanago.PublicKey,
-	program ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeeded {
+	program ag_solanago.PublicKey) *UserWrapReceiptTokenIfNeededInstruction {
 	return NewUserWrapReceiptTokenIfNeededInstructionBuilder().
 		SetTargetBalance(target_balance).
 		SetUserAccount(user).

--- a/generated/restaking/userwrapreceipttokenifneeded_test.go
+++ b/generated/restaking/userwrapreceipttokenifneeded_test.go
@@ -15,13 +15,13 @@ func TestEncodeDecode_UserWrapReceiptTokenIfNeeded(t *testing.T) {
 	for i := 0; i < 1; i++ {
 		t.Run("UserWrapReceiptTokenIfNeeded"+strconv.Itoa(i), func(t *testing.T) {
 			{
-				params := new(UserWrapReceiptTokenIfNeeded)
+				params := new(UserWrapReceiptTokenIfNeededInstruction)
 				fu.Fuzz(params)
 				params.AccountMetaSlice = nil
 				buf := new(bytes.Buffer)
 				err := encodeT(*params, buf)
 				ag_require.NoError(t, err)
-				got := new(UserWrapReceiptTokenIfNeeded)
+				got := new(UserWrapReceiptTokenIfNeededInstruction)
 				err = decodeT(got, buf.Bytes())
 				got.AccountMetaSlice = nil
 				ag_require.NoError(t, err)

--- a/generator.go
+++ b/generator.go
@@ -518,6 +518,10 @@ func formatBuilderFuncName(insExportedName string) string {
 	return "New" + insExportedName + "InstructionBuilder"
 }
 
+func formatInstructionTypeName(insExportedName string) string {
+	return insExportedName + "Instruction"
+}
+
 func formatByteSliceName(insExportedName string) string {
 	return ToCamel(ToLower(insExportedName)) + "Bytes"
 }

--- a/main.go
+++ b/main.go
@@ -614,6 +614,7 @@ func decodeErrorCode(rpcErr error) (errorCode int, ok bool) {
 	for _, instruction := range idl.Instructions {
 		file := NewGoFile(idl.Metadata.Name, true)
 		insExportedName := ToCamel(instruction.Name)
+
 		var args []IdlField
 		for _, arg := range instruction.Args {
 			idlFieldArg := IdlField{
@@ -654,7 +655,7 @@ func decodeErrorCode(rpcErr error) (errorCode int, ok bool) {
 				).Line()
 			}
 
-			code.Type().Id(insExportedName).StructFunc(func(fieldsGroup *Group) {
+			code.Type().Id(formatInstructionTypeName(insExportedName)).StructFunc(func(fieldsGroup *Group) {
 				for argIndex, arg := range args {
 					if len(arg.Docs) > 0 {
 						if argIndex > 0 {
@@ -741,12 +742,12 @@ func decodeErrorCode(rpcErr error) (errorCode int, ok bool) {
 			code.Commentf(
 				"%s creates a new `%s` instruction builder.",
 				builderFuncName,
-				insExportedName,
+				formatInstructionTypeName(insExportedName),
 			).Line()
 			//
-			code.Func().Id(builderFuncName).Params().Op("*").Id(insExportedName).
+			code.Func().Id(builderFuncName).Params().Op("*").Id(formatInstructionTypeName(insExportedName)).
 				BlockFunc(func(body *Group) {
-					body.Id("nd").Op(":=").Op("&").Id(insExportedName).Block(
+					body.Id("nd").Op(":=").Op("&").Id(formatInstructionTypeName(insExportedName)).Block(
 						Id("AccountMetaSlice").Op(":").Make(Qual(PkgSolanaGo, "AccountMetaSlice"), Lit(instruction.Accounts.NumAccounts())).Op(","),
 					)
 
@@ -804,7 +805,7 @@ func decodeErrorCode(rpcErr error) (errorCode int, ok bool) {
 					code.Comment(doc).Line()
 				}
 
-				code.Func().Params(Id("inst").Op("*").Id(insExportedName)).Id(name).
+				code.Func().Params(Id("inst").Op("*").Id(formatInstructionTypeName(insExportedName))).Id(name).
 					Params(
 						ListFunc(func(params *Group) {
 							// Parameters:
@@ -814,7 +815,7 @@ func decodeErrorCode(rpcErr error) (errorCode int, ok bool) {
 					Params(
 						ListFunc(func(results *Group) {
 							// Results:
-							results.Op("*").Id(insExportedName)
+							results.Op("*").Id(formatInstructionTypeName(insExportedName))
 						}),
 					).
 					BlockFunc(func(body *Group) {
@@ -873,7 +874,7 @@ func decodeErrorCode(rpcErr error) (errorCode int, ok bool) {
 						}).Line().Line()
 
 					// Method on intruction builder that accepts the accounts group builder, and copies the accounts:
-					code.Line().Line().Func().Params(Id("inst").Op("*").Id(insExportedName)).Id("Set" + ToCamel(parentGroup.Name) + "AccountsFromBuilder").
+					code.Line().Line().Func().Params(Id("inst").Op("*").Id(formatInstructionTypeName(insExportedName))).Id("Set" + ToCamel(parentGroup.Name) + "AccountsFromBuilder").
 						Params(
 							ListFunc(func(st *Group) {
 								// Parameters:
@@ -883,7 +884,7 @@ func decodeErrorCode(rpcErr error) (errorCode int, ok bool) {
 						Params(
 							ListFunc(func(st *Group) {
 								// Results:
-								st.Op("*").Id(insExportedName)
+								st.Op("*").Id(formatInstructionTypeName(insExportedName))
 							}),
 						).
 						BlockFunc(func(gr *Group) {
@@ -913,7 +914,7 @@ func decodeErrorCode(rpcErr error) (errorCode int, ok bool) {
 
 					var receiverTypeName string
 					if parentGroupPath == "" {
-						receiverTypeName = insExportedName
+						receiverTypeName = formatInstructionTypeName(insExportedName)
 					} else {
 						receiverTypeName = builderStructName
 					}
@@ -938,7 +939,7 @@ func decodeErrorCode(rpcErr error) (errorCode int, ok bool) {
 			// Declare `Build` method on instruction:
 			code := Empty()
 
-			code.Line().Line().Func().Params(Id("inst").Id(insExportedName)).Id("Build").
+			code.Line().Line().Func().Params(Id("inst").Id(formatInstructionTypeName(insExportedName))).Id("Build").
 				Params(
 					ListFunc(func(params *Group) {
 						// Parameters:
@@ -1021,7 +1022,7 @@ func decodeErrorCode(rpcErr error) (errorCode int, ok bool) {
 				Line().
 				Comment("Otherwise, it builds and returns the instruction.").
 				Line().
-				Func().Params(Id("inst").Id(insExportedName)).Id("ValidateAndBuild").
+				Func().Params(Id("inst").Id(formatInstructionTypeName(insExportedName))).Id("ValidateAndBuild").
 				Params(
 					ListFunc(func(params *Group) {
 						// Parameters:
@@ -1051,7 +1052,7 @@ func decodeErrorCode(rpcErr error) (errorCode int, ok bool) {
 			// Declare `Validate` method on instruction:
 			code := Empty()
 
-			code.Line().Line().Func().Params(Id("inst").Op("*").Id(insExportedName)).Id("Validate").
+			code.Line().Line().Func().Params(Id("inst").Op("*").Id(formatInstructionTypeName(insExportedName))).Id("Validate").
 				Params(
 					ListFunc(func(params *Group) {
 						// Parameters:
@@ -1116,7 +1117,7 @@ func decodeErrorCode(rpcErr error) (errorCode int, ok bool) {
 			// Declare `EncodeToTree(parent treeout.Branches)` method in instruction:
 			code := Empty()
 
-			code.Line().Line().Func().Params(Id("inst").Op("*").Id(insExportedName)).Id("EncodeToTree").
+			code.Line().Line().Func().Params(Id("inst").Op("*").Id(formatInstructionTypeName(insExportedName))).Id("EncodeToTree").
 				Params(
 					ListFunc(func(params *Group) {
 						// Parameters:
@@ -1185,7 +1186,7 @@ func decodeErrorCode(rpcErr error) (errorCode int, ok bool) {
 				genMarshalWithEncoder_struct(
 					&idl,
 					false,
-					insExportedName,
+					formatInstructionTypeName(insExportedName),
 					"",
 					args,
 					true,
@@ -1199,7 +1200,7 @@ func decodeErrorCode(rpcErr error) (errorCode int, ok bool) {
 				genUnmarshalWithDecoder_struct(
 					&idl,
 					false,
-					insExportedName,
+					formatInstructionTypeName(insExportedName),
 					"",
 					args,
 					bin.TypeID{},
@@ -1213,7 +1214,7 @@ func decodeErrorCode(rpcErr error) (errorCode int, ok bool) {
 				paramNames = append(paramNames, arg.Name)
 			}
 			code := Empty()
-			name := "New" + insExportedName + "Instruction"
+			name := "New" + formatInstructionTypeName(insExportedName)
 			code.Commentf("%s declares a new %s instruction with the provided parameters and accounts.", name, insExportedName)
 			code.Line()
 			code.Func().Id(name).
@@ -1262,7 +1263,7 @@ func decodeErrorCode(rpcErr error) (errorCode int, ok bool) {
 				Params(
 					ListFunc(func(results *Group) {
 						// Results:
-						results.Op("*").Id(insExportedName)
+						results.Op("*").Id(formatInstructionTypeName(insExportedName))
 					}),
 				).
 				BlockFunc(func(body *Group) {
@@ -2140,7 +2141,7 @@ func genProgramBoilerplate(idl IDL) (*File, error) {
 											insName := ToCamel(instruction.Name)
 											insExportedName := ToCamel(instruction.Name)
 											variantBlock.Block(
-												List(Lit(insName), Parens(Op("*").Id(insExportedName)).Parens(Nil())).Op(","),
+												List(Lit(insName), Parens(Op("*").Id(formatInstructionTypeName(insExportedName))).Parens(Nil())).Op(","),
 											).Op(",")
 										}
 									}).Op(",").Line()
@@ -2167,7 +2168,7 @@ func genProgramBoilerplate(idl IDL) (*File, error) {
 											insName := sighash.ToSnakeForSighash(instruction.Name)
 											insExportedName := ToCamel(instruction.Name)
 											variantBlock.Block(
-												List(Id("Name").Op(":").Lit(insName), Id("Type").Op(":").Parens(Op("*").Id(insExportedName)).Parens(Nil())).Op(","),
+												List(Id("Name").Op(":").Lit(insName), Id("Type").Op(":").Parens(Op("*").Id(formatInstructionTypeName(insExportedName))).Parens(Nil())).Op(","),
 											).Op(",")
 										}
 									}).Op(",").Line()


### PR DESCRIPTION
Add suffix to instruction types to avoid type conflicts with idl definitions

 * Defines a new helper to build instructionTypeNames.