### PR TITLE
feat: Add support for old Anchor IDL format (pre-0.30.0) 

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	. "github.com/dave/jennifer/jen"
 	"github.com/davecgh/go-spew/spew"
 	bin "github.com/gagliardetto/binary"
@@ -53,7 +54,7 @@ func typeStringToType(ts IdlTypeAsString) *Statement {
 		stat.Index().Byte()
 	case IdlTypeString:
 		stat.String()
-	case IdlTypePubkey:
+	case IdlTypePubkey, IdlTypePublicKey:
 		stat.Qual(PkgSolanaGo, "PublicKey")
 	case IdlTypeF32:
 		stat.Float32()

--- a/idl.go
+++ b/idl.go
@@ -56,8 +56,15 @@ func (idl *IDL) Validate() error {
 }
 
 type IdlEvent struct {
-	Name          string   `json:"name"`
-	Discriminator *[8]byte `json:"discriminator,omitempty"`
+	Name          string          `json:"name"`
+	Discriminator *[8]byte        `json:"discriminator,omitempty"`
+	Fields        []IdlEventField `json:"fields,omitempty"` // Old Anchor format
+}
+
+type IdlEventField struct {
+	Name  string  `json:"name"`
+	Type  IdlType `json:"type"`
+	Index bool    `json:"index"`
 }
 
 type IdlInstruction struct {
@@ -205,9 +212,9 @@ type idlAccountPDA struct {
 }
 
 type idlAccountPDASeed struct {
-	Kind  string `json:"kind"`  // const or account
-	Value []byte `json:"value"` // const
-	Path  string `json:"path,omitempty"`
+	Kind    string `json:"kind"`  // const or account
+	Value   []byte `json:"value"` // const
+	Path    string `json:"path,omitempty"`
 	Account string `json:"account,omitempty"`
 }
 
@@ -227,22 +234,23 @@ type IdlField struct {
 type IdlTypeAsString string
 
 const (
-	IdlTypeBool   IdlTypeAsString = "bool"
-	IdlTypeU8     IdlTypeAsString = "u8"
-	IdlTypeI8     IdlTypeAsString = "i8"
-	IdlTypeU16    IdlTypeAsString = "u16"
-	IdlTypeI16    IdlTypeAsString = "i16"
-	IdlTypeU32    IdlTypeAsString = "u32"
-	IdlTypeI32    IdlTypeAsString = "i32"
-	IdlTypeU64    IdlTypeAsString = "u64"
-	IdlTypeI64    IdlTypeAsString = "i64"
-	IdlTypeU128   IdlTypeAsString = "u128"
-	IdlTypeI128   IdlTypeAsString = "i128"
-	IdlTypeBytes  IdlTypeAsString = "bytes"
-	IdlTypeString IdlTypeAsString = "string"
-	IdlTypePubkey IdlTypeAsString = "pubkey"
-	IdlTypeF32    IdlTypeAsString = "f32"
-	IdlTypeF64    IdlTypeAsString = "f64"
+	IdlTypeBool      IdlTypeAsString = "bool"
+	IdlTypeU8        IdlTypeAsString = "u8"
+	IdlTypeI8        IdlTypeAsString = "i8"
+	IdlTypeU16       IdlTypeAsString = "u16"
+	IdlTypeI16       IdlTypeAsString = "i16"
+	IdlTypeU32       IdlTypeAsString = "u32"
+	IdlTypeI32       IdlTypeAsString = "i32"
+	IdlTypeU64       IdlTypeAsString = "u64"
+	IdlTypeI64       IdlTypeAsString = "i64"
+	IdlTypeU128      IdlTypeAsString = "u128"
+	IdlTypeI128      IdlTypeAsString = "i128"
+	IdlTypeBytes     IdlTypeAsString = "bytes"
+	IdlTypeString    IdlTypeAsString = "string"
+	IdlTypePubkey    IdlTypeAsString = "pubkey"
+	IdlTypePublicKey IdlTypeAsString = "publicKey"
+	IdlTypeF32       IdlTypeAsString = "f32"
+	IdlTypeF64       IdlTypeAsString = "f64"
 
 	// Custom additions:
 	IdlTypeUnixTimestamp IdlTypeAsString = "unixTimestamp"

--- a/main.go
+++ b/main.go
@@ -341,12 +341,19 @@ func DecodeInstructions(message *ag_solanago.Message) (instructions []*Instructi
 		// Declare account layouts from IDL:
 		for _, acc := range idl.Accounts {
 			if _, ok := defs[acc.Name]; ok {
+				// New Anchor 0.30+ format: account references a type definition
 				file.Add(genTypeDef(&idl, acc.Discriminator, IdlTypeDef{
 					Name: defs[acc.Name].Name + "Account",
 					Type: defs[acc.Name].Type,
 				}))
+			} else if acc.Type.Kind != "" {
+				// Old Anchor format: account has embedded type definition
+				file.Add(genTypeDef(&idl, acc.Discriminator, IdlTypeDef{
+					Name: acc.Name,
+					Type: acc.Type,
+				}))
 			} else {
-				panic(`not implemented - only IDL from ("anchor": ">=0.30.0") is available`)
+				panic(Sf("account %s has no type definition", acc.Name))
 			}
 		}
 		files = append(files, &FileWrapper{
@@ -358,28 +365,48 @@ func DecodeInstructions(message *ag_solanago.Message) (instructions []*Instructi
 	{
 		file := NewGoFile(idl.Metadata.Name, true)
 
-		// Declare account layouts from IDL:
+		// Declare event layouts from IDL:
 		for _, evt := range idl.Events {
+			var eventDataTypeName string
 			if _, ok := defs[evt.Name]; ok {
-				eventDataTypeName := defs[evt.Name].Name + "EventData"
+				// New Anchor 0.30+ format: event references a type definition
+				eventDataTypeName = defs[evt.Name].Name + "EventData"
 				file.Add(genTypeDef(&idl, evt.Discriminator, IdlTypeDef{
 					Name: eventDataTypeName,
 					Type: defs[evt.Name].Type,
 				}))
-				file.Add(Func().Params(Op("*").Id(eventDataTypeName)).Id("isEventData").Params().Block())
-
-				file.Add(Func().Params(Id("obj").Op("*").Id(eventDataTypeName)).Id("Self").Params().
-					Params(
-						ListFunc(func(results *Group) {
-							// Results:
-							results.Any()
-						}),
-					).BlockFunc(func(body *Group) {
-					body.Return(Id("obj"))
+			} else if len(evt.Fields) > 0 {
+				// Old Anchor format: event has embedded fields
+				eventDataTypeName = evt.Name + "EventData"
+				// Convert event fields to struct fields
+				structFields := make(IdlStructFieldSlice, len(evt.Fields))
+				for i, f := range evt.Fields {
+					structFields[i] = IdlField{
+						Name: f.Name,
+						Type: f.Type,
+					}
+				}
+				file.Add(genTypeDef(&idl, evt.Discriminator, IdlTypeDef{
+					Name: eventDataTypeName,
+					Type: IdlTypeDefTy{
+						Kind:   IdlTypeDefTyKindStruct,
+						Fields: &structFields,
+					},
 				}))
 			} else {
-				panic(`not implemented - only IDL from ("anchor": ">=0.30.0") is available`)
+				continue // Skip events without type definitions
 			}
+			file.Add(Func().Params(Op("*").Id(eventDataTypeName)).Id("isEventData").Params().Block())
+
+			file.Add(Func().Params(Id("obj").Op("*").Id(eventDataTypeName)).Id("Self").Params().
+				Params(
+					ListFunc(func(results *Group) {
+						// Results:
+						results.Any()
+					}),
+				).BlockFunc(func(body *Group) {
+				body.Return(Id("obj"))
+			}))
 		}
 
 		file.Add(Empty().Var().Id("eventTypes").Op("=").Map(Index(Lit(8)).Byte()).Qual("reflect", "Type").Values(DictFunc(func(d Dict) {


### PR DESCRIPTION
- Add support for 'publicKey' type (old Anchor format) alongside 'pubkey'
- Add support for embedded account type definitions in old IDL format
- Add support for embedded event fields in old IDL format
- Add IdlEventField struct for parsing old-style events